### PR TITLE
feat: read devnet manifest from shared data directory

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -109,14 +109,34 @@ fn get_app_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
 
-/// Load a devnet manifest from the config directory (if one exists).
+/// Load a devnet manifest (if one exists).
+///
+/// Checks two locations (first match wins):
+/// 1. Shared data directory (`ant_core::config::data_dir()` — e.g. `%APPDATA%/ant/`,
+///    `~/Library/Application Support/ant/`). This is where devnet launchers should
+///    write the manifest so any consumer (GUI, CLI, TUI) can discover it.
+/// 2. Legacy GUI config directory (`config_path()` — `~/.config/autonomi/ant-gui/`
+///    on Linux, platform equivalent elsewhere). Kept for backward compatibility.
+///
 /// Returns the parsed manifest info for the frontend, or null if no manifest found.
 #[tauri::command]
 fn load_devnet_manifest() -> Result<Option<serde_json::Value>, String> {
-    let manifest_path = config::config_path().join("devnet-manifest.json");
-    if !manifest_path.exists() {
+    let manifest_name = "devnet-manifest.json";
+
+    // 1. Shared data directory (preferred — any tool can write here)
+    // 2. Legacy GUI config directory (backward compat)
+    let manifest_path = ant_core::config::data_dir()
+        .ok()
+        .map(|d| d.join(manifest_name))
+        .filter(|p| p.exists())
+        .or_else(|| {
+            let legacy = config::config_path().join(manifest_name);
+            legacy.exists().then_some(legacy)
+        });
+
+    let Some(manifest_path) = manifest_path else {
         return Ok(None);
-    }
+    };
 
     let data = std::fs::read_to_string(&manifest_path)
         .map_err(|e| format!("Failed to read devnet manifest: {e}"))?;


### PR DESCRIPTION
## Summary

- Read `devnet-manifest.json` from the shared ant data directory (`ant_core::config::data_dir()`) instead of only the GUI-specific config directory
- Legacy GUI config path kept as fallback for backward compatibility

This unblocks devnet/testnet launchers from writing the manifest to a shared location that **any consumer** (GUI, CLI, TUI) can discover, without coupling ant-core to ant-gui's filesystem layout.

### Lookup order

| Priority | Location | Example path | Written by |
|----------|----------|-------------|------------|
| 1 | Shared data dir | `%APPDATA%/ant/` (Win), `~/Library/Application Support/ant/` (Mac) | Devnet launcher (ant-core) |
| 2 | Legacy GUI config | `%APPDATA%/autonomi/ant-gui/` (Win) | Manual placement |

First match wins. If neither exists → production mainnet mode (unchanged).

### Companion change needed

On the ant-core side, the devnet launcher examples need to write the manifest to `ant_core::config::data_dir()` instead of the GUI config path. This is a trivial change — replace `dirs::config_dir().join("autonomi/ant-gui")` with `ant_core::config::data_dir()`.

Closes the approach discussed after ant-client#29 was rejected.

### Future direction

This is "Approach A" — the simplest fix. Longer-term, the daemon should be network-aware (expose EVM config via its REST API), and `ant node daemon start --network sepolia` should be the way to select a testnet. See discussion in that PR for approaches B and C.

## Test plan

- [ ] No manifest → production mode (unchanged)
- [ ] Manifest in shared data dir → detected, devnet/Sepolia mode activates
- [ ] Manifest in legacy GUI config dir only → still works (backward compat)
- [ ] Manifest in both locations → shared data dir wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)