### PR TITLE
fix: bundle mainnet bootstrap peers + WalletConnect modal cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,13 @@ jobs:
           chmod +x "src-tauri/binaries/ant-${CROSS_TARGET}"
           echo "Sidecar ready: src-tauri/binaries/ant-${CROSS_TARGET}"
 
+          # Bundle the bootstrap_peers.toml that ships with this daemon version
+          # so the GUI's embedded ant-core client can connect on a fresh install.
+          mkdir -p src-tauri/resources
+          cp "/tmp/ant-${ANT_VERSION}-${ANT_TARGET}/bootstrap_peers.toml" \
+             "src-tauri/resources/bootstrap_peers.toml"
+          echo "Bootstrap peers refreshed from $ANT_TAG"
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -259,6 +266,13 @@ jobs:
           cp "$RUNNER_TEMP/ant-${ANT_VERSION}-${TARGET}/ant.exe" \
             "$GITHUB_WORKSPACE/src-tauri/binaries/ant-${TARGET}.exe"
           echo "Sidecar ready: src-tauri/binaries/ant-${TARGET}.exe"
+
+          # Bundle the bootstrap_peers.toml that ships with this daemon version
+          # so the GUI's embedded ant-core client can connect on a fresh install.
+          mkdir -p "$GITHUB_WORKSPACE/src-tauri/resources"
+          cp "$RUNNER_TEMP/ant-${ANT_VERSION}-${TARGET}/bootstrap_peers.toml" \
+            "$GITHUB_WORKSPACE/src-tauri/resources/bootstrap_peers.toml"
+          echo "Bootstrap peers refreshed from $ANT_TAG"
 
       - name: create client certificate file
         id: prepare_cert

--- a/plugins/appkit.client.ts
+++ b/plugins/appkit.client.ts
@@ -35,6 +35,12 @@ export default defineNuxtPlugin(async () => {
         email: false,
         socials: false,
       },
+      // Tauri's webview has no browser extensions, so the legacy injected
+      // (window.ethereum) and the EIP-6963 multi-wallet discovery channels
+      // can never resolve a wallet — disable both so the modal doesn't
+      // advertise an unreachable "Browser" option.
+      enableInjected: false,
+      enableEIP6963: false,
       themeMode: 'dark',
     })
 

--- a/scripts/setup-sidecar.ps1
+++ b/scripts/setup-sidecar.ps1
@@ -21,3 +21,15 @@ New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
 Copy-Item (Join-Path $ClientDir "target\release\ant.exe") (Join-Path $BinDir "ant-$Target.exe")
 
 Write-Host "Sidecar binary installed: src-tauri\binaries\ant-$Target.exe"
+
+# Refresh bundled bootstrap peers from the sibling ant-client repo so dev
+# builds use the same peer list the daemon ships with.
+$ResourceDir = Join-Path $GuiDir "src-tauri\resources"
+$PeersSrc = Join-Path $ClientDir "resources\bootstrap_peers.toml"
+if (Test-Path $PeersSrc) {
+    New-Item -ItemType Directory -Force -Path $ResourceDir | Out-Null
+    Copy-Item $PeersSrc (Join-Path $ResourceDir "bootstrap_peers.toml") -Force
+    Write-Host "Bootstrap peers refreshed: src-tauri\resources\bootstrap_peers.toml"
+} else {
+    Write-Warning "bootstrap_peers.toml not found at $PeersSrc — keeping vendored snapshot"
+}

--- a/scripts/setup-sidecar.sh
+++ b/scripts/setup-sidecar.sh
@@ -22,3 +22,14 @@ mkdir -p "$GUI_DIR/src-tauri/binaries"
 cp "target/release/ant" "$GUI_DIR/src-tauri/binaries/ant-${TARGET}"
 
 echo "Sidecar binary installed: src-tauri/binaries/ant-${TARGET}"
