### PR TITLE
ci: add cross-platform release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,305 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+
+jobs:
+  release-meta:
+    name: determine release type
+    runs-on: ubuntu-latest
+    outputs:
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: parse tag
+        id: meta
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          version="${tag#v}"
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          if [[ "$version" == *"-rc."* ]] || [[ "$version" == *"-beta."* ]] || [[ "$version" == *"-alpha."* ]]; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
+          echo "Tag: $tag"
+          echo "Version: $version"
+          echo "Prerelease: $(grep prerelease $GITHUB_OUTPUT | cut -d= -f2)"
+
+  build-linux-macos:
+    name: build (${{ matrix.args && matrix.args || matrix.platform }})
+    runs-on: ${{ matrix.platform }}
+    needs: [release-meta]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-22.04
+            args: ""
+          - platform: macos-latest
+            args: "--target aarch64-apple-darwin"
+          - platform: macos-latest
+            args: "--target x86_64-apple-darwin"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: install linux dependencies
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - run: npm install
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: v__VERSION__
+          releaseName: "Autonomi v__VERSION__"
+          releaseDraft: true
+          prerelease: ${{ needs.release-meta.outputs.prerelease == 'true' }}
+          generateReleaseNotes: true
+          args: ${{ matrix.args }}
+
+  build-windows:
+    name: build (windows, no-bundle)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - run: npm install
+
+      - name: build without bundling
+        run: npx tauri build --no-bundle
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-exe-unsigned
+          path: src-tauri/target/release/Autonomi.exe
+
+  sign-windows:
+    name: sign windows binary
+    runs-on: windows-latest
+    needs: [build-windows]
+    env:
+      SM_HOST: ${{ secrets.SM_HOST }}
+      SM_API_KEY: ${{ secrets.SM_API_KEY }}
+      SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+      SM_KEYPAIR_ALIAS: ${{ secrets.SM_KEYPAIR_ALIAS }}
+      SM_LOG_LEVEL: trace
+      SM_LOG_FILE: ${{ github.workspace }}\smctl-signing.log
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-exe-unsigned
+          path: artifacts/
+
+      - name: create client certificate file
+        id: prepare_cert
+        shell: pwsh
+        run: |
+          $raw = @'
+          ${{ secrets.SM_CLIENT_CERT_B64 }}
+          '@
+
+          $clean = ($raw -replace '\s','')
+
+          if ([string]::IsNullOrWhiteSpace($clean)) {
+            Write-Error "SM_CLIENT_CERT_B64 is empty after normalization."
+            exit 1
+          }
+
+          try {
+            $certBytes = [Convert]::FromBase64String($clean)
+          } catch {
+            Write-Error "SM_CLIENT_CERT_B64 is not valid Base64."
+            exit 1
+          }
+
+          $certPath = Join-Path $env:RUNNER_TEMP "Certificate.p12"
+          [System.IO.File]::WriteAllBytes($certPath, $certBytes)
+
+          "SM_CLIENT_CERT_FILE=$certPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "sm_client_cert_b64=$clean" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: setup DigiCert SSM tools
+        uses: digicert/ssm-code-signing@v1.2.1
+        with:
+          sm_host: ${{ secrets.SM_HOST }}
+          sm_api_key: ${{ secrets.SM_API_KEY }}
+          sm_client_cert_b64: ${{ steps.prepare_cert.outputs.sm_client_cert_b64 }}
+          sm_client_cert_password: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+
+      - name: verify smctl installation
+        shell: pwsh
+        run: |
+          smctl -v
+          smctl healthcheck
+
+      - name: sign Autonomi.exe
+        shell: pwsh
+        run: |
+          $file = "artifacts\Autonomi.exe"
+          $result = & smctl sign --keypair-alias "$env:SM_KEYPAIR_ALIAS" --input "$file" 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Signing failed: $result"
+            exit 1
+          }
+          Write-Host "Successfully signed Autonomi.exe"
+
+      - name: verify signature
+        shell: pwsh
+        run: |
+          $sig = Get-AuthenticodeSignature "artifacts\Autonomi.exe"
+          Write-Host "Status: $($sig.Status)"
+          Write-Host "Signer: $($sig.SignerCertificate.Subject)"
+          if ($sig.Status -ne "Valid") {
+            Write-Error "Signature validation failed"
+            exit 1
+          }
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-exe-signed
+          path: artifacts/Autonomi.exe
+
+      - name: upload signing logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: signing-logs
+          path: ${{ github.workspace }}\smctl-signing.log
+          if-no-files-found: ignore
+
+  bundle-windows:
+    name: bundle windows MSI
+    runs-on: windows-latest
+    # Depends on build-linux-macos because tauri-action creates the draft release there.
+    # Without this, gh release upload would fail if the release doesn't exist yet.
+    needs: [sign-windows, release-meta, build-linux-macos]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - run: npm install
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-exe-signed
+          path: src-tauri/target/release/
+
+      - name: bundle MSI and updater artifacts
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: npx tauri build --bundles msi,updater --no-compile
+
+      - name: upload MSI to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+
+          # Upload MSI installer
+          gh release upload "$tag" \
+            src-tauri/target/release/bundle/msi/*.msi \
+            --clobber
+
+          # Upload updater artifacts (.msi.zip and .msi.zip.sig)
+          gh release upload "$tag" \
+            src-tauri/target/release/bundle/msi/*.msi.zip \
+            src-tauri/target/release/bundle/msi/*.msi.zip.sig \
+            --clobber
+
+  update-latest-json:
+    name: merge Windows into latest.json
+    runs-on: ubuntu-latest
+    needs: [bundle-windows, build-linux-macos, release-meta]
+    steps:
+      - name: download latest.json from release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="v${{ needs.release-meta.outputs.version }}"
+          gh release download "$tag" --pattern "latest.json" --dir . --repo "$GITHUB_REPOSITORY"
+
+      - name: get Windows updater artifact URLs and signature
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="v${{ needs.release-meta.outputs.version }}"
+
+          # Get the .msi.zip asset URL
+          msi_zip_url=$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json assets \
+            --jq '.assets[] | select(.name | endswith(".msi.zip")) | .url')
+
+          # Download the .msi.zip.sig and read its contents
+          gh release download "$tag" --pattern "*.msi.zip.sig" --dir . --repo "$GITHUB_REPOSITORY"
+          sig_content=$(cat *.msi.zip.sig)
+
+          echo "MSI_ZIP_URL=${msi_zip_url}" >> $GITHUB_ENV
+          echo "MSI_ZIP_SIG=${sig_content}" >> $GITHUB_ENV
+
+      - name: merge Windows entry into latest.json
+        run: |
+          # Add windows-x86_64 platform to latest.json
+          jq --arg url "$MSI_ZIP_URL" \
+             --arg sig "$MSI_ZIP_SIG" \
+             '.platforms["windows-x86_64"] = {"signature": $sig, "url": $url}' \
+             latest.json > latest-updated.json
+          mv latest-updated.json latest.json
+          echo "Updated latest.json:"
+          cat latest.json | jq .
+
+      - name: upload merged latest.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="v${{ needs.release-meta.outputs.version }}"
+          gh release upload "$tag" latest.json --clobber --repo "$GITHUB_REPOSITORY"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,6 +9,9 @@
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build"
   },
+  "bundle": {
+    "createUpdaterArtifacts": true
+  },
   "app": {
     "windows": [
       {
@@ -30,7 +33,7 @@
       "endpoints": [
         "https://github.com/WithAutonomi/ant-ui/releases/latest/download/latest.json"
       ],
-      "pubkey": ""
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEIzQkZDNDhGOUU3NkMyRDEKUldUUnduYWVqOFMvc3dXbHFiK2F4SGdHNVlCV2l3Q2RoMG9ENW8zNTRGdTl6WmRrWC9iZno2RloK"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add GitHub Actions release workflow triggered by `v*` tags
- Linux + macOS builds use `tauri-action@v0` for build, bundle, and updater signing
- Windows uses a separate pipeline: compile → DigiCert SSM code signing → MSI bundling
- Pre-release support: tags containing `-rc.`, `-beta.`, or `-alpha.` create pre-releases
- Configure Tauri updater: add signing public key and enable `createUpdaterArtifacts`

## Required GitHub Secrets
- `TAURI_SIGNING_PRIVATE_KEY` — Tauri updater signing private key
- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — password for the above
- `SM_HOST`, `SM_API_KEY`, `SM_CLIENT_CERT_B64`, `SM_CLIENT_CERT_PASSWORD`, `SM_KEYPAIR_ALIAS` — DigiCert SSM secrets for Windows code signing

## Test plan
- [ ] Merge to main
- [ ] Push a `v0.1.0-rc.1` tag to trigger the workflow
- [ ] Verify Linux, macOS (x86 + ARM), and Windows jobs complete
- [ ] Verify Windows binary is DigiCert signed
- [ ] Verify draft pre-release is created with all platform assets
- [ ] Verify `latest.json` is present for the updater

🤖 Generated with [Claude Code](https://claude.com/claude-code)