### PR TITLE
feat: add Vitest test suite with store and utility tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  frontend:
+    name: frontend (typecheck + test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - run: npm install
+
+      - name: nuxt type check
+        run: npx nuxi typecheck
+
+      - name: vitest
+        run: npm run test:run
+
+  rust:
+    name: rust (${{ matrix.check }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - check: fmt
+            command: cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
+          - check: clippy
+            command: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+          - check: build
+            command: cargo check --manifest-path src-tauri/Cargo.toml
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: install linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - run: npm install
+
+      # Nuxt generate is needed so Tauri can find the frontend dist
+      - name: build frontend
+        if: matrix.check != 'fmt'
+        run: npm run build
+
+      - name: ${{ matrix.check }}
+        run: ${{ matrix.command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,5 +69,14 @@ jobs:
         if: matrix.check != 'fmt'
         run: npm run build
 
+      # Tauri's build script requires the sidecar binary to exist even for
+      # cargo check/clippy. Create a dummy so the build script passes.
+      - name: create sidecar stub
+        if: matrix.check != 'fmt'
+        run: |
+          TARGET=$(rustc -vV | grep host | awk '{print $2}')
+          mkdir -p src-tauri/binaries
+          touch "src-tauri/binaries/ant-${TARGET}"
+
       - name: ${{ matrix.check }}
         run: ${{ matrix.command }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ant-gui",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ant-gui",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "dependencies": {
         "@pinia/nuxt": "^0.5.0",
         "@reown/appkit": "^1.8.19",
@@ -24,11 +24,15 @@
         "vue-router": "^4.4.0"
       },
       "devDependencies": {
+        "@nuxt/test-utils": "^3.23.0",
         "@tauri-apps/cli": "^2.0.0",
+        "@vue/test-utils": "^2.4.6",
         "autoprefixer": "^10.4.27",
+        "happy-dom": "^20.8.9",
         "postcss": "^8.5.8",
         "tailwindcss": "^3.4.19",
-        "typescript": "^5.5.0"
+        "typescript": "^5.5.0",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -2228,6 +2232,155 @@
       "integrity": "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==",
       "license": "MIT"
     },
+    "node_modules/@nuxt/test-utils": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/test-utils/-/test-utils-3.23.0.tgz",
+      "integrity": "sha512-NZKWSwvfIiTO2qhMoJHVbUQLgJMe96J9ccLhPPqN5+a/XzISZ027LG9wWVp1tC5oB0qQ3eUDhrxmq6Lj8EQLMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "1.0.0-alpha.9",
+        "@nuxt/kit": "^3.20.2",
+        "c12": "^3.3.3",
+        "consola": "^3.4.2",
+        "defu": "^6.1.4",
+        "destr": "^2.0.5",
+        "estree-walker": "^3.0.3",
+        "exsolve": "^1.0.8",
+        "fake-indexeddb": "^6.2.5",
+        "get-port-please": "^3.2.0",
+        "h3": "^1.15.4",
+        "h3-next": "npm:h3@^2.0.1-rc.7",
+        "local-pkg": "^1.1.2",
+        "magic-string": "^0.30.21",
+        "node-fetch-native": "^1.6.7",
+        "node-mock-http": "^1.0.4",
+        "nypm": "^0.6.2",
+        "ofetch": "^1.5.1",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.0.0",
+        "radix3": "^1.1.2",
+        "scule": "^1.3.0",
+        "std-env": "^3.10.0",
+        "tinyexec": "^1.0.2",
+        "ufo": "^1.6.1",
+        "unplugin": "^2.3.11",
+        "vitest-environment-nuxt": "^1.0.1",
+        "vue": "^3.5.26"
+      },
+      "engines": {
+        "node": "^20.11.1 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@cucumber/cucumber": "^10.3.1 || >=11.0.0",
+        "@jest/globals": "^29.5.0 || >=30.0.0",
+        "@playwright/test": "^1.43.1",
+        "@testing-library/vue": "^7.0.0 || ^8.0.1",
+        "@vue/test-utils": "^2.4.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "playwright-core": "^1.43.1",
+        "vitest": "^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@cucumber/cucumber": {
+          "optional": true
+        },
+        "@jest/globals": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "@testing-library/vue": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "@vue/test-utils": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "playwright-core": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/@clack/core": {
+      "version": "1.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.0-alpha.7.tgz",
+      "integrity": "sha512-3vdh6Ar09D14rVxJZIm3VQJkU+ZOKKT5I5cC0cOVazy70CNyYYjiwRj9unwalhESndgxx6bGc/m6Hhs4EKF5XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/@clack/prompts": {
+      "version": "1.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.0-alpha.9.tgz",
+      "integrity": "sha512-sKs0UjiHFWvry4SiRfBi5Qnj0C/6AYx8aKkFPZQSuUZXgAram25ZDmhQmP7vj1aFyLpfHWtLQjWvOvcat0TOLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.0.0-alpha.7",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/crossws": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.4.tgz",
+      "integrity": "sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "srvx": ">=0.7.1"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/h3-next": {
+      "name": "h3",
+      "version": "2.0.1-rc.20",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.20.tgz",
+      "integrity": "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rou3": "^0.8.1",
+        "srvx": "^0.11.13"
+      },
+      "bin": {
+        "h3": "bin/h3.mjs"
+      },
+      "engines": {
+        "node": ">=20.11.1"
+      },
+      "peerDependencies": {
+        "crossws": "^0.4.1"
+      },
+      "peerDependenciesMeta": {
+        "crossws": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nuxt/vite-builder": {
       "version": "3.17.7",
       "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.17.7.tgz",
@@ -2311,6 +2464,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
@@ -5316,6 +5476,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -5325,6 +5496,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -5336,8 +5514,8 @@
       "version": "25.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.4.0.tgz",
       "integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -5383,6 +5561,13 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
@@ -5618,6 +5803,121 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vue-macros/common": {
@@ -5877,6 +6177,17 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.30.tgz",
       "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
       "license": "MIT"
+    },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^2.0.0"
+      }
     },
     "node_modules/@wagmi/connectors": {
       "version": "7.2.1",
@@ -6807,6 +7118,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-kit": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.1.2.tgz",
@@ -7509,6 +7830,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -7530,6 +7868,16 @@
       "optional": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -7827,6 +8175,24 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/consola": {
       "version": "3.4.2",
@@ -8331,6 +8697,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -8765,6 +9141,35 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -9257,6 +9662,16 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -9323,6 +9738,16 @@
       "optional": true,
       "engines": {
         "node": "> 0.1.90"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-fifo": {
@@ -9973,6 +10398,34 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/has-bigints": {
@@ -11051,6 +11504,64 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11417,6 +11928,13 @@
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -12955,6 +13473,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -13839,6 +14367,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/proxy-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
@@ -14472,6 +15007,13 @@
         }
       }
     },
+    "node_modules/rou3": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.8.1.tgz",
+      "integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rpc-websockets": {
       "version": "9.3.5",
       "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.5.tgz",
@@ -14881,6 +15423,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -15052,9 +15601,9 @@
       }
     },
     "node_modules/srvx": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.9.tgz",
-      "integrity": "sha512-97wWJS6F0KTKAhDlHVmBzMvlBOp5FiNp3XrLoodIgYJpXxgG5tE9rX4Pg7s46n2shI4wtEsMATTS1+rI3/ubzA==",
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.15.tgz",
+      "integrity": "sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==",
       "license": "MIT",
       "bin": {
         "srvx": "bin/srvx.mjs"
@@ -15071,6 +15620,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
@@ -15762,6 +16318,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -15785,6 +16348,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -16041,8 +16634,8 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",
@@ -16953,6 +17546,96 @@
         "vue": "^3.5.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest-environment-nuxt": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vitest-environment-nuxt/-/vitest-environment-nuxt-1.0.1.tgz",
+      "integrity": "sha512-eBCwtIQriXW5/M49FjqNKfnlJYlG2LWMSNFsRVKomc8CaMqmhQPBS5LZ9DlgYL9T8xIVsiA6RZn2lk7vxov3Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/test-utils": ">=3.13.1"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -16988,6 +17671,13 @@
       "dependencies": {
         "ufo": "^1.6.1"
       }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
+      "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue-demi": {
       "version": "0.14.10",
@@ -17082,6 +17772,16 @@
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -17197,6 +17897,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/winston": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "nuxt preview",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:build": "tauri build",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@pinia/nuxt": "^0.5.0",
@@ -28,10 +30,14 @@
     "vue-router": "^4.4.0"
   },
   "devDependencies": {
+    "@nuxt/test-utils": "^3.23.0",
     "@tauri-apps/cli": "^2.0.0",
+    "@vue/test-utils": "^2.4.6",
     "autoprefixer": "^10.4.27",
+    "happy-dom": "^20.8.9",
     "postcss": "^8.5.8",
     "tailwindcss": "^3.4.19",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/tests/mocks/appkit.ts
+++ b/tests/mocks/appkit.ts
@@ -1,0 +1,37 @@
+import { vi } from 'vitest'
+
+// Mock WalletConnect / AppKit modules that use CommonJS and break in ESM test env
+vi.mock('@reown/appkit/vue', () => ({
+  createAppKit: vi.fn(),
+}))
+
+vi.mock('@reown/appkit-adapter-wagmi', () => ({
+  WagmiAdapter: vi.fn(),
+}))
+
+vi.mock('@reown/appkit/networks', () => ({
+  arbitrum: { id: 42161, name: 'Arbitrum One' },
+  arbitrumSepolia: { id: 421614, name: 'Arbitrum Sepolia' },
+}))
+
+vi.mock('@wagmi/core', () => ({
+  getAccount: vi.fn(() => ({ address: undefined })),
+  createConfig: vi.fn(),
+  http: vi.fn(),
+  readContract: vi.fn(),
+  writeContract: vi.fn(),
+  waitForTransactionReceipt: vi.fn(),
+  getBalance: vi.fn(),
+}))
+
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: vi.fn(() => ({ address: '0xmock' })),
+}))
+
+vi.mock('viem', () => ({
+  defineChain: vi.fn((c: any) => c),
+  formatEther: vi.fn((v: any) => String(v)),
+  parseEther: vi.fn((v: any) => BigInt(v)),
+  parseUnits: vi.fn((v: any) => BigInt(v)),
+  formatUnits: vi.fn((v: any) => String(v)),
+}))

--- a/tests/mocks/tauri.ts
+++ b/tests/mocks/tauri.ts
@@ -22,9 +22,9 @@ export function resetTauriMocks() {
 
 // Module mocks — these intercept the actual imports
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: (...args: any[]) => mockInvoke(...args),
+  invoke: mockInvoke,
 }))
 
 vi.mock('@tauri-apps/api/event', () => ({
-  listen: (...args: any[]) => mockListen(...args),
+  listen: mockListen,
 }))

