### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Patch bump for the bug-fix release.

## Changes since v0.6.0

- Bundle `bootstrap_peers.toml` so the embedded ant-core client can connect on a fresh install — mainnet upload quoting was broken in v0.6.0 because no peers were ever passed (#14)
- Hide the WalletConnect modal's "Browser" connector — Tauri's webview has no extensions, that option just hung (#14)
- Allow `blob:` in CSP `img-src` so AppKit wallet icons render (#14)
- Pin `ant-core` to the `ant-cli-v0.1.2` tag — embedded client, bundled daemon, and bundled bootstrap peers are now in lockstep (#14)

## Release flow

Once merged, tag `v0.6.1` on main and push to trigger `release.yml`. CI pulls `ant-cli-v0.1.2` (matching the pinned ant-core), bundles `bootstrap_peers.toml` from the same release, builds Linux / macOS (aarch64 + x86_64) / Windows (signed MSI), and creates a **draft** GitHub release. Another team reviews and publishes.

## Test plan

- [x] `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock` all match `0.6.1`
- [ ] CI passes (typecheck, vitest, rust fmt/clippy/check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)