### PR TITLE
chore: bump version to 0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump for release.

Contains the v0.6.2-equivalent code — PR #18's IPv4-only override caused quote collection to fail in the field (close-group DHT lookups couldn't recover from stale IPv4 entries without an IPv6 fallback). PR #20 reverted PR #18 wholesale.

v0.6.4 exists so the auto-updater can be exercised across the 6-7 internal test installs once published; no version was ever actually released publicly, so this is effectively the first live update.

The Estimate Cost heuristic drop (`605d1c5`) was squashed into PR #18 and reverted with the rest. Re-applying in v0.6.5 — tracked as a TODO.

Tag `v0.6.4` will be pushed after merge to kick off the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)