--- a/tests/mocks/tauri.ts
+++ b/tests/mocks/tauri.ts
@@ -1,0 +1,30 @@
+import { vi } from 'vitest'
+
+/**
+ * Mock responses for Tauri invoke commands.
+ * Tests set up responses via `mockInvoke.mockImplementation()` or
+ * `setMockInvokeHandler()` before running store actions.
+ */
+export const mockInvoke = vi.fn()
+export const mockListen = vi.fn(() => vi.fn()) // returns unlisten fn
+
+/** Set a handler that routes invoke calls by command name. */
+export function setMockInvokeHandler(handler: (cmd: string, args?: any) => any) {
+  mockInvoke.mockImplementation(handler)
+}
+
+/** Reset all mocks between tests. */
+export function resetTauriMocks() {
+  mockInvoke.mockReset()
+  mockListen.mockReset()
+  mockListen.mockReturnValue(vi.fn())
+}
+
+// Module mocks — these intercept the actual imports
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: any[]) => mockInvoke(...args),
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: any[]) => mockListen(...args),
+}))

--- a/tests/stores/nodes.test.ts
+++ b/tests/stores/nodes.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setMockInvokeHandler, resetTauriMocks } from '../mocks/tauri'
+import { useNodesStore } from '~/stores/nodes'
+import { useSettingsStore } from '~/stores/settings'
+
+// Mock the daemon-api module — the nodes store imports connectSSE/disconnectSSE
+vi.mock('~/utils/daemon-api', () => ({
+  daemonApi: {
+    status: vi.fn(),
+    nodesStatus: vi.fn(),
+    nodeDetail: vi.fn(),
+  },
+  connectSSE: vi.fn(() => Promise.resolve(vi.fn())),
+  disconnectSSE: vi.fn(() => Promise.resolve()),
+}))
+
+describe('nodes store', () => {
+  let nodesStore: ReturnType<typeof useNodesStore>
+  let settingsStore: ReturnType<typeof useSettingsStore>
+
+  beforeEach(() => {
+    resetTauriMocks()
+    settingsStore = useSettingsStore()
+    settingsStore.$reset()
+    nodesStore = useNodesStore()
+    nodesStore.$reset()
+  })
+
+  describe('init', () => {
+    it('connects to daemon when ensure_daemon_running succeeds', async () => {
+      const { daemonApi } = await import('~/utils/daemon-api')
+
+      setMockInvokeHandler((cmd) => {
+        if (cmd === 'ensure_daemon_running') return 'http://127.0.0.1:55555'
+        if (cmd === 'connect_daemon_sse') return undefined
+      })
+
+      vi.mocked(daemonApi.status).mockResolvedValue({
+        running: true,
+        pid: 1234,
+        port: 55555,
+        uptime_secs: 100,
+        nodes_total: 2,
+        nodes_running: 1,
+        nodes_stopped: 1,
+        nodes_errored: 0,
+      })
+
+      vi.mocked(daemonApi.nodesStatus).mockResolvedValue({
+        nodes: [
+          { node_id: 1, name: 'node1', version: '0.9.0', status: 'running', pid: 100, uptime_secs: 50 },
+          { node_id: 2, name: 'node2', version: '0.9.0', status: 'stopped' },
+        ],
+        total_running: 1,
+        total_stopped: 1,
+      })
+
+      await nodesStore.init()
+
+      expect(nodesStore.daemonConnected).toBe(true)
+      expect(nodesStore.initializing).toBe(false)
+      expect(nodesStore.nodes).toHaveLength(2)
+      expect(settingsStore.daemonUrl).toBe('http://127.0.0.1:55555')
+    })
+
+    it('sets disconnected when daemon is unavailable', async () => {
+      const { daemonApi } = await import('~/utils/daemon-api')
+
+      setMockInvokeHandler((cmd) => {
+        if (cmd === 'ensure_daemon_running') throw new Error('binary not found')
+      })
+
+      vi.mocked(daemonApi.status).mockRejectedValue(new Error('connection refused'))
+
+      await nodesStore.init()
+
+      expect(nodesStore.daemonConnected).toBe(false)
+      expect(nodesStore.initializing).toBe(false)
+    })
+
+    it('updates daemon URL when port changes', async () => {
+      const { daemonApi } = await import('~/utils/daemon-api')
+
+      settingsStore.daemonUrl = 'http://127.0.0.1:12500' // old default
+
+      setMockInvokeHandler((cmd) => {
+        if (cmd === 'ensure_daemon_running') return 'http://127.0.0.1:63210'
+        if (cmd === 'connect_daemon_sse') return undefined
+      })
+
+      vi.mocked(daemonApi.status).mockResolvedValue({
+        running: true, pid: 1, port: 63210, uptime_secs: 0,
+        nodes_total: 0, nodes_running: 0, nodes_stopped: 0, nodes_errored: 0,
+      })
+
+      vi.mocked(daemonApi.nodesStatus).mockResolvedValue({
+        nodes: [], total_running: 0, total_stopped: 0,
+      })
+
+      await nodesStore.init()
+
+      expect(settingsStore.daemonUrl).toBe('http://127.0.0.1:63210')
+    })
+  })
+
+  describe('handleNodeEvent', () => {
+    it('updates node status from SSE events', () => {
+      nodesStore.nodes = [
+        { id: 1, name: 'node1', status: 'stopped', version: '0.9.0' },
+      ]
+
+      nodesStore.handleNodeEvent({ type: 'node_started', node_id: 1, pid: 5678 })
+
+      expect(nodesStore.nodes[0].status).toBe('running')
+      expect(nodesStore.nodes[0].pid).toBe(5678)
+    })
+
+    it('handles node crash event', () => {
+      nodesStore.nodes = [
+        { id: 1, name: 'node1', status: 'running', version: '0.9.0', pid: 5678 },
+      ]
+
+      nodesStore.handleNodeEvent({ type: 'node_crashed', node_id: 1 })
+
+      expect(nodesStore.nodes[0].status).toBe('errored')
+      expect(nodesStore.nodes[0].pid).toBeUndefined()
+    })
+  })
+
+  describe('getters', () => {
+    it('counts nodes by status', () => {
+      nodesStore.nodes = [
+        { id: 1, name: 'n1', status: 'running', version: '' },
+        { id: 2, name: 'n2', status: 'running', version: '' },
+        { id: 3, name: 'n3', status: 'stopped', version: '' },
+        { id: 4, name: 'n4', status: 'errored', version: '' },
+      ]
+
+      expect(nodesStore.running).toBe(2)
+      expect(nodesStore.stopped).toBe(1)
+      expect(nodesStore.errored).toBe(1)
+      expect(nodesStore.total).toBe(4)
+    })
+  })
+})

