### PR TITLE
chore: bump evmlib from 0.4 to 0.8

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -834,7 +834,7 @@ dependencies = [
  "async-stream",
  "axum",
  "bytes",
- "evmlib 0.8.0",
+ "evmlib",
  "flate2",
  "fs2",
  "futures",
@@ -871,11 +871,11 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.2.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",
- "evmlib 0.4.9",
+ "evmlib",
  "futures-util",
  "hex",
  "libc",
@@ -914,7 +914,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "directories",
- "evmlib 0.8.0",
+ "evmlib",
  "flate2",
  "fs2",
  "futures",
@@ -2931,23 +2931,6 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
-]
-
-[[package]]
-name = "evmlib"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0830ac5a8d0e13e2275782c6375464ea49f255c0b59ccba4ca11f8fb7d67cea5"
-dependencies = [
- "alloy",
- "exponential-backoff",
- "hex",
- "rand 0.8.5",
- "serde",
- "serde_with",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,7 +24,7 @@ dirs = "5"
 toml = "0.8"
 tauri-plugin-updater = "2"
 ant-core = { git = "https://github.com/WithAutonomi/ant-client", version = "0.1" }
-evmlib = "0.4"
+evmlib = "0.8"
 hex = "0.4"
 sha2 = "0.10"
 


### PR DESCRIPTION
## Summary

Align evmlib version with the rest of the stack. ant-core and ant-node already use evmlib 0.8 (unified PaymentVault API from ant-node commit a08a727), while ant-ui was still on 0.4.

### Version alignment

| Component | Before | After |
|-----------|--------|-------|
| ant-node | 0.8 | 0.8 |
| ant-core | 0.8 | 0.8 |
| **ant-ui** | **0.4** | **0.8** |

### What changed in evmlib 0.4 → 0.8

The main change was unifying `data_payments_address` + `merkle_payments_address` into a single `payment_vault_address`. ant-ui's frontend already uses the unified `IPaymentVault.json` ABI and the unified contract address — only the Rust-side crate version was stale.

### Impact

ant-ui only imports `QuoteHash` and `TxHash` from evmlib, which are identical across both versions. **No code changes needed** — just the Cargo.toml version bump.

## Test plan

- [x] `cargo check` passes
- [x] All 19 vitest tests pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)