+
+# Refresh bundled bootstrap peers from the sibling ant-client repo so dev
+# builds use the same peer list the daemon ships with.
+PEERS_SRC="$CLIENT_DIR/resources/bootstrap_peers.toml"
+if [ -f "$PEERS_SRC" ]; then
+    mkdir -p "$GUI_DIR/src-tauri/resources"
+    cp "$PEERS_SRC" "$GUI_DIR/src-tauri/resources/bootstrap_peers.toml"
+    echo "Bootstrap peers refreshed: src-tauri/resources/bootstrap_peers.toml"
+else
+    echo "Warning: bootstrap_peers.toml not found at $PEERS_SRC — keeping vendored snapshot"
+fi

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -811,7 +811,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -822,13 +822,13 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "ant-core"
 version = "0.1.1"
-source = "git+https://github.com/WithAutonomi/ant-client#c7d9ee131ddd0edddac1b8d915b999ea812424e5"
+source = "git+https://github.com/WithAutonomi/ant-client?tag=ant-cli-v0.1.2#c7d9ee131ddd0edddac1b8d915b999ea812424e5"
 dependencies = [
  "ant-node",
  "async-stream",
@@ -2639,7 +2639,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2942,7 +2942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4875,7 +4875,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4939,7 +4939,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5970,7 +5970,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5983,7 +5983,7 @@ dependencies = [
  "libc",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6543,7 +6543,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6611,7 +6611,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7433,7 +7433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8134,7 +8134,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8650,7 +8650,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9234,7 +9234,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -811,7 +811,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -822,13 +822,13 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ant-core"
 version = "0.1.1"
-source = "git+https://github.com/WithAutonomi/ant-client#796d0df75d748419a004aec6f5e288b41d8b496e"
+source = "git+https://github.com/WithAutonomi/ant-client#c7d9ee131ddd0edddac1b8d915b999ea812424e5"
 dependencies = [
  "ant-node",
  "async-stream",
@@ -904,8 +904,9 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0-rc.1"
-source = "git+https://github.com/WithAutonomi/ant-node?rev=6dfc7178a940fc842ab3c6542265d9750a08b060#6dfc7178a940fc842ab3c6542265d9750a08b060"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "716cbaf63c0fb090667e8db0c87364ad3293ffc04396999c6ec1a5b394af8989"
 dependencies = [
  "aes-gcm-siv",
  "blake3",
@@ -1398,6 +1399,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,7 +1618,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq 0.4.2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1910,7 +1923,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1920,7 +1944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -2068,7 +2092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -2191,6 +2215,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2363,7 +2396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -2606,7 +2639,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2909,7 +2942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3485,6 +3518,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -4147,6 +4181,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "igd-next"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac9a3c8278f43b4cd8463380f4a25653ac843e5b177e1d3eaf849cc9ba10d4d"
+dependencies = [
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand 0.10.1",
+ "tokio",
+ "url",
+ "xmltree",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4394,7 +4448,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -4821,7 +4875,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4885,7 +4939,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5649,7 +5703,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5661,7 +5715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5916,7 +5970,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5929,7 +5983,7 @@ dependencies = [
  "libc",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5997,6 +6051,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6053,6 +6118,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -6472,7 +6543,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6540,7 +6611,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6616,9 +6687,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad51589091bdbfbf8c42b5db37428a1cad0febd0af616ef3fe3a0f38dc921b24"
+checksum = "8eefc3539465111e2769b9b8334ddd4d7071e12c183de4a9fee7d9bfbdb3da23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6733,9 +6804,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e33412e61b0cb630410981a629f967a858b1663be8f71b75eadb66c9588ef26"
+checksum = "250826f52ac60992947359218d83c21f658aa85407e3980a5dbb258eff4c0cc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6749,6 +6820,7 @@ dependencies = [
  "dirs 5.0.1",
  "futures-util",
  "hex",
+ "igd-next",
  "indexmap 2.13.0",
  "keyring",
  "libc",
@@ -7241,7 +7313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -7252,7 +7324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -7361,7 +7433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8062,7 +8134,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8578,7 +8650,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9162,7 +9234,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9936,6 +10008,21 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ futures-util = "0.3"
 dirs = "5"
 toml = "0.8"
 tauri-plugin-updater = "2"
-ant-core = { git = "https://github.com/WithAutonomi/ant-client", version = "0.1" }
+ant-core = { git = "https://github.com/WithAutonomi/ant-client", tag = "ant-cli-v0.1.2" }
 evmlib = "0.8"
 hex = "0.4"
 sha2 = "0.10"

--- a/src-tauri/resources/bootstrap_peers.toml
+++ b/src-tauri/resources/bootstrap_peers.toml
@@ -1,0 +1,17 @@
+# Autonomi Network — Bootstrap Peers
+#
+# This file provides initial peers for joining the production network.
+# It is loaded automatically when no --bootstrap CLI argument is provided.
+#
+# Format: "ip:port" socket addresses.
+# Port range for ant-node: 10000-10999.
+
+peers = [
+    "207.148.94.42:10000",
+    "45.77.50.10:10000",
+    "66.135.23.83:10000",
+    "149.248.9.2:10000",
+    "49.12.119.240:10000",
+    "5.161.25.133:10000",
+    "18.228.202.183:10000",
+]

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -6,8 +6,46 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::RwLock;
+
+#[derive(Deserialize)]
+struct BootstrapPeersFile {
+    peers: Vec<String>,
+}
+
+/// Read the bundled `bootstrap_peers.toml` shipped as a Tauri resource.
+///
+/// The file lives at `src-tauri/resources/bootstrap_peers.toml` in the repo and
+/// is bundled into the app at build time. CI overwrites it from the daemon
+/// release archive so the bundled list always matches the daemon being shipped.
+fn load_bundled_bootstrap_peers(app: &AppHandle) -> Result<Vec<std::net::SocketAddr>, String> {
+    let path = app
+        .path()
+        .resolve(
+            "resources/bootstrap_peers.toml",
+            tauri::path::BaseDirectory::Resource,
+        )
+        .map_err(|e| format!("Failed to resolve bootstrap_peers.toml resource: {e}"))?;
+
+    let contents = std::fs::read_to_string(&path).map_err(|e| {
+        format!(
+            "Failed to read bundled bootstrap_peers.toml at {}: {e}",
+            path.display()
+        )
+    })?;
+
+    let parsed: BootstrapPeersFile = toml::from_str(&contents)
+        .map_err(|e| format!("Failed to parse bootstrap_peers.toml: {e}"))?;
+
+    let peers: Vec<std::net::SocketAddr> =
+        parsed.peers.iter().filter_map(|s| s.parse().ok()).collect();
+
+    if peers.is_empty() {
+        return Err("Bundled bootstrap_peers.toml has no parseable peers".into());
+    }
+    Ok(peers)
+}
 
 // ── Shared state managed by Tauri ──
 
@@ -91,10 +129,16 @@ pub struct StartUploadRequest {
 
 /// Initialize the data client. Connects to the Autonomi network via bootstrap peers.
 ///
+/// `bootstrap_peers` overrides the bundled list (used by the devnet path).
+/// When `bootstrap_peers` is `None` or empty, falls back to
+/// `resources/bootstrap_peers.toml` shipped with the app — this is the
+/// production-mainnet path.
+///
 /// When `evm_rpc_url` is provided, uses a custom EVM network (for devnet/testnet).
 /// Otherwise defaults to Arbitrum One.
 #[tauri::command]
 pub async fn init_autonomi_client(
+    app: AppHandle,
     state: tauri::State<'_, AutonomiState>,
     bootstrap_peers: Option<Vec<String>>,
     evm_rpc_url: Option<String>,
@@ -106,14 +150,15 @@ pub async fn init_autonomi_client(
         return Ok(true);
     }
 
-    let peers: Vec<std::net::SocketAddr> = bootstrap_peers
-        .unwrap_or_default()
-        .iter()
-        .filter_map(|s| s.parse().ok())
-        .collect();
+    let peers: Vec<std::net::SocketAddr> = match bootstrap_peers {
+        Some(list) if !list.is_empty() => list.iter().filter_map(|s| s.parse().ok()).collect(),
+        _ => load_bundled_bootstrap_peers(&app)?,
+    };
 
     if peers.is_empty() {
-        return Err("No bootstrap peers provided".into());
+        return Err(
+            "No bootstrap peers available (overrides empty and bundled list invalid)".into(),
+        );
     }
 
     let config = ClientConfig::default();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,6 +13,7 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "externalBin": ["binaries/ant"],
+    "resources": ["resources/bootstrap_peers.toml"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* https: wss:; img-src 'self' asset: http://asset.localhost data: https:; font-src 'self' data:"
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* https: wss:; img-src 'self' asset: http://asset.localhost data: blob: https:; font-src 'self' data:"
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary

Three defects found in v0.6.0 testing. All on a fresh-install mainnet build.

### 1. Bootstrap peers never reach the embedded ant-core client (blocks every upload)

Released v0.6.0 fails to quote any upload because the embedded ant-core client never gets bootstrap peers on the mainnet code path:

- `app.vue:51-55` calls `invoke('init_autonomi_client')` with **no args** outside devnet mode.
- `autonomi_ops.rs::init_autonomi_client` errors immediately on `peers.is_empty()`.
- `app.vue:52` swallows the error in a `.catch(console.warn)`, so the user only sees the symptom downstream as the upload dialog timing out with *"Could not connect to the Autonomi network"*.

**Fix:** ship the same `bootstrap_peers.toml` that the daemon ships and read it as a fallback. Cross-platform — the toml is a Tauri resource and the lookup goes through `app.path().resolve(.., BaseDirectory::Resource)`.

- Vendor `src-tauri/resources/bootstrap_peers.toml` (snapshot of the toml from `ant-cli-v0.1.2`)
- Bundle it via `tauri.conf.json` `bundle.resources`
- `init_autonomi_client` now takes `AppHandle`, parses the bundled toml as the fallback peer list when the override is `None` or empty, and only fails if both sources are empty
- `scripts/setup-sidecar.{ps1,sh}` also copy the toml from the sibling `ant-client/resources/` so dev builds match the daemon being built
- `.github/workflows/release.yml` extracts the toml from the daemon release archive into `src-tauri/resources/` on both the Linux/macOS and Windows jobs, so each release ships the toml that matches the bundled daemon version
- Bump `ant-core` git rev (`cargo update`) — not the cause of the bug but worth refreshing alongside this fix

### 2. The "Browser" connector option is unreachable in Tauri

AppKit's modal advertises a "Browser" connector that proxies to whatever browser-extension wallet is injected into the page. Tauri's webview (WebView2 / WKWebView / WebKitGTK) does **not** load browser extensions, so `window.ethereum` is never populated and EIP-6963 announcements never arrive. Selecting "Browser" just hangs.

- `enableInjected: false` — kills the legacy `window.ethereum` channel
- `enableEIP6963: false` — kills the modern multi-wallet discovery channel that current MetaMask uses

`enableCoinbase` stays at the default (`true`) because the Coinbase Wallet SDK supports QR / mobile redirect — it does not require an extension.

### 3. Wallet icons never render

`@reown/appkit-controllers/.../ApiController.js:_fetchWalletImage` fetches each wallet logo from `https://api.web3modal.org/getWalletImage/<id>` and stores it as `URL.createObjectURL(blob)` — the modal renders icons via `<img src="blob:...">`. The CSP previously allowed `img-src 'self' asset: http://asset.localhost data: https:` but not `blob:`, so every fetched icon was silently blocked at render time.

- Add `blob:` to `img-src`.

## Files changed

- `src-tauri/src/autonomi_ops.rs` — `init_autonomi_client` accepts `AppHandle`, falls back to bundled toml when no peer override
- `src-tauri/resources/bootstrap_peers.toml` — vendored from `ant-cli-v0.1.2`
- `src-tauri/tauri.conf.json` — declare resource, add `blob:` to CSP `img-src`
- `src-tauri/Cargo.lock` — `ant-core` bumped via `cargo update`
- `plugins/appkit.client.ts` — `enableInjected: false`, `enableEIP6963: false`
- `scripts/setup-sidecar.{ps1,sh}` — copy peers toml from sibling
- `.github/workflows/release.yml` — extract peers toml from daemon archive on Linux/macOS and Windows jobs

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml --all-features` passes
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` clean
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` clean
- [x] `npm run test:run` — 19/19 pass
- [ ] CI release build pulls latest daemon archive, bundles toml, MSI signs, draft release created
- [ ] Manual on a fresh-install build: connect wallet (no Browser option, icons render), pick a file, see a real cost quote

🤖 Generated with [Claude Code](https://claude.com/claude-code)