### PR TITLE
fix: revert v0.6.3 (restore working v0.6.2 behaviour)

### DIFF
--- a/components/files/CostEstimateDialog.vue
+++ b/components/files/CostEstimateDialog.vue
@@ -20,14 +20,27 @@
           >
             <span class="max-w-[200px] truncate">{{ file.name }}</span>
             <div class="text-right">
-              <span v-if="file.size" class="text-autonomi-muted">{{ formatBytes(file.size) }}</span>
-              <span v-if="file.cost" class="ml-2 text-autonomi-blue">{{ file.cost }}</span>
+              <span v-if="file.size" class="text-autonomi-muted">{{ file.size ? formatBytes(file.size) : '-' }}</span>
+              <span class="ml-2 text-autonomi-blue">
+                {{ file.cost ? file.cost : `~${estimateCost(file.size)} ANT` }}
+              </span>
               <span v-if="file.gas_cost" class="ml-1 text-autonomi-muted">+ {{ file.gas_cost }} gas</span>
             </div>
           </div>
 
+          <div v-if="!hasRealCosts" class="border-t border-autonomi-border pt-3">
+            <div class="flex items-center justify-between text-sm font-medium">
+              <span>Total</span>
+              <div>
+                <span class="text-autonomi-muted">{{ totalSize ? formatBytes(totalSize) : '-' }}</span>
+                <span class="ml-2 text-autonomi-blue">~{{ estimateCost(totalSize) }} ANT</span>
+              </div>
+            </div>
+          </div>
+
           <p class="text-xs text-autonomi-muted">
-            Costs queried from the Autonomi network. Gas fees (ETH) apply on top of storage costs.
+            {{ hasRealCosts ? 'Costs queried from the Autonomi network.' : 'Estimates are approximate and may vary based on network conditions.' }}
+            Gas fees (ETH) apply on top of storage costs.
           </p>
         </div>
 
@@ -51,11 +64,20 @@
 <script setup lang="ts">
 import { formatBytes } from '~/utils/formatters'
 