--- a/tests/stores/settings.test.ts
+++ b/tests/stores/settings.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setMockInvokeHandler, resetTauriMocks } from '../mocks/tauri'
+import { useSettingsStore } from '~/stores/settings'
+
+describe('settings store', () => {
+  let store: ReturnType<typeof useSettingsStore>
+
+  beforeEach(() => {
+    resetTauriMocks()
+    store = useSettingsStore()
+    store.$reset()
+  })
+
+  describe('loadConfig', () => {
+    it('loads config from Tauri backend', async () => {
+      setMockInvokeHandler((cmd) => {
+        if (cmd === 'load_config') {
+          return {
+            storage_dir: '/data/storage',
+            download_dir: '/data/downloads',
+            daemon_url: 'http://127.0.0.1:54321',
+            bell_on_critical: true,
+            earnings_address: '0xabc123',
+            indelible_url: null,
+            indelible_api_key: null,
+          }
+        }
+      })
+
+      await store.loadConfig()
+
+      expect(store.loaded).toBe(true)
+      expect(store.storageDir).toBe('/data/storage')
+      expect(store.downloadDir).toBe('/data/downloads')
+      expect(store.daemonUrl).toBe('http://127.0.0.1:54321')
+      expect(store.bellOnCritical).toBe(true)
+      expect(store.earningsAddress).toBe('0xabc123')
+    })
+
+    it('handles load failure gracefully', async () => {
+      setMockInvokeHandler(() => {
+        throw new Error('config file corrupt')
+      })
+
+      await store.loadConfig()
+
+      // Should not crash, loaded stays false
+      expect(store.loaded).toBe(false)
+    })
+  })
+
+  describe('loadDevnetManifest', () => {
+    it('activates devnet mode when manifest exists', async () => {
+      setMockInvokeHandler((cmd) => {
+        if (cmd === 'load_devnet_manifest') {
+          return {
+            rpc_url: 'http://127.0.0.1:8545',
+            payment_token_address: '0xtoken',
+            payment_vault_address: '0xvault',
+            bootstrap_peers: ['127.0.0.1:20000'],
+            wallet_private_key: '0xdeadbeef',
+          }
+        }
+      })
+
+      await store.loadDevnetManifest()
+
+      expect(store.devnetActive).toBe(true)
+      expect(store.devnetIsSepolia).toBe(false)
+      expect(store.devnetRpcUrl).toBe('http://127.0.0.1:8545')
+      expect(store.devnetTokenAddress).toBe('0xtoken')
+      expect(store.devnetVaultAddress).toBe('0xvault')
+      expect(store.devnetBootstrapPeers).toEqual(['127.0.0.1:20000'])
+    })
+
+    it('detects Sepolia from RPC URL', async () => {
+      setMockInvokeHandler((cmd) => {
+        if (cmd === 'load_devnet_manifest') {
+          return {
+            rpc_url: 'https://sepolia-rollup.arbitrum.io/rpc',
+            payment_token_address: '0xtoken',
+            payment_vault_address: '0xvault',
+            bootstrap_peers: ['127.0.0.1:20000'],
+          }
+        }
+      })
+
+      await store.loadDevnetManifest()
+
+      expect(store.devnetActive).toBe(true)
+      expect(store.devnetIsSepolia).toBe(true)
+    })
+
+    it('stays in production mode when no manifest', async () => {
+      setMockInvokeHandler((cmd) => {
+        if (cmd === 'load_devnet_manifest') return null
+      })
+
+      await store.loadDevnetManifest()
+
+      expect(store.devnetActive).toBe(false)
+    })
+  })
+
+  describe('saveConfig', () => {
+    it('sends current state to Tauri backend', async () => {
+      let savedConfig: any = null
+      setMockInvokeHandler((cmd, args) => {
+        if (cmd === 'load_config') {
+          return {
+            storage_dir: null,
+            download_dir: null,
+            daemon_url: 'http://127.0.0.1:12500',
+            bell_on_critical: false,
+            earnings_address: null,
+            indelible_url: null,
+            indelible_api_key: null,
+          }
+        }
+        if (cmd === 'save_config') {
+          savedConfig = args.config
+        }
+      })
+
+      await store.loadConfig()
+      store.earningsAddress = '0xnewaddr'
+      await store.saveConfig()
+
+      expect(savedConfig).toBeTruthy()
+      expect(savedConfig.earnings_address).toBe('0xnewaddr')
+      expect(savedConfig.daemon_url).toBe('http://127.0.0.1:12500')
+    })
+  })
+})

