### PR TITLE
feat: merkle batch payment support for large uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dist/
 # Tauri
 src-tauri/target/
 src-tauri/gen/schemas/
+src-tauri/icons/android/
+src-tauri/icons/ios/
 
 # IDE
 .vscode/

--- a/assets/abi/IPaymentVault.json
+++ b/assets/abi/IPaymentVault.json
@@ -18,6 +18,34 @@
   },
   {
     "type": "function",
+    "name": "payForMerkleTree",
+    "inputs": [
+      { "name": "depth", "type": "uint8" },
+      {
+        "name": "poolCommitments",
+        "type": "tuple[]",
+        "components": [
+          { "name": "poolHash", "type": "bytes32" },
+          {
+            "name": "candidates",
+            "type": "tuple[16]",
+            "components": [
+              { "name": "rewardsAddress", "type": "address" },
+              { "name": "amount", "type": "uint256" }
+            ]
+          }
+        ]
+      },
+      { "name": "merklePaymentTimestamp", "type": "uint64" }
+    ],
+    "outputs": [
+      { "name": "winnerPoolHash", "type": "bytes32" },
+      { "name": "totalAmount", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "batchLimit",
     "inputs": [],
     "outputs": [{ "name": "", "type": "uint256" }],
@@ -40,6 +68,16 @@
       { "name": "rewardsAddress", "type": "address", "indexed": true },
       { "name": "amount", "type": "uint256", "indexed": true },
       { "name": "quoteHash", "type": "bytes32", "indexed": true }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "MerklePaymentMade",
+    "inputs": [
+      { "name": "winnerPoolHash", "type": "bytes32", "indexed": true },
+      { "name": "depth", "type": "uint8", "indexed": false },
+      { "name": "totalAmount", "type": "uint256", "indexed": false },
+      { "name": "merklePaymentTimestamp", "type": "uint64", "indexed": false }
     ]
   }
 ]

--- a/components/files/UploadConfirmDialog.vue
+++ b/components/files/UploadConfirmDialog.vue
@@ -25,57 +25,16 @@
             </div>
           </div>
 
-          <!-- Payment mode indicator -->
-          <div>
-            <label class="mb-2 block text-xs font-medium uppercase tracking-wider text-autonomi-muted">Payment Method</label>
-            <div class="flex gap-3">
-              <!-- Regular -->
-              <div
-                class="flex-1 rounded-lg border p-3 text-left transition-all"
-                :class="effectivePaymentMode === 'regular'
-                  ? 'border-autonomi-blue bg-autonomi-blue/10'
-                  : 'border-autonomi-border opacity-40'"
-              >
-                <div class="flex items-center gap-2">
-                  <div
-                    class="flex h-4 w-4 items-center justify-center rounded-full border-2"
-                    :class="effectivePaymentMode === 'regular' ? 'border-autonomi-blue' : 'border-autonomi-muted'"
-                  >
-                    <div v-if="effectivePaymentMode === 'regular'" class="h-2 w-2 rounded-full bg-autonomi-blue" />
-                  </div>
-                  <span class="text-sm font-medium">Regular</span>
-                </div>
-                <p class="mt-1.5 pl-6 text-xs text-autonomi-muted">
-                  Pays per batch of chunks. Simple and reliable for any file size.
-                </p>
-                <p v-if="effectivePaymentMode !== 'regular'" class="mt-1 pl-6 text-xs text-yellow-500/80">
-                  Upload exceeds {{ MERKLE_THRESHOLD }} chunks — merkle is more efficient.
-                </p>
-              </div>
-
-              <!-- Merkle -->
-              <div
-                class="flex-1 rounded-lg border p-3 text-left transition-all"
-                :class="effectivePaymentMode === 'merkle'
-                  ? 'border-autonomi-blue bg-autonomi-blue/10'
-                  : 'border-autonomi-border opacity-40'"
-              >
-                <div class="flex items-center gap-2">
-                  <div
-                    class="flex h-4 w-4 items-center justify-center rounded-full border-2"
-                    :class="effectivePaymentMode === 'merkle' ? 'border-autonomi-blue' : 'border-autonomi-muted'"
-                  >
-                    <div v-if="effectivePaymentMode === 'merkle'" class="h-2 w-2 rounded-full bg-autonomi-blue" />
-                  </div>
-                  <span class="text-sm font-medium">Merkle Tree</span>
-                </div>
-                <p class="mt-1.5 pl-6 text-xs text-autonomi-muted">
-                  Single transaction for all chunks. Lower gas for large uploads.
-                </p>
-                <p v-if="effectivePaymentMode !== 'merkle'" class="mt-1 pl-6 text-xs text-yellow-500/80">
-                  Under {{ MERKLE_THRESHOLD }} chunks — regular payment is used.
-                </p>
-              </div>
+          <!-- Payment mode -->
+          <div class="flex items-baseline justify-between">
+            <span class="text-sm text-autonomi-muted">Payment</span>
+            <div class="text-right">
+              <span class="text-sm font-medium">{{ effectivePaymentMode === 'merkle' ? 'Merkle tree' : 'Regular' }}</span>
+              <p class="text-xs text-autonomi-muted">
+                {{ effectivePaymentMode === 'merkle'
+                  ? `Single transaction for ${estimatedChunks} chunks — lower gas.`
+                  : `Per-batch payment for ${estimatedChunks} chunk${estimatedChunks !== 1 ? 's' : ''}.` }}
+              </p>
             </div>
           </div>
 

--- a/components/files/UploadConfirmDialog.vue
+++ b/components/files/UploadConfirmDialog.vue
@@ -25,52 +25,58 @@
             </div>
           </div>
 
-          <!-- Payment mode selector -->
+          <!-- Payment mode indicator -->
           <div>
             <label class="mb-2 block text-xs font-medium uppercase tracking-wider text-autonomi-muted">Payment Method</label>
             <div class="flex gap-3">
               <!-- Regular -->
-              <button
+              <div
                 class="flex-1 rounded-lg border p-3 text-left transition-all"
-                :class="paymentMode === 'regular'
+                :class="effectivePaymentMode === 'regular'
                   ? 'border-autonomi-blue bg-autonomi-blue/10'
-                  : 'border-autonomi-border hover:border-autonomi-blue/30'"
-                @click="paymentMode = 'regular'"
+                  : 'border-autonomi-border opacity-40'"
               >
                 <div class="flex items-center gap-2">
                   <div
                     class="flex h-4 w-4 items-center justify-center rounded-full border-2"
-                    :class="paymentMode === 'regular' ? 'border-autonomi-blue' : 'border-autonomi-muted'"
+                    :class="effectivePaymentMode === 'regular' ? 'border-autonomi-blue' : 'border-autonomi-muted'"
                   >
-                    <div v-if="paymentMode === 'regular'" class="h-2 w-2 rounded-full bg-autonomi-blue" />
+                    <div v-if="effectivePaymentMode === 'regular'" class="h-2 w-2 rounded-full bg-autonomi-blue" />
                   </div>
                   <span class="text-sm font-medium">Regular</span>
                 </div>
                 <p class="mt-1.5 pl-6 text-xs text-autonomi-muted">
                   Pays per batch of chunks. Simple and reliable for any file size.
                 </p>
-              </button>
+                <p v-if="effectivePaymentMode !== 'regular'" class="mt-1 pl-6 text-xs text-yellow-500/80">
+                  Upload exceeds {{ MERKLE_THRESHOLD }} chunks — merkle is more efficient.
+                </p>
+              </div>
 
-              <!-- Merkle (disabled) -->
-              <button
-                disabled
-                class="flex-1 cursor-not-allowed rounded-lg border border-autonomi-border p-3 text-left opacity-40"
+              <!-- Merkle -->
+              <div
+                class="flex-1 rounded-lg border p-3 text-left transition-all"
+                :class="effectivePaymentMode === 'merkle'
+                  ? 'border-autonomi-blue bg-autonomi-blue/10'
+                  : 'border-autonomi-border opacity-40'"
               >
                 <div class="flex items-center gap-2">
-                  <div class="flex h-4 w-4 items-center justify-center rounded-full border-2 border-autonomi-muted">
-                    <div v-if="paymentMode === 'merkle'" class="h-2 w-2 rounded-full bg-autonomi-blue" />
+                  <div
+                    class="flex h-4 w-4 items-center justify-center rounded-full border-2"
+                    :class="effectivePaymentMode === 'merkle' ? 'border-autonomi-blue' : 'border-autonomi-muted'"
+                  >
+                    <div v-if="effectivePaymentMode === 'merkle'" class="h-2 w-2 rounded-full bg-autonomi-blue" />
                   </div>
                   <span class="text-sm font-medium">Merkle Tree</span>
-                  <span class="rounded bg-autonomi-surface px-1.5 py-0.5 text-[10px] text-autonomi-muted">Coming soon</span>
                 </div>
                 <p class="mt-1.5 pl-6 text-xs text-autonomi-muted">
                   Single transaction for all chunks. Lower gas for large uploads.
                 </p>
-              </button>
+                <p v-if="effectivePaymentMode !== 'merkle'" class="mt-1 pl-6 text-xs text-yellow-500/80">
+                  Under {{ MERKLE_THRESHOLD }} chunks — regular payment is used.
+                </p>
+              </div>
             </div>
-            <p v-if="recommendsMerkle" class="mt-1.5 text-xs text-autonomi-muted">
-              Merkle payments would be more efficient for this upload ({{ estimatedChunks }} chunks).
-            </p>
           </div>
 
           <!-- Cost breakdown -->
@@ -87,9 +93,18 @@
                 <span>Getting cost quote from network...</span>
               </div>
             </template>
+            <template v-else-if="!networkConnected">
+              <div v-if="!networkTimedOut" class="flex items-center gap-2 text-sm text-autonomi-muted">
+                <div class="h-3 w-3 animate-spin rounded-full border-2 border-yellow-500 border-t-transparent" />
+                <span>Discovering network...</span>
+              </div>
+              <div v-else class="text-sm text-yellow-500/80">
+                Could not connect to the Autonomi network. You can still upload — the cost will be quoted when the network becomes available.
+              </div>
+            </template>
             <template v-else>
               <div class="text-sm text-autonomi-muted">
-                Real cost will be quoted from the network after confirmation.
+                Cost will be quoted from the network when the upload starts.
               </div>
             </template>
           </div>
@@ -144,7 +159,7 @@
             </div>
           </div>
 
-          <p v-if="quotedCost" class="text-xs text-autonomi-muted">
+          <p v-if="quotedCost && effectivePaymentMode === 'regular'" class="text-xs text-autonomi-muted">
             Cost quoted from the Autonomi network. Gas fees apply on top.
           </p>
 
@@ -172,14 +187,20 @@
 import { formatBytes } from '~/utils/formatters'
 import { MERKLE_THRESHOLD, AVG_CHUNK_SIZE } from '~/utils/constants'
 
+const NETWORK_TIMEOUT_MS = 15_000
+
 const props = defineProps<{
   open: boolean
   files: { name: string; size: number; path: string }[]
   loading: boolean
-  /** Real cost from network quote (e.g. "0.0234 ANT") */
+  /** Real cost from network quote (e.g. "0.0234 ANT" or "Determined on-chain") */
   quotedCost?: string | null
   /** Whether a network quote is in progress */
   quoting?: boolean
+  /** Payment mode selected by the backend (null if no quote yet) */
+  quotedPaymentMode?: 'wave-batch' | 'merkle' | null
+  /** Whether the Autonomi network client is connected */
+  networkConnected?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -188,20 +209,47 @@ const emit = defineEmits<{
 }>()
 
 const visibility = ref<'private' | 'public'>('private')
-const paymentMode = ref<'regular' | 'merkle'>('regular')
+const networkTimedOut = ref(false)
+let networkTimer: ReturnType<typeof setTimeout> | null = null
 
 const totalSize = computed(() => props.files.reduce((sum, f) => sum + f.size, 0))
 const estimatedChunks = computed(() => Math.max(1, Math.ceil(totalSize.value / AVG_CHUNK_SIZE)))
-const recommendsMerkle = computed(() => estimatedChunks.value >= MERKLE_THRESHOLD)
 
-// Auto-select payment mode based on file size (but merkle is disabled for now)
+/** Payment mode — determined by backend quote, or estimated from file size */
+const effectivePaymentMode = computed(() => {
+  if (props.quotedPaymentMode === 'merkle') return 'merkle'
+  if (props.quotedPaymentMode === 'wave-batch') return 'regular'
+  return estimatedChunks.value >= MERKLE_THRESHOLD ? 'merkle' : 'regular'
+})
+
 watch(
   () => props.open,
   (val) => {
     if (val) {
       visibility.value = 'private'
-      // Would default to merkle for large uploads once enabled
-      paymentMode.value = 'regular'
+      networkTimedOut.value = false
+      // Start network discovery timeout when dialog opens and not connected
+      if (!props.networkConnected) {
+        networkTimer = setTimeout(() => {
+          networkTimedOut.value = true
+        }, NETWORK_TIMEOUT_MS)
+      }
+    } else {
+      if (networkTimer) {
+        clearTimeout(networkTimer)
+        networkTimer = null
+      }
+    }
+  },
+)
+
+// Clear timeout if network connects while dialog is open
+watch(
+  () => props.networkConnected,
+  (connected) => {
+    if (connected && networkTimer) {
+      clearTimeout(networkTimer)
+      networkTimer = null
     }
   },
 )
@@ -209,7 +257,7 @@ watch(
 function handleConfirm() {
   emit('confirm', {
     visibility: visibility.value,
-    paymentMode: paymentMode.value,
+    paymentMode: effectivePaymentMode.value,
   })
 }
 

--- a/components/nodes/NodeDetail.vue
+++ b/components/nodes/NodeDetail.vue
@@ -28,7 +28,7 @@
         </div>
         <div>
           <span class="text-autonomi-muted">Storage</span>
-          <p>{{ node.storage_bytes ? formatBytes(node.storage_bytes) : '-' }}</p>
+          <p>{{ node.storage_bytes != null ? formatBytes(node.storage_bytes) : '-' }}</p>
         </div>
         <div>
           <span class="text-autonomi-muted">Earnings</span>

--- a/components/nodes/NodeDetailPanel.vue
+++ b/components/nodes/NodeDetailPanel.vue
@@ -35,7 +35,7 @@
       </div>
       <div>
         <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Storage</p>
-        <p class="text-autonomi-text">{{ node.storage_bytes ? formatBytes(node.storage_bytes) : '-' }}</p>
+        <p class="text-autonomi-text">{{ node.storage_bytes != null ? formatBytes(node.storage_bytes) : '-' }}</p>
       </div>
       <div>
         <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Earnings</p>

--- a/components/nodes/NodeTile.vue
+++ b/components/nodes/NodeTile.vue
@@ -41,7 +41,7 @@
       </div>
       <div>
         <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Storage</p>
-        <p class="text-sm font-mono text-autonomi-text">{{ node.storage_bytes ? formatBytes(node.storage_bytes) : '-' }}</p>
+        <p class="text-sm font-mono text-autonomi-text">{{ node.storage_bytes != null ? formatBytes(node.storage_bytes) : '-' }}</p>
       </div>
     </div>
   </div>

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -149,6 +149,8 @@
       :loading="uploadEstimating"
       :quoted-cost="quotedCostDisplay"
       :quoting="isQuoting"
+      :quoted-payment-mode="quotedPaymentMode"
+      :network-connected="autonomiConnected"
       @confirm="confirmUpload"
       @cancel="cancelUpload"
     />
@@ -303,6 +305,7 @@ const uploadEstimating = ref(false)
 const pendingUploadFiles = ref<{ name: string; size: number; path: string }[]>([])
 const isQuoting = ref(false)
 const quotedCostDisplay = ref<string | null>(null)
+const quotedPaymentMode = ref<'wave-batch' | 'merkle' | null>(null)
 const pendingQuotes = ref<Map<string, UploadQuote>>(new Map())
 
 async function getFileMetas(paths: string[]): Promise<FileMeta[]> {
@@ -366,15 +369,23 @@ async function startQuoting(metas: FileMeta[]) {
     }
     pendingQuotes.value = quotes
 
-    // Sum up total costs for display
     if (quotes.size > 0) {
-      const totalNanos = Array.from(quotes.values()).reduce(
-        (sum, q) => sum + BigInt(q.total_cost), 0n,
-      )
-      // Format using the same logic as formatNanoTokens
-      const whole = totalNanos / 1_000_000_000_000_000_000n
-      const frac = (totalNanos % 1_000_000_000_000_000_000n) / 1_000_000_000_000_000n
-      quotedCostDisplay.value = frac > 0n ? `${whole}.${frac.toString().padStart(3, '0')} ANT` : `${whole} ANT`
+      const quoteValues = Array.from(quotes.values())
+      // Track the payment mode (all files in a batch use the same mode)
+      quotedPaymentMode.value = quoteValues[0].payment_mode
+
+      if (quotedPaymentMode.value === 'merkle') {
+        // Merkle cost is determined on-chain — show placeholder
+        quotedCostDisplay.value = 'Determined on-chain'
+      } else {
+        // Sum up total costs for display
+        const totalNanos = quoteValues.reduce(
+          (sum, q) => sum + BigInt(q.total_cost), 0n,
+        )
+        const whole = totalNanos / 1_000_000_000_000_000_000n
+        const frac = (totalNanos % 1_000_000_000_000_000_000n) / 1_000_000_000_000_000n
+        quotedCostDisplay.value = frac > 0n ? `${whole}.${frac.toString().padStart(3, '0')} ANT` : `${whole} ANT`
+      }
     }
   } catch {
     // Quoting failed — user can still proceed (will re-quote during upload)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -760,7 +760,7 @@ version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fa0c53e8c1e1ef4d01066b01c737fb62fc9397ab52c6e7bb5669f97d281b9bc"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -811,7 +811,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -822,20 +822,19 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "ant-core"
 version = "0.1.1"
-source = "git+https://github.com/WithAutonomi/ant-client#f3b9e40342635ca72994dca19eafcef3b12c0bdb"
+source = "git+https://github.com/WithAutonomi/ant-client#796d0df75d748419a004aec6f5e288b41d8b496e"
 dependencies = [
- "ant-evm",
  "ant-node",
  "async-stream",
  "axum",
  "bytes",
- "evmlib",
+ "evmlib 0.8.0",
  "flate2",
  "fs2",
  "futures",
@@ -843,21 +842,24 @@ dependencies = [
  "futures-util",
  "hex",
  "libc",
- "libp2p",
  "lru",
- "multihash",
+ "openssl",
  "postcard",
  "rand 0.8.5",
  "reqwest 0.12.28",
  "rmp-serde",
  "saorsa-pqc 0.5.0",
+ "self-replace",
  "self_encryption",
+ "semver 1.0.27",
  "serde",
  "serde_json",
  "tar",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "toml 0.8.2",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -868,35 +870,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ant-evm"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a83cf15203b24ca3fd13f9d481a3d15ca1c384032095f20d5069d8f9bc16afb"
-dependencies = [
- "ant-merkle",
- "custom_debug",
- "evmlib",
- "hex",
- "libp2p",
- "rand 0.8.5",
- "ring",
- "rmp-serde",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 1.0.69",
- "tiny-keccak",
- "tracing",
- "xor_name",
-]
-
-[[package]]
 name = "ant-gui"
 version = "0.1.0"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",
- "evmlib",
+ "evmlib 0.4.9",
+ "futures-util",
  "hex",
  "reqwest 0.12.28",
  "serde",
@@ -922,30 +902,27 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9161d53c72cfcc0dd8fee14bff64c0bad06642f074d52c5c91d9ee203acb4042"
+version = "0.10.0-rc.1"
+source = "git+https://github.com/WithAutonomi/ant-node?rev=6dfc7178a940fc842ab3c6542265d9750a08b060#6dfc7178a940fc842ab3c6542265d9750a08b060"
 dependencies = [
  "aes-gcm-siv",
- "ant-evm",
  "blake3",
  "bytes",
  "chrono",
  "clap",
  "color-eyre",
  "directories",
- "evmlib",
+ "evmlib 0.8.0",
  "flate2",
  "fs2",
  "futures",
  "heed",
  "hex",
  "hkdf",
- "libp2p",
  "lru",
- "multihash",
  "objc2",
  "objc2-foundation",
+ "page_size",
  "parking_lot",
  "postcard",
  "rand 0.8.5",
@@ -1381,19 +1358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "asynchronous-codec"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
-dependencies = [
- "bytes",
- "futures-sink",
- "futures-util",
- "memchr",
- "pin-project-lite",
-]
-
-[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,26 +1502,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base256emoji"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
-dependencies = [
- "const-str",
- "match-lookup",
-]
 
 [[package]]
 name = "base64"
@@ -1765,15 +1713,6 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
-]
-
-[[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "tinyvec",
 ]
 
 [[package]]
@@ -2139,12 +2078,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-str"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
-
-[[package]]
 name = "const_format"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,15 +2182,6 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "libc",
-]
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2458,59 +2382,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "custom_debug"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da7d1ad9567b3e11e877f1d7a0fa0360f04162f94965fc4448fbed41a65298e"
-dependencies = [
- "custom_debug_derive",
-]
-
-[[package]]
-name = "custom_debug_derive"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a707ceda8652f6c7624f2be725652e9524c815bf3b9d55a0b2320be2303f9c11"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -2530,22 +2408,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -2569,26 +2436,6 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
-name = "data-encoding-macro"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
-dependencies = [
- "data-encoding",
- "data-encoding-macro-internal",
-]
-
-[[package]]
-name = "data-encoding-macro-internal"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
-dependencies = [
- "data-encoding",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "deflate64"
@@ -2757,7 +2604,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3060,7 +2907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3099,6 +2946,27 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "evmlib"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1338c23c9ce1b4e54ff5cc65e53ce859095f121bfc742e474e1e1f2e03748000"
+dependencies = [
+ "alloy",
+ "ant-merkle",
+ "exponential-backoff",
+ "hex",
+ "rand 0.8.5",
+ "rmp-serde",
+ "serde",
+ "serde_with",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "tokio",
+ "tracing",
+ "xor_name",
 ]
 
 [[package]]
@@ -3375,16 +3243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-bounded"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
-dependencies = [
- "futures-timer",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3452,12 +3310,6 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -3887,15 +3739,6 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4671,181 +4514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libp2p"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce71348bf5838e46449ae240631117b487073d5f347c06d434caddcb91dceb5a"
-dependencies = [
- "bytes",
- "either",
- "futures",
- "futures-timer",
- "getrandom 0.2.17",
- "libp2p-allow-block-list",
- "libp2p-connection-limits",
- "libp2p-core",
- "libp2p-identify",
- "libp2p-identity",
- "libp2p-kad",
- "libp2p-metrics",
- "libp2p-swarm",
- "multiaddr",
- "pin-project",
- "rw-stream-sink",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "libp2p-allow-block-list"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16ccf824ee859ca83df301e1c0205270206223fd4b1f2e512a693e1912a8f4a"
-dependencies = [
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
-]
-
-[[package]]
-name = "libp2p-connection-limits"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18b8b607cf3bfa2f8c57db9c7d8569a315d5cc0a282e6bfd5ebfc0a9840b2a0"
-dependencies = [
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249128cd37a2199aff30a7675dffa51caf073b51aa612d2f544b19932b9aebca"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-identity",
- "multiaddr",
- "multihash",
- "multistream-select",
- "parking_lot",
- "pin-project",
- "quick-protobuf",
- "rand 0.8.5",
- "rw-stream-sink",
- "thiserror 2.0.18",
- "tracing",
- "unsigned-varint 0.8.0",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-identify"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab792a8b68fdef443a62155b01970c81c3aadab5e659621b063ef252a8e65e8"
-dependencies = [
- "asynchronous-codec",
- "either",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "quick-protobuf",
- "quick-protobuf-codec",
- "smallvec",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-identity"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
-dependencies = [
- "bs58",
- "ed25519-dalek",
- "hkdf",
- "multihash",
- "quick-protobuf",
- "rand 0.8.5",
- "sha2",
- "thiserror 2.0.18",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "libp2p-kad"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d3fd632a5872ec804d37e7413ceea20588f69d027a0fa3c46f82574f4dee60"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "quick-protobuf",
- "quick-protobuf-codec",
- "rand 0.8.5",
- "sha2",
- "smallvec",
- "thiserror 2.0.18",
- "tracing",
- "uint 0.10.0",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-metrics"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
-dependencies = [
- "futures",
- "libp2p-core",
- "libp2p-identify",
- "libp2p-identity",
- "libp2p-kad",
- "libp2p-swarm",
- "pin-project",
- "prometheus-client",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.47.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce88c6c4bf746c8482480345ea3edfd08301f49e026889d1cbccfa1808a9ed9e"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "hashlink",
- "libp2p-core",
- "libp2p-identity",
- "multistream-select",
- "rand 0.8.5",
- "smallvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4974,17 +4642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "match-lookup"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "match_token"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5092,61 +4749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multiaddr"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
-dependencies = [
- "arrayref",
- "byteorder",
- "data-encoding",
- "libp2p-identity",
- "multibase",
- "multihash",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint 0.8.0",
- "url",
-]
-
-[[package]]
-name = "multibase"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
-dependencies = [
- "base-x",
- "base256emoji",
- "data-encoding",
- "data-encoding-macro",
-]
-
-[[package]]
-name = "multihash"
-version = "0.19.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
-dependencies = [
- "core2",
- "unsigned-varint 0.8.0",
-]
-
-[[package]]
-name = "multistream-select"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "pin-project",
- "smallvec",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5234,7 +4836,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5298,7 +4900,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5544,6 +5146,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5551,6 +5162,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -6139,7 +5751,7 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "uint 0.9.5",
+ "uint",
 ]
 
 [[package]]
@@ -6233,29 +5845,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus-client"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proptest"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6279,28 +5868,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-protobuf"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "quick-protobuf-codec"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "quick-protobuf",
- "thiserror 1.0.69",
- "unsigned-varint 0.8.0",
-]
 
 [[package]]
 name = "quick-xml"
@@ -6364,7 +5931,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6377,7 +5944,7 @@ dependencies = [
  "libc",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6920,7 +6487,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6988,7 +6555,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7039,17 +6606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rw-stream-sink"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
-dependencies = [
- "futures",
- "pin-project",
- "static_assertions",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7075,9 +6631,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.18.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d05b97f789b0e0b7d54b2fe05f05edfafb94f72d065482fc20ce1e9fab69e"
+checksum = "ad51589091bdbfbf8c42b5db37428a1cad0febd0af616ef3fe3a0f38dc921b24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7095,6 +6651,7 @@ dependencies = [
  "saorsa-transport",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -7191,9 +6748,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9647e1797e760d73568fb6f7035f40945e70b789579bffccd6a5305e9d5d0136"
+checksum = "0e33412e61b0cb630410981a629f967a858b1663be8f71b75eadb66c9588ef26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7622,7 +7179,7 @@ version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7819,7 +7376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8520,7 +8077,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9036,7 +8593,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9044,18 +8601,6 @@ name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
-
-[[package]]
-name = "uint"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -9149,18 +8694,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
@@ -9644,7 +9177,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -1,4 +1,4 @@
-use ant_core::data::{Client, ClientConfig, DataMap, EvmNetwork, PreparedUpload};
+use ant_core::data::{Client, ClientConfig, DataMap, EvmNetwork, ExternalPaymentInfo, PreparedUpload};
 use evmlib::common::{QuoteHash, TxHash};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -39,12 +39,33 @@ impl AutonomiState {
 /// Payment tuple sent to the frontend: [quoteHash, rewardsAddress, amount]
 pub type RawPayment = [String; 3];
 
+/// Serializable candidate node for merkle pool commitments.
+#[derive(Serialize, Clone)]
+pub struct SerializedCandidateNode {
+    pub rewards_address: String,
+    pub amount: String,
+}
+
+/// Serializable pool commitment for merkle payments.
+#[derive(Serialize, Clone)]
+pub struct SerializedPoolCommitment {
+    pub pool_hash: String,
+    pub candidates: Vec<SerializedCandidateNode>,
+}
+
 #[derive(Serialize, Clone)]
 pub struct UploadQuoteEvent {
     pub upload_id: String,
+    /// "wave-batch" or "merkle"
+    pub payment_mode: String,
+    // ── Wave-batch fields (empty for merkle) ──
     pub payments: Vec<RawPayment>,
     pub total_cost: String,
     pub payment_required: bool,
+    // ── Merkle fields (None for wave-batch) ──
+    pub merkle_depth: Option<u8>,
+    pub merkle_pool_commitments: Option<Vec<SerializedPoolCommitment>>,
+    pub merkle_timestamp: Option<u64>,
 }
 
 #[derive(Serialize)]
@@ -66,7 +87,6 @@ pub struct StartUploadRequest {
 /// Initialize the data client. Connects to the Autonomi network via bootstrap peers.
 ///
 /// `bootstrap_peers`: list of "host:port" strings. If empty, uses defaults.
-/// `evm_network`: "arbitrum-one" or "arbitrum-sepolia" (for price queries).
 #[tauri::command]
 pub async fn init_autonomi_client(
     state: tauri::State<'_, AutonomiState>,
@@ -101,7 +121,9 @@ pub async fn init_autonomi_client(
 }
 
 /// Start an upload: encrypts file, collects quotes, emits quote event
-/// with payment tuples for the frontend to pay via wallet.
+/// with payment info for the frontend to pay via wallet.
+///
+/// The backend auto-selects wave-batch (<64 chunks) or merkle (>=64 chunks).
 #[tauri::command]
 pub async fn start_upload(
     app: AppHandle,
@@ -127,28 +149,69 @@ pub async fn start_upload(
         .await
         .map_err(|e| format!("Failed to prepare upload: {e}"))?;
 
-    // Extract payment tuples for the frontend as hex strings
-    let payments: Vec<RawPayment> = prepared
-        .payment_intent
-        .payments
-        .iter()
-        .map(|(quote_hash, rewards_addr, amount)| {
-            [
-                format!("0x{}", hex::encode(quote_hash)),
-                format!("{rewards_addr}"),
-                amount.to_string(),
-            ]
-        })
-        .collect();
+    let quote_event = match &prepared.payment_info {
+        ExternalPaymentInfo::WaveBatch {
+            prepared_chunks: _,
+            payment_intent,
+        } => {
+            let payments: Vec<RawPayment> = payment_intent
+                .payments
+                .iter()
+                .map(|(quote_hash, rewards_addr, amount)| {
+                    [
+                        format!("0x{}", hex::encode(quote_hash)),
+                        format!("{rewards_addr}"),
+                        amount.to_string(),
+                    ]
+                })
+                .collect();
 
-    let total_cost = prepared.payment_intent.total_amount.to_string();
-    let payment_required = !payments.is_empty();
+            let total_cost = payment_intent.total_amount.to_string();
+            let payment_required = !payments.is_empty();
 
-    let quote_event = UploadQuoteEvent {
-        upload_id: request.upload_id.clone(),
-        payments,
-        total_cost,
-        payment_required,
+            UploadQuoteEvent {
+                upload_id: request.upload_id.clone(),
+                payment_mode: "wave-batch".into(),
+                payments,
+                total_cost,
+                payment_required,
+                merkle_depth: None,
+                merkle_pool_commitments: None,
+                merkle_timestamp: None,
+            }
+        }
+        ExternalPaymentInfo::Merkle {
+            prepared_batch,
+            chunk_contents: _,
+            chunk_addresses: _,
+        } => {
+            let pool_commitments: Vec<SerializedPoolCommitment> = prepared_batch
+                .pool_commitments
+                .iter()
+                .map(|pc| SerializedPoolCommitment {
+                    pool_hash: format!("0x{}", hex::encode(pc.pool_hash)),
+                    candidates: pc
+                        .candidates
+                        .iter()
+                        .map(|c| SerializedCandidateNode {
+                            rewards_address: format!("{}", c.rewards_address),
+                            amount: c.price.to_string(),
+                        })
+                        .collect(),
+                })
+                .collect();
+
+            UploadQuoteEvent {
+                upload_id: request.upload_id.clone(),
+                payment_mode: "merkle".into(),
+                payments: vec![],
+                total_cost: "0".into(),
+                payment_required: true,
+                merkle_depth: Some(prepared_batch.depth),
+                merkle_pool_commitments: Some(pool_commitments),
+                merkle_timestamp: Some(prepared_batch.merkle_payment_timestamp),
+            }
+        }
     };
 
     app.emit("upload-quote", &quote_event)
@@ -164,7 +227,7 @@ pub async fn start_upload(
     Ok(())
 }
 
-/// Confirm upload after frontend has paid on-chain.
+/// Confirm wave-batch upload after frontend has paid on-chain.
 /// Accepts tx hashes from the external signer and uploads chunks.
 #[tauri::command]
 pub async fn confirm_upload(
@@ -216,6 +279,57 @@ pub async fn confirm_upload(
         .map_err(|e| format!("Upload failed: {e}"))?;
 
     // Serialize the DataMap for persistence (needed for later download)
+    let data_map_json = serde_json::to_string(&result.data_map)
+        .map_err(|e| format!("Failed to serialize DataMap: {e}"))?;
+
+    app.emit(
+        "upload-progress",
+        serde_json::json!({
+            "upload_id": upload_id,
+            "status": "complete",
+            "chunks_stored": result.chunks_stored,
+        }),
+    )
+    .ok();
+
+    Ok(UploadResult {
+        upload_id,
+        data_map_json,
+        chunks_stored: result.chunks_stored,
+    })
+}
+
+/// Confirm merkle upload after frontend has paid on-chain.
+/// Accepts the winner pool hash from the MerklePaymentMade event.
+#[tauri::command]
+pub async fn confirm_upload_merkle(
+    app: AppHandle,
+    state: tauri::State<'_, AutonomiState>,
+    upload_id: String,
+    winner_pool_hash: String,
+) -> Result<UploadResult, String> {
+    let client_lock = state.client.read().await;
+    let client = client_lock
+        .as_ref()
+        .ok_or("Autonomi client not initialized")?;
+
+    let (prepared, _created_at) = state
+        .pending_uploads
+        .write()
+        .await
+        .remove(&upload_id)
+        .ok_or("No pending upload found for this ID")?;
+
+    let hash_bytes: [u8; 32] = hex::decode(winner_pool_hash.trim_start_matches("0x"))
+        .map_err(|e| format!("Invalid winner pool hash: {e}"))?
+        .try_into()
+        .map_err(|_| "Winner pool hash must be exactly 32 bytes".to_string())?;
+
+    let result = client
+        .finalize_upload_merkle(prepared, hash_bytes)
+        .await
+        .map_err(|e| format!("Merkle upload failed: {e}"))?;
+
     let data_map_json = serde_json::to_string(&result.data_map)
         .map_err(|e| format!("Failed to serialize DataMap: {e}"))?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -335,6 +335,44 @@ fn read_file_bytes(path: String) -> Result<Vec<u8>, String> {
     std::fs::read(&canonical).map_err(|e| format!("Failed to read {path}: {e}"))
 }
 
+/// Recursively calculate the total size of a directory in bytes.
+#[tauri::command]
+async fn get_dir_size(path: String) -> Result<u64, String> {
+    let canonical = tokio::fs::canonicalize(&path)
+        .await
+        .map_err(|e| format!("Invalid path {path}: {e}"))?;
+
+    if !canonical.is_dir() {
+        return Err(format!("Not a directory: {path}"));
+    }
+
+    // Run the recursive walk on a blocking thread to avoid blocking the async runtime
+    tokio::task::spawn_blocking(move || {
+        let mut total: u64 = 0;
+        let mut stack = vec![canonical];
+        while let Some(dir) = stack.pop() {
+            let entries = match std::fs::read_dir(&dir) {
+                Ok(e) => e,
+                Err(_) => continue, // skip dirs we can't read
+            };
+            for entry in entries.flatten() {
+                let meta = match entry.metadata() {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+                if meta.is_dir() {
+                    stack.push(entry.path());
+                } else {
+                    total += meta.len();
+                }
+            }
+        }
+        Ok(total)
+    })
+    .await
+    .map_err(|e| format!("Directory scan failed: {e}"))?
+}
+
 #[tauri::command]
 fn load_upload_history() -> Result<Vec<UploadHistoryEntry>, String> {
     let history = UploadHistory::load().map_err(|e| e.to_string())?;
@@ -362,6 +400,7 @@ pub fn run() {
             daemon_status,
             daemon_request,
             get_file_sizes,
+            get_dir_size,
             read_file_bytes,
             load_upload_history,
             save_upload_history,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -372,6 +372,7 @@ pub fn run() {
             autonomi_ops::init_autonomi_client,
             autonomi_ops::start_upload,
             autonomi_ops::confirm_upload,
+            autonomi_ops::confirm_upload_merkle,
             autonomi_ops::download_file,
             autonomi_ops::is_autonomi_connected,
         ])

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -3,17 +3,23 @@ import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { useToastStore } from './toasts'
 import { useSettingsStore } from './settings'
-import { payForQuotes, formatNanoTokens, type RawPayment } from '~/utils/payment'
+import { payForQuotes, payForMerkleTree, formatNanoTokens, type RawPayment, type SerializedPoolCommitment } from '~/utils/payment'
 import { indelibleApi } from '~/utils/indelible-api'
 
 // ── Pre-obtained quote from network ──
 
 export interface UploadQuote {
   upload_id: string
+  payment_mode: 'wave-batch' | 'merkle'
+  // Wave-batch fields
   payments: RawPayment[]
   total_cost: string
   total_cost_display: string
   payment_required: boolean
+  // Merkle fields
+  merkle_depth?: number
+  merkle_pool_commitments?: SerializedPoolCommitment[]
+  merkle_timestamp?: number
 }
 
 // ── Unified file entry ──
@@ -190,11 +196,7 @@ export const useFilesStore = defineStore('files', {
       const uploadId = `quote-${Date.now()}-${Math.random().toString(36).slice(2)}`
 
       try {
-        const quotePromise = new Promise<{
-          payments: RawPayment[]
-          total_cost: string
-          payment_required: boolean
-        }>((resolve, reject) => {
+        const quotePromise = new Promise<any>((resolve, reject) => {
           const timeout = setTimeout(() => reject(new Error('Quote timeout')), 120_000)
           listen<any>('upload-quote', (event) => {
             if (event.payload.upload_id === uploadId) {
@@ -211,10 +213,14 @@ export const useFilesStore = defineStore('files', {
         const quote = await quotePromise
         return {
           upload_id: uploadId,
-          payments: quote.payments,
+          payment_mode: quote.payment_mode,
+          payments: quote.payments ?? [],
           total_cost: quote.total_cost,
-          total_cost_display: formatNanoTokens(quote.total_cost),
+          total_cost_display: quote.payment_mode === 'merkle' ? 'Determined on-chain' : formatNanoTokens(quote.total_cost),
           payment_required: quote.payment_required,
+          merkle_depth: quote.merkle_depth,
+          merkle_pool_commitments: quote.merkle_pool_commitments,
+          merkle_timestamp: quote.merkle_timestamp,
         }
       } catch {
         return null
@@ -233,7 +239,7 @@ export const useFilesStore = defineStore('files', {
 
       try {
         let uploadId: string
-        let quote: { payments: RawPayment[]; total_cost: string; payment_required: boolean }
+        let quote: UploadQuote
 
         if (preQuote) {
           // Use pre-obtained quote (from dialog phase)
@@ -245,11 +251,7 @@ export const useFilesStore = defineStore('files', {
           uploadId = `upload-${id}-${Date.now()}`
           this.updateEntry(id, { status: 'quoting' })
 
-          const quotePromise = new Promise<{
-            payments: RawPayment[]
-            total_cost: string
-            payment_required: boolean
-          }>((resolve, reject) => {
+          const quotePromise = new Promise<any>((resolve, reject) => {
             const timeout = setTimeout(() => reject(new Error('Quote timeout')), 120_000)
             listen<any>('upload-quote', (event) => {
               if (event.payload.upload_id === uploadId) {
@@ -266,50 +268,103 @@ export const useFilesStore = defineStore('files', {
             },
           })
 
-          quote = await quotePromise
-          const costDisplay = formatNanoTokens(quote.total_cost)
-          this.updateEntry(id, { cost: costDisplay })
+          const raw = await quotePromise
+          quote = {
+            upload_id: uploadId,
+            payment_mode: raw.payment_mode,
+            payments: raw.payments ?? [],
+            total_cost: raw.total_cost,
+            total_cost_display: raw.payment_mode === 'merkle' ? 'Determined on-chain' : formatNanoTokens(raw.total_cost),
+            payment_required: raw.payment_required,
+            merkle_depth: raw.merkle_depth,
+            merkle_pool_commitments: raw.merkle_pool_commitments,
+            merkle_timestamp: raw.merkle_timestamp,
+          }
+          this.updateEntry(id, { cost: quote.total_cost_display })
         }
 
-        // Pay via wallet and collect tx hash mapping (5 min timeout for user approval)
-        let txHashes: Record<string, string> = {}
-        if (quote.payment_required) {
-          this.updateEntry(id, { status: 'paying' })
+        this.updateEntry(id, { status: 'paying' })
+
+        if (quote.payment_mode === 'merkle') {
+          // Merkle path: single tx for all chunks
           try {
             const payResult = await withTimeout(
-              payForQuotes(wagmiConfig, quote.payments),
+              payForMerkleTree(
+                wagmiConfig,
+                quote.merkle_depth!,
+                quote.merkle_pool_commitments!,
+                BigInt(quote.merkle_timestamp!),
+              ),
               300_000,
               'Payment timed out — wallet approval took too long',
             )
-            txHashes = payResult.txHashMap
+
+            this.updateEntry(id, { status: 'uploading', progress: 0, cost: formatNanoTokens(payResult.totalPaid.toString()) })
+
+            const result = await withTimeout(
+              invoke<{ upload_id: string; data_map_json: string; chunks_stored: number }>('confirm_upload_merkle', {
+                uploadId,
+                winnerPoolHash: payResult.winnerPoolHash,
+              }),
+              120_000,
+              'Upload timed out',
+            )
+
+            const duration = entry.transferStartedAt
+              ? Math.round((Date.now() - entry.transferStartedAt) / 1000)
+              : 0
+            this.updateEntry(id, {
+              status: 'complete',
+              progress: 100,
+              data_map_json: result.data_map_json,
+              duration,
+              transferStartedAt: undefined,
+            })
           } catch (e: any) {
             this.updateEntry(id, { status: 'failed', error: `Payment failed: ${e.message}` })
             toasts.add(`Payment failed: ${e.message}`, 'error')
             return
           }
+        } else {
+          // Wave-batch path: pay per batch then finalize
+          let txHashes: Record<string, string> = {}
+          if (quote.payment_required) {
+            try {
+              const payResult = await withTimeout(
+                payForQuotes(wagmiConfig, quote.payments),
+                300_000,
+                'Payment timed out — wallet approval took too long',
+              )
+              txHashes = payResult.txHashMap
+            } catch (e: any) {
+              this.updateEntry(id, { status: 'failed', error: `Payment failed: ${e.message}` })
+              toasts.add(`Payment failed: ${e.message}`, 'error')
+              return
+            }
+          }
+
+          this.updateEntry(id, { status: 'uploading', progress: 0 })
+
+          const result = await withTimeout(
+            invoke<{ upload_id: string; data_map_json: string; chunks_stored: number }>('confirm_upload', {
+              uploadId,
+              txHashes,
+            }),
+            120_000,
+            'Upload timed out',
+          )
+
+          const duration = entry.transferStartedAt
+            ? Math.round((Date.now() - entry.transferStartedAt) / 1000)
+            : 0
+          this.updateEntry(id, {
+            status: 'complete',
+            progress: 100,
+            data_map_json: result.data_map_json,
+            duration,
+            transferStartedAt: undefined,
+          })
         }
-
-        this.updateEntry(id, { status: 'uploading', progress: 0 })
-
-        const result = await withTimeout(
-          invoke<{ upload_id: string; data_map_json: string; chunks_stored: number }>('confirm_upload', {
-            uploadId,
-            txHashes,
-          }),
-          120_000,
-          'Upload timed out',
-        )
-
-        const duration = entry.transferStartedAt
-          ? Math.round((Date.now() - entry.transferStartedAt) / 1000)
-          : 0
-        this.updateEntry(id, {
-          status: 'complete',
-          progress: 100,
-          data_map_json: result.data_map_json,
-          duration,
-          transferStartedAt: undefined,
-        })
 
         await this.persistHistory()
         toasts.add(`Upload complete: ${entry.name}`, 'info')

--- a/stores/nodes.ts
+++ b/stores/nodes.ts
@@ -4,7 +4,7 @@ import { useSettingsStore } from './settings'
 import { invoke } from '@tauri-apps/api/core'
 import { daemonApi, connectSSE, disconnectSSE, type NodeEvent } from '~/utils/daemon-api'
 import type { NodeStatusSummary, NodeStatus as ApiNodeStatus, DaemonStatus } from '~/utils/daemon-api'
-import { POLL_INTERVAL } from '~/utils/constants'
+import { POLL_INTERVAL, DETAIL_POLL_INTERVAL } from '~/utils/constants'
 import type { UnlistenFn } from '@tauri-apps/api/event'
 
 // Frontend node status — ant-core values + frontend-only states
@@ -49,6 +49,7 @@ export const useNodesStore = defineStore('nodes', {
     daemonConnected: false,
     daemonStatus: null as DaemonStatus | null,
     _pollTimer: null as ReturnType<typeof setInterval> | null,
+    _detailPollTimer: null as ReturnType<typeof setInterval> | null,
     _sseDisconnect: null as (() => void) | null,
     _sseUnlisten: null as UnlistenFn | null,
     _sseWindowHandler: null as ((e: Event) => void) | null,
@@ -85,6 +86,7 @@ export const useNodesStore = defineStore('nodes', {
         this.daemonConnected = true
         await this.fetchNodes()
         this.startPolling()
+        this.enrichNodeDetails() // fire-and-forget — don't block init
         await this.connectSSE()
       } catch {
         console.warn('Daemon not available')
@@ -128,16 +130,48 @@ export const useNodesStore = defineStore('nodes', {
       }
     },
 
+    /** Enrich nodes with detail (data_dir, config) and calculate storage usage. */
+    async enrichNodeDetails() {
+      for (const node of this.nodes) {
+        if (node.id < 0) continue // skip placeholders
+        try {
+          const detail = await daemonApi.nodeDetail(node.id)
+          node.data_dir = detail.data_dir
+          node.rewards_address = detail.rewards_address
+          node.binary_path = detail.binary_path
+          node.log_dir = detail.log_dir
+          node.node_port = detail.node_port
+          node.metrics_port = detail.metrics_port
+
+          // Calculate storage from data_dir
+          if (detail.data_dir) {
+            try {
+              node.storage_bytes = await invoke<number>('get_dir_size', { path: detail.data_dir })
+            } catch {
+              // Dir might not exist yet for newly added nodes
+            }
+          }
+        } catch {
+          // Node may have been removed between status and detail fetch
+        }
+      }
+    },
+
     /** Start polling for status updates */
     startPolling() {
       this.stopPolling()
       this._pollTimer = setInterval(() => this.fetchNodes(), POLL_INTERVAL)
+      this._detailPollTimer = setInterval(() => this.enrichNodeDetails(), DETAIL_POLL_INTERVAL)
     },
 
     stopPolling() {
       if (this._pollTimer) {
         clearInterval(this._pollTimer)
         this._pollTimer = null
+      }
+      if (this._detailPollTimer) {
+        clearInterval(this._detailPollTimer)
+        this._detailPollTimer = null
       }
     },
 
@@ -251,6 +285,7 @@ export const useNodesStore = defineStore('nodes', {
           this.daemonConnected = true
           await this.fetchNodes()
           this.startPolling()
+          this.enrichNodeDetails()
           await this.connectSSE()
         } catch {
           this.scheduleReconnect()

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,4 +1,5 @@
 export const POLL_INTERVAL = 5000
+export const DETAIL_POLL_INTERVAL = 30_000
 export const PENDING_UPLOAD_TTL_MS = 300_000
 export const MERKLE_THRESHOLD = 64
 export const AVG_CHUNK_SIZE = 262_144

--- a/utils/daemon-api.ts
+++ b/utils/daemon-api.ts
@@ -151,6 +151,9 @@ export const daemonApi = {
   /** GET /api/v1/nodes/status */
   nodesStatus: () => request<NodeStatusResult>('GET', '/api/v1/nodes/status'),
 
+  /** GET /api/v1/nodes/:id — full config + runtime state */
+  nodeDetail: (id: number) => request<NodeInfo>('GET', `/api/v1/nodes/${id}`),
+
   /** POST /api/v1/nodes */
   addNodes: (opts: AddNodeOpts) => request<AddNodeResult>('POST', '/api/v1/nodes', opts),
 

--- a/utils/payment.ts
+++ b/utils/payment.ts
@@ -3,24 +3,34 @@ import { arbitrum } from '@reown/appkit/networks'
 import { ANT_TOKEN_ADDRESS, PAYMENT_VAULT_ADDRESS } from '~/utils/wallet-config'
 import paymentVaultAbi from '~/assets/abi/IPaymentVault.json'
 import paymentTokenAbi from '~/assets/abi/PaymentToken.json'
+import { decodeEventLog } from 'viem'
 
 const MAX_PAYMENTS_PER_BATCH = 256
 
 export type RawPayment = [string, string, string] // [quoteHash, rewardsAddress, amount]
 
 export interface PaymentResult {
-  /** Map of quoteHash → txHash for each payment */
+  /** Map of quoteHash -> txHash for each payment */
   txHashMap: Record<string, string>
   totalPaid: bigint
 }
 
+export interface MerklePaymentResult {
+  /** Winner pool hash (bytes32 hex) from the MerklePaymentMade event */
+  winnerPoolHash: string
+  /** Total amount paid */
+  totalPaid: bigint
+}
+
+/** Serialized pool commitment from Rust backend */
+export interface SerializedPoolCommitment {
+  pool_hash: string
+  candidates: { rewards_address: string; amount: string }[]
+}
+
 /**
- * Pay for store quotes via the PaymentVault contract.
+ * Pay for store quotes via the PaymentVault contract (wave-batch path).
  * Handles ERC20 approval and batching (max 256 per tx).
- *
- * @param wagmiConfig - The wagmi config from the adapter
- * @param payments - Array of [quoteHash, rewardsAddress, amount] from the Rust backend
- * @returns Transaction hashes for all payment batches
  */
 export async function payForQuotes(
   wagmiConfig: any,
@@ -70,6 +80,68 @@ export async function payForQuotes(
   }
 
   return { txHashMap, totalPaid: totalAmount }
+}
+
+/**
+ * Pay for merkle tree via the PaymentVault contract (merkle path).
+ * Single transaction for all chunks — lower gas for large uploads.
+ */
+export async function payForMerkleTree(
+  wagmiConfig: any,
+  depth: number,
+  poolCommitments: SerializedPoolCommitment[],
+  merkleTimestamp: bigint,
+): Promise<MerklePaymentResult> {
+  // Convert serialized commitments to contract-compatible format
+  const commitments = poolCommitments.map(pc => ({
+    poolHash: pc.pool_hash as `0x${string}`,
+    candidates: pc.candidates.map(c => ({
+      rewardsAddress: c.rewards_address as `0x${string}`,
+      amount: BigInt(c.amount),
+    })),
+  }))
+
+  // Sum all candidate amounts across all pools to estimate total cost for allowance.
+  // The contract picks the winning pool — actual cost will be <= this sum.
+  // Use the max pool total as a conservative estimate.
+  const maxPoolCost = commitments.reduce((max, pc) => {
+    const poolTotal = pc.candidates.reduce((sum, c) => sum + c.amount, 0n)
+    return poolTotal > max ? poolTotal : max
+  }, 0n)
+
+  await ensureAllowance(wagmiConfig, maxPoolCost)
+
+  const hash = await writeContract(wagmiConfig, {
+    abi: paymentVaultAbi,
+    address: PAYMENT_VAULT_ADDRESS,
+    functionName: 'payForMerkleTree',
+    args: [depth, commitments, merkleTimestamp],
+    chainId: arbitrum.id,
+  })
+
+  const receipt = await waitForTransactionReceipt(wagmiConfig, { hash, chainId: arbitrum.id })
+
+  // Extract winnerPoolHash from MerklePaymentMade event
+  for (const log of receipt.logs) {
+    try {
+      const decoded = decodeEventLog({
+        abi: paymentVaultAbi,
+        data: log.data,
+        topics: log.topics,
+      })
+      if (decoded.eventName === 'MerklePaymentMade') {
+        const args = decoded.args as unknown as { winnerPoolHash: string; totalAmount: bigint }
+        return {
+          winnerPoolHash: args.winnerPoolHash,
+          totalPaid: args.totalAmount,
+        }
+      }
+    } catch {
+      // Not our event, skip
+    }
+  }
+
+  throw new Error('MerklePaymentMade event not found in transaction receipt')
 }
 
 /**

--- a/utils/wallet-config.ts
+++ b/utils/wallet-config.ts
@@ -4,8 +4,8 @@ import { arbitrum } from '@reown/appkit/networks'
 export const WALLETCONNECT_PROJECT_ID = 'c57e0bb001a4dc96b54b9ced656a3cb8'
 
 export const ANT_TOKEN_ADDRESS = '0xa78d8321B20c4Ef90eCd72f2588AA985A4BDb684' as const
-export const PAYMENT_VAULT_ADDRESS = '0xB1b5219f8Aaa18037A2506626Dd0406a46f70BcC' as const
-export const PAYMASTER_ADDRESS = '0x95bf2207288ca0e7fE421F8303D355AF1ca41EF4' as const
+// Unified PaymentVault — handles both payForQuotes (wave-batch) and payForMerkleTree
+export const PAYMENT_VAULT_ADDRESS = '0x9A3EcAc693b699Fc0B2B6A50B5549e50c2320A26' as const
 
 export const SUPPORTED_CHAIN = arbitrum
 


### PR DESCRIPTION
## Summary

- Implements GUI support for merkle batch payments from [ant-client PR #12](https://github.com/WithAutonomi/ant-client/pull/12)
- Files with 64+ chunks auto-select merkle payment (single tx) instead of wave-batch, reducing gas costs
- Updates to unified PaymentVault contract (evmlib 0.8.0) — new address `0x9A3EcAc693b699Fc0B2B6A50B5549e50c2320A26`

### Changes

**Rust backend** (`autonomi_ops.rs`, `lib.rs`):
- Match on `ExternalPaymentInfo::WaveBatch` vs `::Merkle` in `start_upload`
- Serialize merkle params (depth, pool commitments, timestamp) to frontend
- New `confirm_upload_merkle` command accepting winner pool hash

**Frontend payment** (`payment.ts`):
- `payForMerkleTree()` — calls `payForMerkleTree` on unified vault, extracts `winnerPoolHash` from `MerklePaymentMade` event
- ERC20 allowance handling shared with wave-batch path

**Upload flow** (`stores/files.ts`):
- `UploadQuote` carries payment mode + merkle fields
- `startRealUpload` branches: merkle → `payForMerkleTree` + `confirm_upload_merkle`, wave-batch → `payForQuotes` + `confirm_upload`

**UI** (`UploadConfirmDialog.vue`):
- Payment mode indicator (auto-selected, not user-chosen) with explanation text on inactive option
- Network discovery state: spinner → timeout message when not connected

**Contract** (`IPaymentVault.json`, `wallet-config.ts`):
- Unified ABI with both `payForQuotes` and `payForMerkleTree`
- Updated vault address for evmlib 0.8.0

## Test plan

- [ ] Small file upload (<16MB) uses wave-batch path
- [ ] Large file upload (>16MB / 64+ chunks) uses merkle path
- [ ] Dialog shows correct payment mode indicator with explanation
- [ ] Network discovery spinner + timeout when not connected
- [ ] ERC20 allowance approval works for both paths
- [ ] MerklePaymentMade event correctly decoded from receipt

🤖 Generated with [Claude Code](https://claude.com/claude-code)