### PR TITLE
chore: bump version to 0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump for release.

Contains the fixes from #18:
- IPv4-only embedded connect (workaround for upstream `Network::new` hardcoding `ipv6(true)` — measured cold-start 218s → 100s; verified 187s with 78 peers on today's live network)
- `ant-core` rev bumped from `f88c95d` to `eb29e99` (current ant-client main — v0.1.3/v0.1.4 ant-cli releases + per-chunk verbose progress)
- Estimate Cost dialog: dropped heuristic fallback, always fetches real quotes (retries connection if offline; toast + bail with Indelible backend)

Tag `v0.6.3` will be pushed after merge to kick off the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)