### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Minor version bump for the next release.

## Notable changes since v0.5.0

- Disable Public upload option in the upload dialog until external-signer backend support lands (#12)
- Bump `evmlib` from 0.4 → 0.8 (#11)
- Add Vitest test suite + PR CI checks (nuxt typecheck, vitest, cargo fmt/clippy) (#10)
- Parallel CI builds + pre-built sidecar binaries (#8)

## Release flow

Once merged, tag `v0.6.0` on main and push the tag to trigger `.github/workflows/release.yml`. CI will pull `ant-cli latest` (currently `ant-cli-v0.1.2` → `ant` daemon `0.1.2` bundling `ant-node` `0.10.0`) as the sidecar, build Linux / macOS (aarch64 + x86_64) / Windows (signed MSI), and create a **draft** GitHub release. Another team will review and publish.

## Test plan

- [x] `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock` all match `0.6.0`
- [ ] CI passes (typecheck, vitest, rust fmt/clippy/check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)