### PR TITLE
chore: bump version to 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump for release.

Contains the fixes from #16:
- Connect timeout bumped to 240s so saorsa-core's sequential bootstrap loop can finish before the UI gives up
- ant-core rev bumped to pick up the `allow_loopback` opt-in (production peers previously rejected the handshake)
- Real network quote in the Estimate Cost dialog
- Upload-quote listener race fix
- Wallet refresh flicker fix
- MetaMask "Browser" tab removed from the per-wallet view
- Misc: tracing-subscriber init, Vite modulePreload disabled

Tag `v0.6.2` will be pushed after merge to kick off the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)