-defineProps<{
+const props = defineProps<{
   open: boolean
   files: { name: string; size: number; cost?: string; gas_cost?: string }[]
   loading: boolean
 }>()
 
 defineEmits<{ close: [] }>()
+
+const totalSize = computed(() => props.files.reduce((sum, f) => sum + f.size, 0))
+const hasRealCosts = computed(() => props.files.some(f => f.cost))
+
+/** Rough client-side estimate — real cost is determined by network quotes during upload. */
+function estimateCost(bytes: number) {
+  return (bytes / 1_048_576 * 0.05).toFixed(4)
+}
+
 </script>

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -480,31 +480,27 @@ async function estimateCost() {
 
     const paths = Array.isArray(selected) ? selected : [selected]
     const pathStrings = paths.map(p => String(p))
-
-    // Indelible prices uploads server-side, so the embedded ant-core has
-    // nothing to quote against. There's no heuristic fallback anymore —
-    // tell the user up front rather than open an empty dialog.
-    if (settingsStore.indelibleConnected && !settingsStore.devnetActive) {
-      toastStore.add('Cost estimation requires the Autonomi backend', 'warning')
-      return
-    }
-
     costLoading.value = true
     costFiles.value = []
     showCostDialog.value = true
 
     const metas = await getFileMetas(pathStrings)
     costMetas.value = metas
+    // Show sizes immediately; the dialog falls back to the heuristic estimate
+    // per file until real costs land below.
     costFiles.value = metas.map(m => ({ name: m.name, size: m.size }))
+    costLoading.value = false
 
+    // Skip network quoting when Indelible is the active backend — Indelible
+    // prices uploads server-side, so the embedded ant-core has nothing to
+    // quote against.
+    if (settingsStore.indelibleConnected && !settingsStore.devnetActive) return
+
+    // If the embedded client is connected (or devnet override is active),
+    // fire real quotes now. Otherwise the watcher below picks up the case
+    // where the connection completes after the dialog opened.
     if (autonomiConnected.value || settingsStore.devnetActive) {
-      await runCostEstimateQuotes(metas)
-      costLoading.value = false
-    } else {
-      // Kick off a connection attempt; the watcher below runs the quotes
-      // once the connection lands and clears loading then. Dialog stays
-      // in its loading state until real costs arrive.
-      invoke('retry_autonomi_client').catch(() => {})
+      runCostEstimateQuotes(metas)
     }
   } catch (err) {
     showCostDialog.value = false
@@ -536,20 +532,19 @@ async function runCostEstimateQuotes(metas: FileMeta[]) {
   }
 }
 
-// If estimateCost() opened the dialog before the embedded client was
-// connected, invoke('retry_autonomi_client') is in flight; this watcher
-// fires the real quotes once the connection lands and clears loading.
+// Same watch+retry pattern as the upload-confirm dialog: if the estimate
+// dialog is open with sizes only and the network later becomes available,
+// run the quotes then so the user doesn't have to close and reopen.
 watch(
   () => autonomiConnected.value,
-  async (connected) => {
+  (connected) => {
     if (!connected) return
     if (!showCostDialog.value) return
     if (settingsStore.indelibleConnected && !settingsStore.devnetActive) return
     if (costEstimateQuoting.value) return
     if (costMetas.value.length === 0) return
     if (costFiles.value.every(f => f.cost)) return
-    await runCostEstimateQuotes(costMetas.value)
-    costLoading.value = false
+    runCostEstimateQuotes(costMetas.value)
   },
 )
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 [[package]]
 name = "ant-core"
 version = "0.1.1"
-source = "git+https://github.com/WithAutonomi/ant-client?rev=eb29e99937b1aedba02db04e1ae59bd923b424a3#eb29e99937b1aedba02db04e1ae59bd923b424a3"
+source = "git+https://github.com/WithAutonomi/ant-client?rev=f88c95daa003d9e5aee3c76eb67914ed1d907ccb#f88c95daa003d9e5aee3c76eb67914ed1d907ccb"
 dependencies = [
  "ant-node",
  "async-stream",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,10 +25,11 @@ toml = "0.8"
 tauri-plugin-updater = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-# Pinned to the head of WithAutonomi/ant-client main at the time of v0.6.3
-# (includes the allow_loopback fix, per-chunk progress bars, and ant-cli
-# v0.1.4 release). Repoint to an `ant-cli-vX.Y.Z` tag once those resume.
-ant-core = { git = "https://github.com/WithAutonomi/ant-client", rev = "eb29e99937b1aedba02db04e1ae59bd923b424a3" }
+# Pinned to the merge commit of WithAutonomi/ant-client#40 (allow_loopback
+# fix). Repoint to the next `ant-cli-vX.Y.Z` tag once it ships — the fix
+# can't go into the v0.1.2 tag because that's what the deployed daemon
+# uses and we don't want drift.
+ant-core = { git = "https://github.com/WithAutonomi/ant-client", rev = "f88c95daa003d9e5aee3c76eb67914ed1d907ccb" }
 evmlib = "0.8"
 hex = "0.4"
 sha2 = "0.10"

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -1,6 +1,5 @@
 use ant_core::data::{
-    Client, ClientConfig, CoreNodeConfig, CustomNetwork, DataMap, EvmNetwork, ExternalPaymentInfo,
-    MultiAddr, NodeMode, P2PNode, PreparedUpload, MAX_WIRE_MESSAGE_SIZE,
+    Client, ClientConfig, CustomNetwork, DataMap, EvmNetwork, ExternalPaymentInfo, PreparedUpload,
 };
 use evmlib::common::{QuoteHash, TxHash};
 use serde::{Deserialize, Serialize};
@@ -89,11 +88,11 @@ pub struct InitArgs {
 /// processed every configured peer. That loop is sequential (one `.await`
 /// per peer — see saorsa-core `network.rs` ~line 2022), with a 15s
 /// identity-exchange timeout per unresponsive peer. With 7 bundled
-/// bootstrap peers and IPv4-only sockets (see the `ipv6(false)` override
-/// in the connect loop) cold start is ~60-120s in practice. `ant-cli` has
-/// no timeout on this phase and relies on its spinner for progress; we
-/// give ourselves 240s, which covers the worst case we've observed
-/// without letting a genuine failure wedge the UI.
+/// bootstrap peers and realistic network conditions (2-3 unresponsive or
+/// firewalled at any given time) the loop commonly takes 90-180s on a
+/// cold start. `ant-cli` has no timeout on this phase and relies on its
+/// spinner for progress; we give ourselves 240s, which covers the worst
+/// case we've observed without letting a genuine failure wedge the UI.
 const CONNECT_ATTEMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(240);
 /// Maximum number of connect attempts before giving up.
 ///
@@ -272,63 +271,14 @@ async fn run_connection_loop(app: AppHandle, args: InitArgs) {
         )
         .await;
 
-        let client_config = ClientConfig {
+        let config = ClientConfig {
             allow_loopback,
             ..ClientConfig::default()
         };
-
-        // Force IPv4-only on outbound connections. Upstream `Network::new`
-        // hardcodes `ipv6(true)` (ant-client PR #33), which dual-stacks the
-        // socket and turns every peer send into a `[DUAL SEND]` that wastes
-        // ~15s per failing IPv6 leg on home networks where the ISP drops
-        // outbound v6. Measured cold-start on this machine was 100s with
-        // ipv6(false) vs 218s with ipv6(true).
-        //
-        // Temporary workaround — remove once upstream ships RFC 8305 happy
-        // eyeballs / IPv6 reachability detection so dual-stack is safe to
-        // leave on by default (see docs/ipv6-bootstrap-proposal.md in the
-        // review thread). Until then we mirror `ant-cli::create_client_node_raw`
-        // by building `CoreNodeConfig` directly and calling `Client::from_node`,
-        // bypassing `Client::connect` / `Network::new`.
-        let mut core_config = match CoreNodeConfig::builder()
-            .port(0)
-            .ipv6(false)
-            .local(allow_loopback)
-            .mode(NodeMode::Client)
-            .max_message_size(MAX_WIRE_MESSAGE_SIZE)
-            .build()
-        {
-            Ok(cfg) => cfg,
-            Err(e) => {
-                last_error = format!("core config build failed: {e}");
-                eprintln!("Autonomi connect attempt {attempt}: {last_error}");
-                if attempt < CONNECT_MAX_ATTEMPTS {
-                    let backoff = CONNECT_BACKOFFS
-                        .get((attempt - 1) as usize)
-                        .copied()
-                        .unwrap_or(std::time::Duration::from_secs(20));
-                    tokio::time::sleep(backoff).await;
-                }
-                continue;
-            }
-        };
-        core_config.bootstrap_peers = peers.iter().map(|addr| MultiAddr::quic(*addr)).collect();
-
-        let connect_fut = async move {
-            let node = P2PNode::new(core_config)
-                .await
-                .map_err(|e| format!("P2PNode::new failed: {e}"))?;
-            node.start()
-                .await
-                .map_err(|e| format!("P2PNode::start failed: {e}"))?;
-            Ok::<_, String>(std::sync::Arc::new(node))
-        };
-
-        match tokio::time::timeout(CONNECT_ATTEMPT_TIMEOUT, connect_fut).await {
-            Ok(Ok(node)) => {
-                let peer_count = node.connected_peers().await.len();
-                let client =
-                    Client::from_node(node, client_config).with_evm_network(evm_network.clone());
+        match tokio::time::timeout(CONNECT_ATTEMPT_TIMEOUT, Client::connect(&peers, config)).await {
+            Ok(Ok(client)) => {
+                let peer_count = client.network().connected_peers().await.len();
+                let client = client.with_evm_network(evm_network.clone());
                 *app.state::<AutonomiState>().client.write().await = Some(client);
                 eprintln!("Autonomi connect attempt {attempt} succeeded ({peer_count} peers)");
                 set_connection_status(&app, ConnectionStatus::Connected).await;


### PR DESCRIPTION
## Why

v0.6.3 shipped a `ipv6(false)` override that broke quote collection in the field — close-group DHT lookups return peer records with IPv4 and IPv6 multiaddrs, and IPv4-only lost the IPv6 fallback path that let dual-stack work around stale IPv4 entries. Symptom: "identity MISMATCH" warnings flooding logs, quotes never return, uploads unusable. v0.6.2 worked (slowly, 100-220s cold start).

## What this does

`git revert 9796d7a` — undoes PR #18 wholesale. Brings `main` back to exactly v0.6.2 code.

## Known regression this PR reintroduces

PR #18 also contained `605d1c5 fix(files): drop heuristic cost estimate` — an unrelated UX fix that got squashed into the same merge commit. Reverting PR #18 also reverts that. It'll be re-applied in v0.6.5 via `git show 9796d7a -- pages/files.vue components/files/CostEstimateDialog.vue`. Noted as a standalone TODO.

## What follows

Version bump to v0.6.4 in a separate PR. v0.6.4 release exists so the auto-updater flow can be exercised across the 6-7 test installs (v0.6.1 / v0.6.2 builds in the wild), since no prior version was ever actually published and this is effectively the first.

## Test plan

- [x] `cargo check` passes — revert compiles cleanly, merged with the interleaved v0.6.3 version bump without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)