--- a/tests/utils/wallet-config.test.ts
+++ b/tests/utils/wallet-config.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { resetTauriMocks } from '../mocks/tauri'
+import { useSettingsStore } from '~/stores/settings'
+import {
+  getTokenAddress,
+  getVaultAddress,
+  getActiveChainId,
+  ANT_TOKEN_ADDRESS,
+  PAYMENT_VAULT_ADDRESS,
+} from '~/utils/wallet-config'
+
+describe('wallet-config', () => {
+  let settings: ReturnType<typeof useSettingsStore>
+
+  beforeEach(() => {
+    resetTauriMocks()
+    settings = useSettingsStore()
+    settings.$reset()
+  })
+
+  describe('getTokenAddress', () => {
+    it('returns mainnet address in production mode', () => {
+      expect(getTokenAddress()).toBe(ANT_TOKEN_ADDRESS)
+    })
+
+    it('returns devnet override when active', () => {
+      settings.devnetActive = true
+      settings.devnetTokenAddress = '0xdevtoken'
+
+      expect(getTokenAddress()).toBe('0xdevtoken')
+    })
+  })
+
+  describe('getVaultAddress', () => {
+    it('returns mainnet address in production mode', () => {
+      expect(getVaultAddress()).toBe(PAYMENT_VAULT_ADDRESS)
+    })
+
+    it('returns devnet override when active', () => {
+      settings.devnetActive = true
+      settings.devnetVaultAddress = '0xdevvault'
+
+      expect(getVaultAddress()).toBe('0xdevvault')
+    })
+  })
+
+  describe('getActiveChainId', () => {
+    it('returns Arbitrum mainnet (42161) in production', () => {
+      expect(getActiveChainId()).toBe(42161)
+    })
+
+    it('returns Anvil (31337) in local devnet', () => {
+      settings.devnetActive = true
+      settings.devnetIsSepolia = false
+
+      expect(getActiveChainId()).toBe(31337)
+    })
+
+    it('returns Sepolia (421614) in Sepolia mode', () => {
+      settings.devnetActive = true
+      settings.devnetIsSepolia = true
+
+      expect(getActiveChainId()).toBe(421614)
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineVitestConfig } from '@nuxt/test-utils/config'
+
+export default defineVitestConfig({
+  test: {
+    environment: 'nuxt',
+    environmentOptions: {
+      nuxt: {
+        domEnvironment: 'happy-dom',
+      },
+    },
+    setupFiles: ['./tests/mocks/appkit.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

Set up Vitest with `@nuxt/test-utils` for unit and integration testing. Includes mock infrastructure and initial test coverage for the most critical frontend logic.

### What's included

| File | Purpose |
|------|---------|
| `vitest.config.ts` | Nuxt test environment with happy-dom |
| `tests/mocks/tauri.ts` | Mock for `@tauri-apps/api/core` `invoke()` — lets tests simulate Tauri command responses |
| `tests/mocks/appkit.ts` | Mocks for WalletConnect/AppKit/wagmi (CommonJS modules that break in ESM test env) |
| `tests/stores/settings.test.ts` | Config load/save, devnet manifest detection, Sepolia detection |
| `tests/stores/nodes.test.ts` | Daemon connection flow, SSE event handling, status getters |
| `tests/utils/wallet-config.test.ts` | Chain ID selection, token/vault address overrides per network mode |

### Test coverage

**19 tests across 3 suites:**

- **Settings store** (6 tests): loads config from backend, handles corrupt config gracefully, activates devnet mode from manifest, detects Sepolia from RPC URL, stays in production mode without manifest, persists config changes
- **Nodes store** (6 tests): connects to daemon on startup, updates daemon URL on port change, sets disconnected when daemon unavailable, handles SSE node events, handles crash events, counts nodes by status
- **Wallet config** (7 tests): returns correct chain ID for mainnet/Sepolia/Anvil, returns correct token and vault addresses with devnet overrides

### How to run

```bash
npm test          # watch mode
npm run test:run  # single run
```

## Test plan

- [x] All 19 tests pass locally
- [x] Tauri invoke mock correctly intercepts all store commands
- [x] AppKit/WalletConnect mocked to avoid CommonJS import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)