### PR TITLE
fix: v0.6.1 connection, wallet, and upload reliability

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -11,6 +11,7 @@ import { useSettingsStore } from '~/stores/settings'
 import { useUpdaterStore } from '~/stores/updater'
 import { useNodesStore } from '~/stores/nodes'
 import { useFilesStore } from '~/stores/files'
+import { useConnectionStore } from '~/stores/connection'
 
 useHead({
   title: 'Autonomi',
@@ -23,6 +24,7 @@ const settingsStore = useSettingsStore()
 const updaterStore = useUpdaterStore()
 const nodesStore = useNodesStore()
 const filesStore = useFilesStore()
+const connectionStore = useConnectionStore()
 
 onMounted(async () => {
   await settingsStore.loadConfig()
@@ -31,6 +33,8 @@ onMounted(async () => {
   filesStore.loadHistory()
   updaterStore.checkForUpdate()
   settingsStore.reconnectIndelible()
+  // Listen for backend connection-status events so the UI reflects retry state.
+  connectionStore.startListening()
 
   // Initialize autonomi client — when manifest present, pass custom config
   if (settingsStore.devnetActive) {

--- a/components/files/UploadConfirmDialog.vue
+++ b/components/files/UploadConfirmDialog.vue
@@ -56,18 +56,36 @@
                 <span>Getting cost quote from network...</span>
               </div>
             </template>
-            <template v-else-if="!networkConnected">
-              <div v-if="!networkTimedOut" class="flex items-center gap-2 text-sm text-autonomi-muted">
+            <template v-else-if="connectionStore.isConnecting">
+              <div class="flex items-center gap-2 text-sm text-autonomi-muted">
                 <div class="h-3 w-3 animate-spin rounded-full border-2 border-yellow-500 border-t-transparent" />
-                <span>Discovering network...</span>
+                <span>
+                  Connecting to the Autonomi network
+                  <template v-if="connectingDetails">({{ connectingDetails }})</template>...
+                </span>
               </div>
-              <div v-else class="text-sm text-yellow-500/80">
-                Could not connect to the Autonomi network. You can still upload — the cost will be quoted when the network becomes available.
+            </template>
+            <template v-else-if="connectionStore.hasFailed">
+              <div class="space-y-2">
+                <div class="text-sm text-yellow-500/80">
+                  Could not connect to the Autonomi network after {{ failedAttempts }} attempt{{ failedAttempts !== 1 ? 's' : '' }}.
+                </div>
+                <div v-if="failedReason" class="text-xs text-autonomi-muted break-words">
+                  {{ failedReason }}
+                </div>
+                <button
+                  type="button"
+                  class="rounded-md border border-autonomi-blue/40 px-2.5 py-1 text-xs font-medium text-autonomi-blue hover:bg-autonomi-blue/10"
+                  @click="connectionStore.retry()"
+                >
+                  Retry
+                </button>
               </div>
             </template>
             <template v-else>
-              <div class="text-sm text-autonomi-muted">
-                Cost will be quoted from the network when the upload starts.
+              <div class="flex items-center gap-2 text-sm text-autonomi-muted">
+                <div class="h-3 w-3 animate-spin rounded-full border-2 border-autonomi-blue border-t-transparent" />
+                <span>Preparing cost quote...</span>
               </div>
             </template>
           </div>
@@ -145,8 +163,7 @@
 <script setup lang="ts">
 import { formatBytes } from '~/utils/formatters'
 import { MERKLE_THRESHOLD, AVG_CHUNK_SIZE } from '~/utils/constants'
-
-const NETWORK_TIMEOUT_MS = 15_000
+import { useConnectionStore } from '~/stores/connection'
 
 const props = defineProps<{
   open: boolean
@@ -160,7 +177,11 @@ const props = defineProps<{
   quoting?: boolean
   /** Payment mode selected by the backend (null if no quote yet) */
   quotedPaymentMode?: 'wave-batch' | 'merkle' | null
-  /** Whether the Autonomi network client is connected */
+  /**
+   * Kept for backward compatibility with the parent — the dialog now reads
+   * the richer connection state directly from useConnectionStore() so it can
+   * show "Connecting (attempt N of M)..." and a Retry button.
+   */
   networkConnected?: boolean
 }>()
 
@@ -169,9 +190,9 @@ const emit = defineEmits<{
   cancel: []
 }>()
 
+const connectionStore = useConnectionStore()
+
 const visibility = ref<'private' | 'public'>('private')
-const networkTimedOut = ref(false)
-let networkTimer: ReturnType<typeof setTimeout> | null = null
 
 const totalSize = computed(() => props.files.reduce((sum, f) => sum + f.size, 0))
 const estimatedChunks = computed(() => Math.max(1, Math.ceil(totalSize.value / AVG_CHUNK_SIZE)))
@@ -183,34 +204,23 @@ const effectivePaymentMode = computed(() => {
   return estimatedChunks.value >= MERKLE_THRESHOLD ? 'merkle' : 'regular'
 })
 
+const connectingDetails = computed(() => {
+  const s = connectionStore.current
+  if (s.status !== 'connecting') return null
+  return `attempt ${s.attempt} of ${s.of}`
+})
+const failedReason = computed(() =>
+  connectionStore.current.status === 'failed' ? connectionStore.current.reason : null,
+)
+const failedAttempts = computed(() =>
+  connectionStore.current.status === 'failed' ? connectionStore.current.attempts : 0,
+)
+
 watch(
   () => props.open,
   (val) => {
     if (val) {
       visibility.value = 'private'
-      networkTimedOut.value = false
-      // Start network discovery timeout when dialog opens and not connected
-      if (!props.networkConnected) {
-        networkTimer = setTimeout(() => {
-          networkTimedOut.value = true
-        }, NETWORK_TIMEOUT_MS)
-      }
-    } else {
-      if (networkTimer) {
-        clearTimeout(networkTimer)
-        networkTimer = null
-      }
-    }
-  },
-)
-
-// Clear timeout if network connects while dialog is open
-watch(
-  () => props.networkConnected,
-  (connected) => {
-    if (connected && networkTimer) {
-      clearTimeout(networkTimer)
-      networkTimer = null
     }
   },
 )

--- a/composables/useWallet.ts
+++ b/composables/useWallet.ts
@@ -4,79 +4,99 @@ import { useWalletStore } from '~/stores/wallet'
 import { useSettingsStore } from '~/stores/settings'
 import { getTokenAddress, getActiveChainId } from '~/utils/wallet-config'
 
-export function useWallet() {
+// Module-level guard so the AppKit→walletStore watcher is only installed once
+// across the app's lifetime, no matter how many call sites import useWallet().
+// Calling useWallet() a second time used to set up a duplicate `watch` with
+// `immediate: true`, which fired with a momentarily-undefined `connected` and
+// briefly nulled walletStore.connected/balances — visible in the UI as a
+// "wallet disconnected" flicker on Refresh Balances.
+let syncStarted = false
+
+/**
+ * Fetch wallet balances and update the store. Safe to call repeatedly from
+ * anywhere — does not touch the AppKit watcher or any reactive setup.
+ */
+export async function refreshBalances() {
+  const { $appkitReady, $wagmiAdapter } = useNuxtApp()
+  if (!$appkitReady || !$wagmiAdapter?.wagmiConfig) return
+
   const walletStore = useWalletStore()
-  const settingsStore = useSettingsStore()
-  const { $wagmiAdapter, $appkitReady } = useNuxtApp()
+  if (!walletStore.paymentAddress) return
 
-  async function syncFromAppKit() {
-    if (!$appkitReady) return
-    if (settingsStore._devnetWalletKeySet) return
+  try {
+    const addr = walletStore.paymentAddress as `0x${string}`
+    const config = $wagmiAdapter.wagmiConfig
 
-    const { useAppKitAccount } = await import('@reown/appkit/vue')
+    const ethResult = await getBalance(config, {
+      address: addr,
+      chainId: getActiveChainId(),
+    })
+    const ethFormatted = parseFloat(formatEther(ethResult.value)).toFixed(4)
 
-    // Re-check after async import — key may have been set during the await
-    if (settingsStore._devnetWalletKeySet) return
-
-    const account = useAppKitAccount()
-    const address = computed(() => (account.value as any)?.address as string | undefined)
-    const isConnected = computed(() => (account.value as any)?.isConnected as boolean | undefined)
-
-    watch(
-      [isConnected, address],
-      ([connected, addr]) => {
-        if (settingsStore._devnetWalletKeySet) return
-        walletStore.connected = !!connected
-        walletStore.paymentAddress = addr ?? null
-        if (connected && addr) {
-          refreshBalances()
-        } else {
-          walletStore.balance = null
-          walletStore.ethBalance = null
-          walletStore.antBalance = null
-        }
-      },
-      { immediate: true },
-    )
-  }
-
-  async function refreshBalances() {
-    if (!$appkitReady || !$wagmiAdapter?.wagmiConfig || !walletStore.paymentAddress) return
-
+    let antFormatted = '0.00'
     try {
-      const addr = walletStore.paymentAddress as `0x${string}`
-      const config = $wagmiAdapter.wagmiConfig
-
-      const ethResult = await getBalance(config, {
-        address: addr,
+      const antResult = await readContract(config, {
+        address: getTokenAddress(),
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [addr],
         chainId: getActiveChainId(),
       })
-      const ethFormatted = parseFloat(formatEther(ethResult.value)).toFixed(4)
-
-      let antFormatted = '0.00'
-      try {
-        const antResult = await readContract(config, {
-          address: getTokenAddress(),
-          abi: erc20Abi,
-          functionName: 'balanceOf',
-          args: [addr],
-          chainId: getActiveChainId(),
-        })
-        antFormatted = parseFloat(formatUnits(antResult as bigint, 18)).toFixed(2)
-      } catch {
-        // ANT token read may fail
-      }
-
-      walletStore.ethBalance = `${ethFormatted} ETH`
-      walletStore.antBalance = `${antFormatted} ANT`
-      walletStore.balance = `${ethFormatted} ETH / ${antFormatted} ANT`
-    } catch (err) {
-      console.error('Failed to fetch balances:', err)
+      antFormatted = parseFloat(formatUnits(antResult as bigint, 18)).toFixed(2)
+    } catch {
+      // ANT token read may fail on chains without the contract deployed.
     }
+
+    walletStore.ethBalance = `${ethFormatted} ETH`
+    walletStore.antBalance = `${antFormatted} ANT`
+    walletStore.balance = `${ethFormatted} ETH / ${antFormatted} ANT`
+  } catch (err) {
+    console.error('Failed to fetch balances:', err)
   }
+}
 
-  // Start syncing
-  syncFromAppKit()
+/**
+ * Install the AppKit→walletStore sync watcher. Idempotent — additional calls
+ * are no-ops. Intended to be invoked once at app startup (see app.vue).
+ */
+export function useWallet() {
+  if (syncStarted) return
+  syncStarted = true
 
-  return { refreshBalances }
+  void syncFromAppKit()
+}
+
+async function syncFromAppKit() {
+  const { $appkitReady } = useNuxtApp()
+  if (!$appkitReady) return
+
+  const settingsStore = useSettingsStore()
+  if (settingsStore._devnetWalletKeySet) return
+
+  const { useAppKitAccount } = await import('@reown/appkit/vue')
+
+  // Re-check after async import — key may have been set during the await.
+  if (settingsStore._devnetWalletKeySet) return
+
+  const walletStore = useWalletStore()
+  const account = useAppKitAccount()
+  const address = computed(() => (account.value as any)?.address as string | undefined)
+  const isConnected = computed(() => (account.value as any)?.isConnected as boolean | undefined)
+
+  watch(
+    [isConnected, address],
+    ([connected, addr]) => {
+      if (settingsStore._devnetWalletKeySet) return
+      walletStore.connected = !!connected
+      walletStore.paymentAddress = addr ?? null
+      if (connected && addr) {
+        refreshBalances()
+      } else {
+        walletStore.balance = null
+        walletStore.ethBalance = null
+        walletStore.antBalance = null
+      }
+    },
+    { immediate: true },
+  )
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -24,6 +24,14 @@ export default defineNuxtConfig({
     resolve: {
       dedupe: ['vue'],
     },
+    build: {
+      // Disable auto-generated <link rel="modulepreload"> tags. In a Tauri
+      // SPA the user rarely navigates to all routes immediately, so the
+      // browser warns "resource preloaded but not used within a few seconds"
+      // for every unused chunk (55+ per session). Loading from local app
+      // resources is fast enough that we don't need the prefetch.
+      modulePreload: false,
+    },
   },
 
   compatibilityDate: '2024-11-01',

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -166,6 +166,7 @@ import { useFilesStore, type FileEntry, type UploadQuote } from '~/stores/files'
 import { formatBytes, truncateAddress } from '~/utils/formatters'
 import { useSettingsStore } from '~/stores/settings'
 import { useToastStore } from '~/stores/toasts'
+import { useConnectionStore } from '~/stores/connection'
 
 interface FileMeta {
   path: string
@@ -176,17 +177,10 @@ interface FileMeta {
 const filesStore = useFilesStore()
 const settingsStore = useSettingsStore()
 const toastStore = useToastStore()
+const connectionStore = useConnectionStore()
 
-// Autonomi client state
-const autonomiConnected = ref(false)
-
-async function checkAutonomiClient() {
-  try {
-    autonomiConnected.value = await invoke<boolean>('is_autonomi_connected')
-  } catch {
-    autonomiConnected.value = false
-  }
-}
+// Autonomi client state — driven by connection-status events from the backend.
+const autonomiConnected = computed(() => connectionStore.isConnected)
 
 function getWagmiConfig() {
   // Direct wallet (private key) takes priority if initialized
@@ -295,6 +289,7 @@ async function setupDragDrop() {
 const showUploadConfirm = ref(false)
 const uploadEstimating = ref(false)
 const pendingUploadFiles = ref<{ name: string; size: number; path: string }[]>([])
+const pendingMetas = ref<FileMeta[]>([])
 const isQuoting = ref(false)
 const quotedCostDisplay = ref<string | null>(null)
 const quotedGasEstimate = ref<string | null>(null)
@@ -331,6 +326,7 @@ async function uploadFiles() {
 async function showUploadConfirmForPaths(paths: string[]) {
   uploadEstimating.value = true
   pendingUploadFiles.value = []
+  pendingMetas.value = []
   quotedCostDisplay.value = null
   quotedGasEstimate.value = null
   quotedPaymentMode.value = null
@@ -338,6 +334,7 @@ async function showUploadConfirmForPaths(paths: string[]) {
   showUploadConfirm.value = true
 
   const metas = await getFileMetas(paths)
+  pendingMetas.value = metas
   pendingUploadFiles.value = metas.map(m => ({
     name: m.name,
     size: m.size,
@@ -345,11 +342,31 @@ async function showUploadConfirmForPaths(paths: string[]) {
   }))
   uploadEstimating.value = false
 
-  // Start real quoting in background (only when connected to network)
+  // Start real quoting in background (only when connected to network).
+  // The watcher below picks up the case where connection completes after the
+  // dialog is already open.
   if ((autonomiConnected.value || settingsStore.devnetActive) && !settingsStore.indelibleConnected) {
     startQuoting(metas)
   }
 }
+
+// If the embedded ant-core client connects (or finishes retrying) while the
+// upload dialog is open and we don't yet have a quote, kick off quoting now.
+// Without this, opening the dialog before the network is ready leaves the
+// dialog stuck on the misleading "Cost will be quoted from the network when
+// upload starts" fallback even after the connection succeeds.
+watch(
+  () => autonomiConnected.value,
+  (connected) => {
+    if (!connected) return
+    if (!showUploadConfirm.value) return
+    if (settingsStore.indelibleConnected) return
+    if (isQuoting.value) return
+    if (quotedCostDisplay.value) return
+    if (pendingMetas.value.length === 0) return
+    startQuoting(pendingMetas.value)
+  },
+)
 
 async function startQuoting(metas: FileMeta[]) {
   isQuoting.value = true
@@ -507,7 +524,6 @@ onMounted(() => {
   if (!filesStore.historyLoaded) {
     filesStore.loadHistory()
   }
-  checkAutonomiClient()
   setupDragDrop()
 })
 

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -467,6 +467,7 @@ function handleDownload(address: string, filename: string) {
 
 const showCostDialog = ref(false)
 const costFiles = ref<{ name: string; size: number; cost?: string }[]>([])
+const costMetas = ref<FileMeta[]>([])
 const costLoading = ref(false)
 
 async function estimateCost() {
@@ -483,16 +484,69 @@ async function estimateCost() {
     costFiles.value = []
     showCostDialog.value = true
 
-    // Cost estimation shows file sizes; real costs come from the upload quote flow
     const metas = await getFileMetas(pathStrings)
+    costMetas.value = metas
+    // Show sizes immediately; the dialog falls back to the heuristic estimate
+    // per file until real costs land below.
     costFiles.value = metas.map(m => ({ name: m.name, size: m.size }))
-
     costLoading.value = false
+
+    // Skip network quoting when Indelible is the active backend — Indelible
+    // prices uploads server-side, so the embedded ant-core has nothing to
+    // quote against.
+    if (settingsStore.indelibleConnected && !settingsStore.devnetActive) return
+
+    // If the embedded client is connected (or devnet override is active),
+    // fire real quotes now. Otherwise the watcher below picks up the case
+    // where the connection completes after the dialog opened.
+    if (autonomiConnected.value || settingsStore.devnetActive) {
+      runCostEstimateQuotes(metas)
+    }
   } catch (err) {
     showCostDialog.value = false
     console.error('File dialog error:', err)
   }
 }
+
+/** Whether a cost-estimate quoting pass is currently in flight. Prevents
+ *  the connection watcher from firing duplicate quote rounds. */
+const costEstimateQuoting = ref(false)
+
+async function runCostEstimateQuotes(metas: FileMeta[]) {
+  if (costEstimateQuoting.value) return
+  costEstimateQuoting.value = true
+  try {
+    for (const meta of metas) {
+      const quote = await filesStore.getUploadQuote(meta.path)
+      if (!quote) continue
+      const idx = costFiles.value.findIndex(f => f.name === meta.name)
+      if (idx === -1) continue
+      // Mutate the entry in place so the dialog's reactive `:files` re-renders.
+      costFiles.value[idx] = {
+        ...costFiles.value[idx],
+        cost: quote.total_cost_display,
+      }
+    }
+  } finally {
+    costEstimateQuoting.value = false
+  }
+}
+
+// Same watch+retry pattern as the upload-confirm dialog: if the estimate
+// dialog is open with sizes only and the network later becomes available,
+// run the quotes then so the user doesn't have to close and reopen.
+watch(
+  () => autonomiConnected.value,
+  (connected) => {
+    if (!connected) return
+    if (!showCostDialog.value) return
+    if (settingsStore.indelibleConnected && !settingsStore.devnetActive) return
+    if (costEstimateQuoting.value) return
+    if (costMetas.value.length === 0) return
+    if (costFiles.value.every(f => f.cost)) return
+    runCostEstimateQuotes(costMetas.value)
+  },
+)
 
 // ── Utilities ──
 

--- a/pages/wallet.vue
+++ b/pages/wallet.vue
@@ -154,11 +154,12 @@ async function refreshBalances() {
     initDevnetWallet() // re-fetches balances
     return
   }
-  // AppKit wallet
+  // AppKit wallet — call refreshBalances directly. Calling useWallet() here
+  // would re-install the AppKit watcher and momentarily flicker the wallet
+  // into a disconnected state.
   if ($appkitReady) {
-    const { useWallet } = await import('~/composables/useWallet')
-    const wallet = useWallet()
-    wallet.refreshBalances()
+    const { refreshBalances: refresh } = await import('~/composables/useWallet')
+    await refresh()
   }
 }
 

--- a/plugins/appkit.client.ts
+++ b/plugins/appkit.client.ts
@@ -38,11 +38,25 @@ export default defineNuxtPlugin(async () => {
       // Tauri's webview has no browser extensions, so the legacy injected
       // (window.ethereum) and the EIP-6963 multi-wallet discovery channels
       // can never resolve a wallet — disable both so the modal doesn't
-      // advertise an unreachable "Browser" option.
+      // advertise an unreachable "Browser" connector card.
       enableInjected: false,
       enableEIP6963: false,
       themeMode: 'dark',
     })
+
+    // Mark the modal as a "universal provider" client. Two effects:
+    //   1. Suppresses the per-wallet "Browser" platform option (e.g. the
+    //      Browser tab inside MetaMask's connect view) — that path requires
+    //      a browser extension we don't have.
+    //   2. Filters the explorer wallet list down to wallets that have at
+    //      least one of mobile_link / desktop_link / webapp_link — pure
+    //      extension-only wallets are unreachable from Tauri.
+    // Set via OptionsController directly because `isUniversalProvider` lives
+    // in OptionsControllerStateInternal, which Reown does not expose on the
+    // createAppKit options type even though setIsUniversalProvider is the
+    // setter the SDK itself uses.
+    const { OptionsController } = await import('@reown/appkit-controllers')
+    OptionsController.setIsUniversalProvider(true)
 
     return {
       provide: {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -811,7 +811,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -822,13 +822,13 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ant-core"
 version = "0.1.1"
-source = "git+https://github.com/WithAutonomi/ant-client?tag=ant-cli-v0.1.2#c7d9ee131ddd0edddac1b8d915b999ea812424e5"
+source = "git+https://github.com/WithAutonomi/ant-client?rev=f88c95daa003d9e5aee3c76eb67914ed1d907ccb#f88c95daa003d9e5aee3c76eb67914ed1d907ccb"
 dependencies = [
  "ant-node",
  "async-stream",
@@ -2641,7 +2641,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2944,7 +2944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4877,7 +4877,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4941,7 +4941,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5972,7 +5972,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5985,7 +5985,7 @@ dependencies = [
  "libc",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6545,7 +6545,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6613,7 +6613,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7435,7 +7435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8136,7 +8136,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8652,7 +8652,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9236,7 +9236,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -891,6 +891,8 @@ dependencies = [
  "tauri-plugin-updater",
  "tokio",
  "toml 0.8.2",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -811,7 +811,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -822,7 +822,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2641,7 +2641,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2944,7 +2944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4877,7 +4877,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4941,7 +4941,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5972,7 +5972,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5985,7 +5985,7 @@ dependencies = [
  "libc",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6545,7 +6545,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6613,7 +6613,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7435,7 +7435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8136,7 +8136,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8652,7 +8652,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9236,7 +9236,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,8 @@ futures-util = "0.3"
 dirs = "5"
 toml = "0.8"
 tauri-plugin-updater = "2"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ant-core = { git = "https://github.com/WithAutonomi/ant-client", tag = "ant-cli-v0.1.2" }
 evmlib = "0.8"
 hex = "0.4"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,11 @@ toml = "0.8"
 tauri-plugin-updater = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-ant-core = { git = "https://github.com/WithAutonomi/ant-client", tag = "ant-cli-v0.1.2" }
+# Pinned to the merge commit of WithAutonomi/ant-client#40 (allow_loopback
+# fix). Repoint to the next `ant-cli-vX.Y.Z` tag once it ships — the fix
+# can't go into the v0.1.2 tag because that's what the deployed daemon
+# uses and we don't want drift.
+ant-core = { git = "https://github.com/WithAutonomi/ant-client", rev = "f88c95daa003d9e5aee3c76eb67914ed1d907ccb" }
 evmlib = "0.8"
 hex = "0.4"
 sha2 = "0.10"

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -82,15 +82,27 @@ pub struct InitArgs {
     pub evm_vault_address: Option<String>,
 }
 
-/// Per-attempt timeout for `Client::connect`.
-const CONNECT_ATTEMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// Per-attempt timeout for building + starting the embedded P2P node.
+///
+/// `P2PNode::start()` blocks until the saorsa-core bootstrap loop has
+/// processed every configured peer. That loop is sequential (one `.await`
+/// per peer — see saorsa-core `network.rs` ~line 2022), with a 15s
+/// identity-exchange timeout per unresponsive peer. With 7 bundled
+/// bootstrap peers and realistic network conditions (2-3 unresponsive or
+/// firewalled at any given time) the loop commonly takes 90-180s on a
+/// cold start. `ant-cli` has no timeout on this phase and relies on its
+/// spinner for progress; we give ourselves 240s, which covers the worst
+/// case we've observed without letting a genuine failure wedge the UI.
+const CONNECT_ATTEMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(240);
 /// Maximum number of connect attempts before giving up.
-const CONNECT_MAX_ATTEMPTS: u32 = 3;
+///
+/// Two attempts is enough in practice: if a 4-minute attempt fails, the
+/// bootstrap peer list or the local network is actually broken, not
+/// transiently slow. A second attempt is a cheap hedge; a third just
+/// keeps the user staring at a spinner.
+const CONNECT_MAX_ATTEMPTS: u32 = 2;
 /// Backoff schedule between attempts (length must be ≥ CONNECT_MAX_ATTEMPTS - 1).
-const CONNECT_BACKOFFS: [std::time::Duration; 2] = [
-    std::time::Duration::from_secs(5),
-    std::time::Duration::from_secs(10),
-];
+const CONNECT_BACKOFFS: [std::time::Duration; 1] = [std::time::Duration::from_secs(5)];
 
 /// Pending uploads older than this are garbage-collected.
 const PENDING_UPLOAD_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
@@ -265,8 +277,10 @@ async fn run_connection_loop(app: AppHandle, args: InitArgs) {
         };
         match tokio::time::timeout(CONNECT_ATTEMPT_TIMEOUT, Client::connect(&peers, config)).await {
             Ok(Ok(client)) => {
+                let peer_count = client.network().connected_peers().await.len();
                 let client = client.with_evm_network(evm_network.clone());
                 *app.state::<AutonomiState>().client.write().await = Some(client);
+                eprintln!("Autonomi connect attempt {attempt} succeeded ({peer_count} peers)");
                 set_connection_status(&app, ConnectionStatus::Connected).await;
                 return;
             }

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -49,10 +49,48 @@ fn load_bundled_bootstrap_peers(app: &AppHandle) -> Result<Vec<std::net::SocketA
 
 // ── Shared state managed by Tauri ──
 
+/// State of the embedded ant-core client connection. Mirrored to the frontend
+/// via `connection-status` events so the UI can show progress / retry buttons.
+#[derive(Serialize, Clone, Debug)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum ConnectionStatus {
+    /// No connect attempt has run yet (initial state on app start).
+    Idle,
+    /// A connect attempt is in flight.
+    Connecting { attempt: u32, of: u32 },
+    /// Successfully connected to the network.
+    Connected,
+    /// All retries exhausted. `reason` is the error from the last attempt.
+    Failed { reason: String, attempts: u32 },
+}
+
 pub struct AutonomiState {
     pub client: RwLock<Option<Client>>,
     pub pending_uploads: RwLock<HashMap<String, (PreparedUpload, std::time::Instant)>>,
+    pub connection_status: RwLock<ConnectionStatus>,
+    /// Holds the last set of args used for `init_autonomi_client`, so a manual
+    /// `retry_autonomi_client` can re-run with the same configuration.
+    pub last_init_args: RwLock<Option<InitArgs>>,
 }
+
+/// Captured arguments from the most recent `init_autonomi_client` call.
+#[derive(Clone)]
+pub struct InitArgs {
+    pub bootstrap_peers: Option<Vec<String>>,
+    pub evm_rpc_url: Option<String>,
+    pub evm_token_address: Option<String>,
+    pub evm_vault_address: Option<String>,
+}
+
+/// Per-attempt timeout for `Client::connect`.
+const CONNECT_ATTEMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// Maximum number of connect attempts before giving up.
+const CONNECT_MAX_ATTEMPTS: u32 = 3;
+/// Backoff schedule between attempts (length must be ≥ CONNECT_MAX_ATTEMPTS - 1).
+const CONNECT_BACKOFFS: [std::time::Duration; 2] = [
+    std::time::Duration::from_secs(5),
+    std::time::Duration::from_secs(10),
+];
 
 /// Pending uploads older than this are garbage-collected.
 const PENDING_UPLOAD_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
@@ -62,6 +100,8 @@ impl AutonomiState {
         Self {
             client: RwLock::new(None),
             pending_uploads: RwLock::new(HashMap::new()),
+            connection_status: RwLock::new(ConnectionStatus::Idle),
+            last_init_args: RwLock::new(None),
         }
     }
 
@@ -127,15 +167,138 @@ pub struct StartUploadRequest {
 
 // ── Tauri commands ──
 
-/// Initialize the data client. Connects to the Autonomi network via bootstrap peers.
-///
-/// `bootstrap_peers` overrides the bundled list (used by the devnet path).
-/// When `bootstrap_peers` is `None` or empty, falls back to
-/// `resources/bootstrap_peers.toml` shipped with the app — this is the
-/// production-mainnet path.
-///
-/// When `evm_rpc_url` is provided, uses a custom EVM network (for devnet/testnet).
-/// Otherwise defaults to Arbitrum One.
+/// Update the connection status and emit a `connection-status` event for the
+/// frontend. Always call this rather than mutating `connection_status` directly
+/// so the UI stays in sync.
+async fn set_connection_status(app: &AppHandle, new_status: ConnectionStatus) {
+    let state = app.state::<AutonomiState>();
+    *state.connection_status.write().await = new_status.clone();
+    if let Err(e) = app.emit("connection-status", &new_status) {
+        eprintln!("Failed to emit connection-status event: {e}");
+    }
+}
+
+/// Background task: try `Client::connect` up to `CONNECT_MAX_ATTEMPTS` times
+/// with a per-attempt timeout and backoff between attempts. Each transition is
+/// emitted to the frontend via `set_connection_status`. Returns silently — the
+/// frontend learns the outcome through events / `get_connection_status`.
+async fn run_connection_loop(app: AppHandle, args: InitArgs) {
+    let peers: Vec<std::net::SocketAddr> = match &args.bootstrap_peers {
+        Some(list) if !list.is_empty() => list.iter().filter_map(|s| s.parse().ok()).collect(),
+        _ => match load_bundled_bootstrap_peers(&app) {
+            Ok(peers) => peers,
+            Err(e) => {
+                set_connection_status(
+                    &app,
+                    ConnectionStatus::Failed {
+                        reason: format!("Could not load bootstrap peers: {e}"),
+                        attempts: 0,
+                    },
+                )
+                .await;
+                return;
+            }
+        },
+    };
+
+    if peers.is_empty() {
+        set_connection_status(
+            &app,
+            ConnectionStatus::Failed {
+                reason: "No bootstrap peers available".into(),
+                attempts: 0,
+            },
+        )
+        .await;
+        return;
+    }
+
+    let evm_network = if let Some(rpc_url) = &args.evm_rpc_url {
+        let Some(token) = &args.evm_token_address else {
+            set_connection_status(
+                &app,
+                ConnectionStatus::Failed {
+                    reason: "evm_token_address required with evm_rpc_url".into(),
+                    attempts: 0,
+                },
+            )
+            .await;
+            return;
+        };
+        let Some(vault) = &args.evm_vault_address else {
+            set_connection_status(
+                &app,
+                ConnectionStatus::Failed {
+                    reason: "evm_vault_address required with evm_rpc_url".into(),
+                    attempts: 0,
+                },
+            )
+            .await;
+            return;
+        };
+        EvmNetwork::Custom(CustomNetwork::new(rpc_url, token, vault))
+    } else {
+        EvmNetwork::ArbitrumOne
+    };
+
+    let mut last_error = String::new();
+    for attempt in 1..=CONNECT_MAX_ATTEMPTS {
+        set_connection_status(
+            &app,
+            ConnectionStatus::Connecting {
+                attempt,
+                of: CONNECT_MAX_ATTEMPTS,
+            },
+        )
+        .await;
+
+        let config = ClientConfig::default();
+        match tokio::time::timeout(CONNECT_ATTEMPT_TIMEOUT, Client::connect(&peers, config)).await {
+            Ok(Ok(client)) => {
+                let client = client.with_evm_network(evm_network.clone());
+                *app.state::<AutonomiState>().client.write().await = Some(client);
+                set_connection_status(&app, ConnectionStatus::Connected).await;
+                return;
+            }
+            Ok(Err(e)) => {
+                last_error = format!("connect failed: {e}");
+                eprintln!("Autonomi connect attempt {attempt} failed: {e}");
+            }
+            Err(_) => {
+                last_error = format!(
+                    "connect timed out after {}s",
+                    CONNECT_ATTEMPT_TIMEOUT.as_secs()
+                );
+                eprintln!("Autonomi connect attempt {attempt} timed out");
+            }
+        }
+
+        if attempt < CONNECT_MAX_ATTEMPTS {
+            let backoff = CONNECT_BACKOFFS
+                .get((attempt - 1) as usize)
+                .copied()
+                .unwrap_or(std::time::Duration::from_secs(20));
+            tokio::time::sleep(backoff).await;
+        }
+    }
+
+    set_connection_status(
+        &app,
+        ConnectionStatus::Failed {
+            reason: last_error,
+            attempts: CONNECT_MAX_ATTEMPTS,
+        },
+    )
+    .await;
+}
+
+/// Spawn the connection loop if no client is already set. Returns immediately —
+/// the actual connect runs in the background and reports state via
+/// `connection-status` events. `bootstrap_peers` overrides the bundled list
+/// (devnet path); when None/empty, falls back to the bundled
+/// `resources/bootstrap_peers.toml`. `evm_rpc_url`/`evm_token_address`/
+/// `evm_vault_address` together select a custom EVM network; otherwise the
+/// client uses Arbitrum One.
 #[tauri::command]
 pub async fn init_autonomi_client(
     app: AppHandle,
@@ -145,39 +308,68 @@ pub async fn init_autonomi_client(
     evm_token_address: Option<String>,
     evm_vault_address: Option<String>,
 ) -> Result<bool, String> {
-    let mut client_lock = state.client.write().await;
-    if client_lock.is_some() {
+    if state.client.read().await.is_some() {
         return Ok(true);
     }
-
-    let peers: Vec<std::net::SocketAddr> = match bootstrap_peers {
-        Some(list) if !list.is_empty() => list.iter().filter_map(|s| s.parse().ok()).collect(),
-        _ => load_bundled_bootstrap_peers(&app)?,
-    };
-
-    if peers.is_empty() {
-        return Err(
-            "No bootstrap peers available (overrides empty and bundled list invalid)".into(),
-        );
+    // Don't start a second loop if one is already in flight.
+    if matches!(
+        *state.connection_status.read().await,
+        ConnectionStatus::Connecting { .. }
+    ) {
+        return Ok(false);
     }
 
-    let config = ClientConfig::default();
-    let client = Client::connect(&peers, config)
-        .await
-        .map_err(|e| format!("Failed to connect to Autonomi network: {e}"))?;
-
-    let evm_network = if let Some(rpc_url) = evm_rpc_url {
-        let token = evm_token_address.ok_or("evm_token_address required with evm_rpc_url")?;
-        let vault = evm_vault_address.ok_or("evm_vault_address required with evm_rpc_url")?;
-        EvmNetwork::Custom(CustomNetwork::new(&rpc_url, &token, &vault))
-    } else {
-        EvmNetwork::ArbitrumOne
+    let args = InitArgs {
+        bootstrap_peers,
+        evm_rpc_url,
+        evm_token_address,
+        evm_vault_address,
     };
+    *state.last_init_args.write().await = Some(args.clone());
 
-    let client = client.with_evm_network(evm_network);
+    let app_for_task = app.clone();
+    tokio::spawn(async move { run_connection_loop(app_for_task, args).await });
 
-    *client_lock = Some(client);
-    Ok(true)
+    Ok(false)
+}
+
+/// Re-run the connection loop with the same arguments as the most recent
+/// `init_autonomi_client` call. Used by the frontend Retry button on the
+/// "could not connect" screen.
+#[tauri::command]
+pub async fn retry_autonomi_client(
+    app: AppHandle,
+    state: tauri::State<'_, AutonomiState>,
+) -> Result<(), String> {
+    if state.client.read().await.is_some() {
+        return Ok(());
+    }
+    if matches!(
+        *state.connection_status.read().await,
+        ConnectionStatus::Connecting { .. }
+    ) {
+        return Ok(());
+    }
+
+    let args = state
+        .last_init_args
+        .read()
+        .await
+        .clone()
+        .ok_or("init_autonomi_client has not been called yet")?;
+
+    let app_for_task = app.clone();
+    tokio::spawn(async move { run_connection_loop(app_for_task, args).await });
+    Ok(())
+}
+
+/// Return the current connection status. Used by the frontend on first mount
+/// to populate state; subsequent updates arrive via `connection-status` events.
+#[tauri::command]
+pub async fn get_connection_status(
+    state: tauri::State<'_, AutonomiState>,
+) -> Result<ConnectionStatus, String> {
+    Ok(state.connection_status.read().await.clone())
 }
 
 /// Start an upload: encrypts file, collects quotes, emits quote event

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -241,6 +241,13 @@ async fn run_connection_loop(app: AppHandle, args: InitArgs) {
         EvmNetwork::ArbitrumOne
     };
 
+    // Devnet (custom EVM RPC) runs on loopback — opt the saorsa-transport
+    // `local` flag in for that case only. Production peers reject the
+    // loopback handshake variant, so the default of `false` is correct
+    // for mainnet uploads. Matches the `--allow-loopback` semantics in
+    // ant-cli (see WithAutonomi/ant-client#40).
+    let allow_loopback = args.evm_rpc_url.is_some();
+
     let mut last_error = String::new();
     for attempt in 1..=CONNECT_MAX_ATTEMPTS {
         set_connection_status(
@@ -252,7 +259,10 @@ async fn run_connection_loop(app: AppHandle, args: InitArgs) {
         )
         .await;
 
-        let config = ClientConfig::default();
+        let config = ClientConfig {
+            allow_loopback,
+            ..ClientConfig::default()
+        };
         match tokio::time::timeout(CONNECT_ATTEMPT_TIMEOUT, Client::connect(&peers, config)).await {
             Ok(Ok(client)) => {
                 let client = client.with_evm_network(evm_network.clone());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -553,6 +553,23 @@ fn save_upload_history(entries: Vec<UploadHistoryEntry>) -> Result<(), String> {
 }
 
 pub fn run() {
+    // Pipe ant-core / ant-node tracing events to stderr so the dev console
+    // surfaces upload progress (encrypt → quote → store → finalize). Without
+    // a subscriber installed every `tracing::info!()` from those crates is
+    // silently dropped, which makes long-running operations look hung.
+    //
+    // Filter defaults are conservative — `ant_core=info` is the sweet spot
+    // for upload visibility; `ant_node=warn` keeps peer-discovery noise low.
+    // Override at runtime with the standard `RUST_LOG` env var, e.g.
+    // `RUST_LOG=ant_core=debug,ant_node=info` for deeper investigation.
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("ant_core=info,ant_node=warn,ant_gui=info,warn"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .with_writer(std::io::stderr)
+        .try_init();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -584,6 +584,8 @@ pub fn run() {
             autonomi_ops::confirm_upload_merkle,
             autonomi_ops::download_file,
             autonomi_ops::is_autonomi_connected,
+            autonomi_ops::retry_autonomi_client,
+            autonomi_ops::get_connection_status,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -562,8 +562,9 @@ pub fn run() {
     // for upload visibility; `ant_node=warn` keeps peer-discovery noise low.
     // Override at runtime with the standard `RUST_LOG` env var, e.g.
     // `RUST_LOG=ant_core=debug,ant_node=info` for deeper investigation.
-    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("ant_core=info,ant_node=warn,ant_gui=info,warn"));
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        tracing_subscriber::EnvFilter::new("ant_core=info,ant_node=warn,ant_gui=info,warn")
+    });
     let _ = tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_target(true)

--- a/stores/connection.ts
+++ b/stores/connection.ts
@@ -1,0 +1,61 @@
+import { defineStore } from 'pinia'
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
+
+/**
+ * Discriminated union mirroring the Rust ConnectionStatus enum.
+ * `status` is the tag; the rest of the fields depend on the variant.
+ */
+export type ConnectionStatus =
+  | { status: 'idle' }
+  | { status: 'connecting'; attempt: number; of: number }
+  | { status: 'connected' }
+  | { status: 'failed'; reason: string; attempts: number }
+
+export const useConnectionStore = defineStore('connection', {
+  state: () => ({
+    current: { status: 'idle' } as ConnectionStatus,
+    /** Whether the SSE-style listener has been installed. */
+    listening: false,
+  }),
+
+  getters: {
+    isConnected: (state) => state.current.status === 'connected',
+    isConnecting: (state) => state.current.status === 'connecting',
+    hasFailed: (state) => state.current.status === 'failed',
+  },
+
+  actions: {
+    /**
+     * Start listening for `connection-status` events from the backend and
+     * fetch the current status once. Idempotent — safe to call from multiple
+     * places at app start.
+     */
+    async startListening() {
+      if (this.listening) return
+      this.listening = true
+
+      try {
+        this.current = await invoke<ConnectionStatus>('get_connection_status')
+      } catch (e) {
+        console.warn('get_connection_status failed:', e)
+      }
+
+      await listen<ConnectionStatus>('connection-status', (event) => {
+        this.current = event.payload
+      })
+    },
+
+    /**
+     * Manually re-trigger the connection loop. Used by the Retry button on
+     * the upload dialog when the previous attempts failed.
+     */
+    async retry() {
+      try {
+        await invoke('retry_autonomi_client')
+      } catch (e) {
+        console.error('retry_autonomi_client failed:', e)
+      }
+    },
+  },
+})

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -200,16 +200,36 @@ export const useFilesStore = defineStore('files', {
     async getUploadQuote(path: string): Promise<UploadQuote | null> {
       const uploadId = `quote-${Date.now()}-${Math.random().toString(36).slice(2)}`
 
+      // Deferred so we can resolve/reject from the listener and the timeout
+      // independently of where the Promise is awaited.
+      let resolveQuote: (value: any) => void = () => {}
+      let rejectQuote: (err: Error) => void = () => {}
+      const quotePromise = new Promise<any>((resolve, reject) => {
+        resolveQuote = resolve
+        rejectQuote = reject
+      })
+
+      let unlisten: (() => void) | null = null
+      // The 120s timeout is registered AFTER listen() is awaited below — see
+      // explanation there. Holding the handle here so finally{} can clear it.
+      let timeoutId: ReturnType<typeof setTimeout> | null = null
+
       try {
-        const quotePromise = new Promise<any>((resolve, reject) => {
-          const timeout = setTimeout(() => reject(new Error('Quote timeout')), 120_000)
-          listen<any>('upload-quote', (event) => {
-            if (event.payload.upload_id === uploadId) {
-              clearTimeout(timeout)
-              resolve(event.payload)
-            }
-          })
+        // Register the listener BEFORE invoking start_upload. The previous
+        // implementation called listen() inside a `new Promise(...)` executor
+        // without awaiting it, then immediately did `await invoke(...)`. The
+        // backend can emit `upload-quote` before listen() finishes registering,
+        // in which case the event is missed and the 120s timeout eventually
+        // fires — visible in the dev console as "Uncaught (in promise) Error:
+        // Quote timeout". Awaiting listen() first eliminates the race and
+        // capturing `unlisten` lets us clean up so listeners do not pile up.
+        unlisten = await listen<any>('upload-quote', (event) => {
+          if (event.payload.upload_id === uploadId) {
+            resolveQuote(event.payload)
+          }
         })
+
+        timeoutId = setTimeout(() => rejectQuote(new Error('Quote timeout')), 120_000)
 
         await invoke('start_upload', {
           request: { files: [path], upload_id: uploadId },
@@ -227,8 +247,16 @@ export const useFilesStore = defineStore('files', {
           merkle_pool_commitments: quote.merkle_pool_commitments,
           merkle_timestamp: quote.merkle_timestamp,
         }
-      } catch {
+      } catch (err) {
+        // Settle the deferred so any later listener firing does not surface
+        // as an unhandled rejection; we already returned null to the caller.
+        rejectQuote(err instanceof Error ? err : new Error(String(err)))
+        // Swallow our own rejection so the deferred has a handler.
+        quotePromise.catch(() => {})
         return null
+      } finally {
+        if (timeoutId) clearTimeout(timeoutId)
+        if (unlisten) unlisten()
       }
     },
 


### PR DESCRIPTION
## Summary

Bundle of fixes found during v0.6.1 mainnet testing. All changes are `ant-ui` only — no upstream (`ant-core` / `ant-node` / `evmlib`) source changes beyond a dep-rev bump to pick up the already-merged `allow_loopback` opt-in.

### 1. No real timeout/retry on the embedded ant-core connect
`Client::connect` had no per-attempt timeout — a slow or NAT-restricted bootstrap could leave `init_autonomi_client` hanging indefinitely. The 15s "Could not connect" message in the upload dialog was a *cosmetic* dialog timeout, not a real connection budget.

- New `ConnectionStatus` enum (`Idle | Connecting{attempt,of} | Connected | Failed{reason,attempts}`) stored in `AutonomiState` and emitted via `connection-status` events.
- `init_autonomi_client` returns immediately and spawns a background task that wraps `Client::connect` in a per-attempt timeout and retries with backoff.
- New Tauri commands `get_connection_status` and `retry_autonomi_client`.
- Dialog shows "Connecting (attempt N of M)..." while in flight and a Retry button on Failed.

### 2. Connect timeout was 30s but bootstrap takes ~100-200s
After #1 shipped, the 30s per-attempt timeout was still too tight. saorsa-core's bootstrap loop (`network.rs` ~line 2022) is **sequential** — one `.await` per peer with a 15s identity-exchange timeout. With 7 bundled peers and 2-3 typically unresponsive, cold-start commonly runs 90-180s. Every retry was clipping bootstrap *while 70+ DHT peers were actively connecting*.

- Raise per-attempt timeout to **240s** (ant-cli has none at all; this covers worst-case without wedging the UI on real failures).
- Drop max attempts 3 → 2 (a 4-minute attempt's failure isn't transiently slow; a second try is a cheap hedge, a third is just a longer spinner).
- Log final peer count on success so tracing mirrors ant-cli's "Connected to autonomi network (found N peers)".

### 3. Upload dialog stuck on "Cost will be quoted from the network when upload starts"
`pages/files.vue` gated `startQuoting` on `autonomiConnected.value` *at the moment the dialog opens*. On a fresh launch — where the embedded client hasn't bootstrapped yet — the dialog fell back to the misleading message and never re-quoted.

- New `stores/connection.ts` Pinia store subscribes to the events from #1.
- Replaces the local `autonomiConnected` ref + one-shot `is_autonomi_connected` poll.
- Added watcher: when the connection store flips to `connected` while the dialog is still open with no quote, `startQuoting` runs.

### 4. Upload-quote listener race
`getUploadQuote` registered its event listener inside a `new Promise(...)` executor without awaiting `listen()`, so `await invoke('start_upload')` could fire the emit before the listener registered. Moved to a deferred resolve/reject pattern, `await listen()` first, cleanup in `finally`.

### 5. ant-core bump for `allow_loopback` opt-in
Pinned rev was forcing `local=true` in the saorsa-transport handshake — production peers reject that handshake variant, so public-network connects silently failed. Upstream PR #40 (merged) made `allow_loopback` a `ClientConfig` opt-in defaulting to `false`.

- Bump `ant-core` rev in `src-tauri/Cargo.toml` to the PR #40 merge commit.
- Backend now sets `allow_loopback = args.evm_rpc_url.is_some()` — only true for devnet / local EVM RPC.

### 6. Refresh Balances flickered as wallet disconnect
`pages/wallet.vue:158` called `useWallet()` just to grab `refreshBalances`, and `useWallet()` re-installed an AppKit `watch(..., { immediate: true })`. The immediate firing read `connected` while AppKit's account state was momentarily `undefined` → the else branch nulled `walletStore.connected` and the balance fields → UI flashed "disconnected" before the next tick re-set everything.

- Hoist `refreshBalances` to a module-level export.
- Module-level `syncStarted` guard makes `useWallet()` idempotent.
- `pages/wallet.vue` calls `refreshBalances()` directly — no re-watch.

### 7. MetaMask "Browser" platform tab still shown
PR #14 disabled `enableInjected`/`enableEIP6963` (the connector card at the top of the modal). The "Browser" option *inside* the MetaMask per-wallet connect view is a different surface — computed from `rdns`/`injected_id` + `checkInstalled(window.ethereum)`, gated on `OptionsController.state.isUniversalProvider !== true`.

- `plugins/appkit.client.ts` calls `OptionsController.setIsUniversalProvider(true)` after `createAppKit`. AppKit doesn't expose this on the public options type (lives in `OptionsControllerStateInternal`), but it's the same setter the SDK uses internally.

### 8. Misc quality-of-life
- `lib.rs`: init `tracing-subscriber` so `ant-core` / `ant-node` events reach stderr — without a subscriber every `tracing::info!` from those crates was silently dropped, making long operations look hung. Default filter `ant_core=info,ant_node=warn,ant_gui=info,warn`, overridable via `RUST_LOG`.
- `nuxt.config.ts`: `vite.build.modulePreload: false` — silences preload warnings Vite emits for async chunks Tauri already has in-memory.

## Commits

- `cd6932b` fix: connection retry loop, wallet refresh flicker, MM Browser tab
- `bbefd5d` fix(files): register upload-quote listener before invoking start_upload
- `e0a0fec` feat(files): real network quotes in Estimate Cost dialog
- `cc16820` chore(build): disable Vite modulePreload to silence preload warnings
- `e79d785` chore(backend): init tracing-subscriber to surface ant-core logs
- `dd90091` fix(autonomi): bump ant-core for allow_loopback; opt in only for devnet
- `5d03d31` fix(autonomi): bump connect timeout past the bootstrap loop

## Test plan

- [x] \`cargo check --manifest-path src-tauri/Cargo.toml --all-features\` passes
- [ ] \`cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings\` clean (CI)
- [x] \`cargo fmt --check\` clean
- [ ] \`npx nuxi typecheck\` — no new errors (CI)
- [ ] \`npm run test:run\` (CI)
- [x] Manual: fresh dev launch connects in ~100-220s with verbose logging, UI flips from Connecting → Connected at 72-85 peers
- [x] Manual: reverts of mid-session diagnostics (CLI-bypass, dedicated 4-worker runtime) retested — default \`Client::connect\` + Tauri runtime works fine once the 240s timeout covers the bootstrap window

🤖 Generated with [Claude Code](https://claude.com/claude-code)