### PR TITLE
fix(ui): disable public upload option until backend is wired

### DIFF
--- a/components/files/UploadConfirmDialog.vue
+++ b/components/files/UploadConfirmDialog.vue
@@ -98,25 +98,21 @@
                 </p>
               </button>
 
-              <!-- Public -->
+              <!-- Public (disabled — not yet implemented in backend) -->
               <button
-                class="flex-1 rounded-lg border p-3 text-left transition-all"
-                :class="visibility === 'public'
-                  ? 'border-autonomi-blue bg-autonomi-blue/10'
-                  : 'border-autonomi-border hover:border-autonomi-blue/30'"
-                @click="visibility = 'public'"
+                type="button"
+                disabled
+                aria-disabled="true"
+                title="Public uploads are not yet available"
+                class="flex-1 cursor-not-allowed rounded-lg border border-autonomi-border p-3 text-left opacity-50"
               >
                 <div class="flex items-center gap-2">
-                  <div
-                    class="flex h-4 w-4 items-center justify-center rounded-full border-2"
-                    :class="visibility === 'public' ? 'border-autonomi-blue' : 'border-autonomi-muted'"
-                  >
-                    <div v-if="visibility === 'public'" class="h-2 w-2 rounded-full bg-autonomi-blue" />
-                  </div>
+                  <div class="flex h-4 w-4 items-center justify-center rounded-full border-2 border-autonomi-muted" />
                   <span class="text-sm font-medium">Public</span>
+                  <span class="ml-auto rounded bg-autonomi-border/60 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-autonomi-muted">Coming soon</span>
                 </div>
-                <p class="mt-1.5 pl-6 text-xs text-autonomi-warning">
-                  Not encrypted. Anyone on the network can access this file with its address.
+                <p class="mt-1.5 pl-6 text-xs text-autonomi-muted">
+                  Not yet available. All uploads are currently private.
                 </p>
               </button>
             </div>


### PR DESCRIPTION
## Summary

**This PR blocks the Public upload option in the ant-gui UI.** The Public button in the upload-confirm dialog becomes disabled and labelled "Coming soon". Users can still upload files — every upload is now unambiguously private, which is exactly what Public was doing under the hood anyway.

## Why block it

Before this PR, the dialog offered a Public/Private toggle that had no backend support:

- **Frontend drops the flag silently.** `stores/files.ts:235-240` accepts `options.visibility` in `startRealUpload` but the parameter is never referenced in the function body.
- **Backend has no public path.** `src-tauri/src/autonomi_ops.rs` never calls `client.data_map_store()`, so the serialized DataMap is never published as a public chunk on the Autonomi network.
- **The displayed "address" is a lie.** For every upload, the backend returns `Sha256::digest(data_map_json)` computed locally (`autonomi_ops.rs:305`, `:358`). That's a fingerprint of the local data map JSON, not a retrievable network address. Sharing that address would give the recipient nothing.

Picking Public today gives the user a false sense of having published the file. The data never actually leaks — the data map stays on the uploader's disk — but the UX promise is broken, and a toggle that silently does nothing is worse than no toggle at all.

## Why not implement public here

Public uploads need an external-signer-compatible way to store the serialized DataMap as an additional paid chunk. That does not exist in `WithAutonomi/ant-client` today:

- `client.data_map_store` internally calls `pay_for_storage`, which hard-requires a wallet. ant-gui has no wallet on the Rust side — all payments go via WalletConnect / direct-wallet on the frontend (external-signer flow).
- The chunk-storage plumbing needed to hand-roll it (`store_paid_chunks`, `chunk_put_to_close_group`, `merkle_upload_chunks`) is `pub(crate)`, so external callers cannot use it.

An upstream PR is in flight on `WithAutonomi/ant-client` to add a `Visibility` argument to `file_prepare_upload`, bundling the serialized DataMap into the existing payment batch as one additional chunk. Once that lands and we bump the git dep, a follow-up PR on this repo will re-enable the Public button and thread the visibility flag through `start_upload` / `confirm_upload`.

## Changes

- `components/files/UploadConfirmDialog.vue` — Public button becomes a real `<button disabled>`, with reduced opacity, `cursor-not-allowed`, a "Coming soon" pill, and explanatory subtext. Private remains selectable and is the only emitted value; the `visibility` ref resets to `'private'` on every dialog open.

## Test plan

- [x] `npx nuxi typecheck` passes
- [x] `npm run test:run` — 19/19 pass (no existing tests cover this component)
- [x] Manual: open an upload, Public button is greyed and unclickable
- [x] Manual: complete a private upload end-to-end — behaviour unchanged