### PR TITLE
feat: network connection UX, download-by-datamap, and connect/upload simplification

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -13,6 +13,33 @@
         </span>
       </div>
 
+      <!-- Network connection indicator -->
+      <div
+        v-if="connectionStore.isConnecting"
+        class="flex items-center gap-2 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted"
+        title="Connecting to the Autonomi network"
+      >
+        <div class="h-2.5 w-2.5 animate-spin rounded-full border-2 border-yellow-500 border-t-transparent" />
+        <span>Connecting</span>
+      </div>
+      <div
+        v-else-if="connectionStore.isConnected"
+        class="flex items-center gap-2 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-text"
+        title="Connected to the Autonomi network"
+      >
+        <span class="text-autonomi-success">●</span>
+        <span>Network</span>
+      </div>
+      <button
+        v-else-if="connectionStore.hasFailed"
+        class="flex items-center gap-2 rounded-md border border-red-500/30 bg-red-500/5 px-2.5 py-1 text-xs text-red-400 hover:bg-red-500/10"
+        title="Connection failed — click to retry"
+        @click="connectionStore.retry()"
+      >
+        <span>●</span>
+        <span>Offline · Retry</span>
+      </button>
+
       <!-- Indelible indicator (replaces wallet when connected) -->
       <div
         v-if="settingsStore.indelibleConnected"
@@ -50,12 +77,14 @@ import { useNodesStore } from '~/stores/nodes'
 import { useFilesStore } from '~/stores/files'
 import { useWalletStore } from '~/stores/wallet'
 import { useSettingsStore } from '~/stores/settings'
+import { useConnectionStore } from '~/stores/connection'
 
 const route = useRoute()
 const nodesStore = useNodesStore()
 const filesStore = useFilesStore()
 const walletStore = useWalletStore()
 const settingsStore = useSettingsStore()
+const connectionStore = useConnectionStore()
 const { $appkit, $appkitReady } = useNuxtApp()
 
 function openModal() {

--- a/components/files/DatamapSaveAsDialog.vue
+++ b/components/files/DatamapSaveAsDialog.vue
@@ -1,0 +1,74 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      @click.self="$emit('close')"
+    >
+      <div role="dialog" aria-modal="true" aria-labelledby="datamap-saveas-title" class="w-[26rem] rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl">
+        <h2 id="datamap-saveas-title" class="mb-4 text-lg font-medium">Save downloaded file as</h2>
+
+        <div class="mb-4">
+          <label class="mb-1 block text-xs text-autonomi-muted">Filename</label>
+          <input
+            ref="inputEl"
+            v-model="filename"
+            type="text"
+            placeholder="myfile.dat"
+            class="w-full rounded-md border border-autonomi-border bg-autonomi-surface px-3 py-2 text-sm text-autonomi-text focus:border-autonomi-blue focus:outline-none"
+            @keyup.enter="confirm"
+            @keyup.escape="$emit('close')"
+          />
+        </div>
+
+        <div class="flex justify-end gap-2">
+          <button
+            class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
+            @click="$emit('close')"
+          >
+            Cancel
+          </button>
+          <button
+            class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+            :disabled="!valid"
+            @click="confirm"
+          >
+            Download
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  open: boolean
+  defaultName: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  confirm: [filename: string]
+}>()
+
+const inputEl = ref<HTMLInputElement | null>(null)
+const filename = ref('')
+
+const valid = computed(() => filename.value.trim().length > 0)
+
+watch(() => props.open, (val) => {
+  if (val) {
+    filename.value = props.defaultName
+    nextTick(() => {
+      inputEl.value?.focus()
+      inputEl.value?.select()
+    })
+  }
+})
+
+function confirm() {
+  if (!valid.value) return
+  emit('confirm', filename.value.trim())
+}
+</script>

--- a/components/files/DownloadByDatamapDialog.vue
+++ b/components/files/DownloadByDatamapDialog.vue
@@ -17,7 +17,7 @@
               v-for="c in candidates"
               :key="c.data_map_file"
               class="flex cursor-pointer items-center justify-between px-3 py-2 text-sm hover:bg-autonomi-surface/70"
-              @click="select(c.data_map_file)"
+              @click="select(c.data_map_file, c.name)"
             >
               <div class="min-w-0">
                 <div class="truncate text-autonomi-text">{{ c.name }}</div>
@@ -71,11 +71,11 @@ defineProps<{
 const emit = defineEmits<{
   close: []
   browse: []
-  select: [dataMapPath: string]
+  select: [dataMapPath: string, suggestedName: string]
 }>()
 
-function select(path: string) {
-  emit('select', path)
+function select(path: string, suggestedName: string) {
+  emit('select', path, suggestedName)
   emit('close')
 }
 

--- a/components/files/DownloadByDatamapDialog.vue
+++ b/components/files/DownloadByDatamapDialog.vue
@@ -1,0 +1,93 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      @click.self="$emit('close')"
+    >
+      <div role="dialog" aria-modal="true" aria-labelledby="datamap-download-title" class="w-[32rem] rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl">
+        <h2 id="datamap-download-title" class="mb-1 text-lg font-medium">Download by Datamap</h2>
+        <p class="mb-4 text-xs text-autonomi-muted">
+          Pick a previous upload to re-download, or browse for a datamap file you received from elsewhere.
+        </p>
+
+        <div v-if="candidates.length" class="mb-4 max-h-72 overflow-y-auto rounded-md border border-autonomi-border">
+          <ul class="divide-y divide-autonomi-border">
+            <li
+              v-for="c in candidates"
+              :key="c.data_map_file"
+              class="flex cursor-pointer items-center justify-between px-3 py-2 text-sm hover:bg-autonomi-surface/70"
+              @click="select(c.data_map_file)"
+            >
+              <div class="min-w-0">
+                <div class="truncate text-autonomi-text">{{ c.name }}</div>
+                <div class="truncate font-mono text-[11px] text-autonomi-muted">
+                  {{ basename(c.data_map_file) }}
+                </div>
+              </div>
+              <div class="ml-3 shrink-0 text-right text-[11px] text-autonomi-muted">
+                <div>{{ c.size_bytes ? formatBytes(c.size_bytes) : '-' }}</div>
+                <div>{{ formatShortDate(c.date) }}</div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div v-else class="mb-4 rounded-md border border-dashed border-autonomi-border px-3 py-6 text-center text-xs text-autonomi-muted">
+          No previous uploads with a saved datamap yet.
+        </div>
+
+        <div class="flex items-center justify-between gap-2">
+          <button
+            class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
+            @click="$emit('browse')"
+          >
+            Browse for datamap file…
+          </button>
+          <button
+            class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
+            @click="$emit('close')"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { formatBytes } from '~/utils/formatters'
+
+defineProps<{
+  open: boolean
+  candidates: Array<{
+    name: string
+    data_map_file: string
+    date: string
+    size_bytes: number
+  }>
+}>()
+
+const emit = defineEmits<{
+  close: []
+  browse: []
+  select: [dataMapPath: string]
+}>()
+
+function select(path: string) {
+  emit('select', path)
+  emit('close')
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).pop() ?? path
+}
+
+function formatShortDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  } catch {
+    return iso
+  }
+}
+</script>

--- a/components/files/UploadConfirmDialog.vue
+++ b/components/files/UploadConfirmDialog.vue
@@ -59,16 +59,13 @@
             <template v-else-if="connectionStore.isConnecting">
               <div class="flex items-center gap-2 text-sm text-autonomi-muted">
                 <div class="h-3 w-3 animate-spin rounded-full border-2 border-yellow-500 border-t-transparent" />
-                <span>
-                  Connecting to the Autonomi network
-                  <template v-if="connectingDetails">({{ connectingDetails }})</template>...
-                </span>
+                <span>Connecting to the Autonomi network...</span>
               </div>
             </template>
             <template v-else-if="connectionStore.hasFailed">
               <div class="space-y-2">
                 <div class="text-sm text-yellow-500/80">
-                  Could not connect to the Autonomi network after {{ failedAttempts }} attempt{{ failedAttempts !== 1 ? 's' : '' }}.
+                  Could not connect to the Autonomi network.
                 </div>
                 <div v-if="failedReason" class="text-xs text-autonomi-muted break-words">
                   {{ failedReason }}
@@ -179,8 +176,8 @@ const props = defineProps<{
   quotedPaymentMode?: 'wave-batch' | 'merkle' | null
   /**
    * Kept for backward compatibility with the parent — the dialog now reads
-   * the richer connection state directly from useConnectionStore() so it can
-   * show "Connecting (attempt N of M)..." and a Retry button.
+   * the connection state directly from useConnectionStore() so it can show
+   * a Retry button when the connect fails.
    */
   networkConnected?: boolean
 }>()
@@ -204,16 +201,8 @@ const effectivePaymentMode = computed(() => {
   return estimatedChunks.value >= MERKLE_THRESHOLD ? 'merkle' : 'regular'
 })
 
-const connectingDetails = computed(() => {
-  const s = connectionStore.current
-  if (s.status !== 'connecting') return null
-  return `attempt ${s.attempt} of ${s.of}`
-})
 const failedReason = computed(() =>
   connectionStore.current.status === 'failed' ? connectionStore.current.reason : null,
-)
-const failedAttempts = computed(() =>
-  connectionStore.current.status === 'failed' ? connectionStore.current.attempts : 0,
 )
 
 watch(

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -33,76 +33,160 @@
         <span v-if="filesStore.files.length" class="text-xs text-autonomi-muted">
           {{ filesStore.files.length }} file{{ filesStore.files.length !== 1 ? 's' : '' }}
         </span>
+      </div>
+    </div>
+
+    <!-- Uploads table + drop zone -->
+    <section class="mb-6">
+      <div class="mb-2 flex items-center justify-between">
+        <h2 class="text-sm font-medium text-autonomi-text">Uploads</h2>
         <button
-          v-if="filesStore.settledFiles.some(f => f.status === 'complete' || f.status === 'failed')"
+          v-if="hasSettledUploads"
           class="text-xs text-autonomi-muted hover:text-autonomi-text"
-          @click="filesStore.clearCompleted()"
+          @click="filesStore.clearUploadHistory()"
         >
           Clear History
         </button>
       </div>
-    </div>
 
-    <!-- Unified table / drop zone -->
-    <div class="relative">
-      <!-- Drop overlay -->
-      <Transition
-        enter-active-class="transition-opacity duration-150"
-        enter-from-class="opacity-0"
-        enter-to-class="opacity-100"
-        leave-active-class="transition-opacity duration-150"
-        leave-from-class="opacity-100"
-        leave-to-class="opacity-0"
-      >
-        <div
-          v-if="dragging"
-          class="absolute inset-0 z-10 flex items-center justify-center rounded-lg border-2 border-dashed border-autonomi-blue bg-autonomi-dark/90"
+      <div class="relative">
+        <!-- Drop overlay -->
+        <Transition
+          enter-active-class="transition-opacity duration-150"
+          enter-from-class="opacity-0"
+          enter-to-class="opacity-100"
+          leave-active-class="transition-opacity duration-150"
+          leave-from-class="opacity-100"
+          leave-to-class="opacity-0"
         >
-          <div class="text-center">
-            <svg class="mx-auto mb-2 h-8 w-8 text-autonomi-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
-            </svg>
-            <p class="text-sm font-medium text-autonomi-blue">Drop files to upload</p>
+          <div
+            v-if="dragging"
+            class="absolute inset-0 z-10 flex items-center justify-center rounded-lg border-2 border-dashed border-autonomi-blue bg-autonomi-dark/90"
+          >
+            <div class="text-center">
+              <svg class="mx-auto mb-2 h-8 w-8 text-autonomi-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+              </svg>
+              <p class="text-sm font-medium text-autonomi-blue">Drop files to upload</p>
+            </div>
           </div>
-        </div>
-      </Transition>
+        </Transition>
 
-      <!-- Empty state -->
-      <div
-        v-if="sortedFiles.length === 0"
-        class="flex flex-col items-center justify-center rounded-lg border border-dashed border-autonomi-border py-20"
-      >
-        <svg class="mb-3 h-8 w-8 text-autonomi-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
-        </svg>
-        <p class="text-sm text-autonomi-muted">No files yet</p>
-        <p class="mt-1 text-xs text-autonomi-muted">Drag files here, or use the buttons above</p>
+        <div
+          v-if="sortedUploads.length === 0"
+          class="flex flex-col items-center justify-center rounded-lg border border-dashed border-autonomi-border py-16"
+        >
+          <svg class="mb-3 h-8 w-8 text-autonomi-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+          </svg>
+          <p class="text-sm text-autonomi-muted">No uploads yet</p>
+          <p class="mt-1 text-xs text-autonomi-muted">Drag files here, or use the buttons above</p>
+        </div>
+
+        <div v-else class="overflow-hidden rounded-lg border border-autonomi-border">
+          <table class="w-full text-sm">
+            <thead class="bg-autonomi-surface">
+              <tr class="text-left text-xs uppercase tracking-wider text-autonomi-muted">
+                <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('name')">
+                  Name {{ uploadSortIndicator('name') }}
+                </th>
+                <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('size_bytes')">
+                  Size {{ uploadSortIndicator('size_bytes') }}
+                </th>
+                <th class="px-4 py-2.5">Status</th>
+                <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('cost')">
+                  Cost {{ uploadSortIndicator('cost') }}
+                </th>
+                <th class="px-4 py-2.5">Address</th>
+                <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('date')">
+                  Date {{ uploadSortIndicator('date') }}
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-autonomi-border">
+              <tr
+                v-for="file in sortedUploads"
+                :key="file.id"
+                class="transition-colors"
+                :class="rowClass(file)"
+              >
+                <td class="px-4 py-2.5">{{ file.name }}</td>
+                <td class="px-4 py-2.5 text-autonomi-muted">{{ file.size_bytes ? formatBytes(file.size_bytes) : '-' }}</td>
+                <td class="px-4 py-2.5">
+                  <StatusBadge :status="statusLabel(file)" />
+                </td>
+                <td class="px-4 py-2.5 text-autonomi-muted">
+                  <span>{{ file.cost ?? '-' }}</span>
+                  <span v-if="file.gas_cost" class="block text-[10px] text-autonomi-muted/60">+ {{ file.gas_cost }} gas</span>
+                </td>
+                <td class="px-4 py-2.5">
+                  <span
+                    v-if="file.data_map_file"
+                    class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
+                    :title="`Reveal ${datamapBasename(file.data_map_file)} in its folder`"
+                    @click.stop="openFolder(file.data_map_file)"
+                  >
+                    {{ datamapBasename(file.data_map_file) }}
+                  </span>
+                  <span
+                    v-else-if="file.address"
+                    class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
+                    @click.stop="copyAddress(file.address)"
+                  >
+                    {{ truncateAddress(file.address, 8, 6) }}
+                  </span>
+                  <span v-else class="text-autonomi-muted">-</span>
+                </td>
+                <td class="px-4 py-2.5 text-autonomi-muted">{{ formatDate(file.date) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <!-- Downloads table -->
+    <section>
+      <div class="mb-2 flex items-center justify-between">
+        <h2 class="text-sm font-medium text-autonomi-text">Downloads</h2>
+        <button
+          v-if="hasSettledDownloads"
+          class="text-xs text-autonomi-muted hover:text-autonomi-text"
+          @click="filesStore.clearDownloads()"
+        >
+          Clear
+        </button>
       </div>
 
-      <!-- File table -->
+      <div
+        v-if="sortedDownloads.length === 0"
+        class="flex flex-col items-center justify-center rounded-lg border border-dashed border-autonomi-border py-12"
+      >
+        <p class="text-sm text-autonomi-muted">No downloads yet</p>
+        <p class="mt-1 text-xs text-autonomi-muted">Use "Download by Address" or "Download by Datamap"</p>
+      </div>
+
       <div v-else class="overflow-hidden rounded-lg border border-autonomi-border">
         <table class="w-full text-sm">
           <thead class="bg-autonomi-surface">
             <tr class="text-left text-xs uppercase tracking-wider text-autonomi-muted">
-              <th class="px-4 py-2.5 cursor-pointer hover:text-autonomi-text" @click="toggleSort('name')">
-                Name {{ sortIndicator('name') }}
+              <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleDownloadSort('name')">
+                Name {{ downloadSortIndicator('name') }}
               </th>
-              <th class="px-4 py-2.5 cursor-pointer hover:text-autonomi-text" @click="toggleSort('size_bytes')">
-                Size {{ sortIndicator('size_bytes') }}
+              <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleDownloadSort('size_bytes')">
+                Size {{ downloadSortIndicator('size_bytes') }}
               </th>
               <th class="px-4 py-2.5">Status</th>
-              <th class="px-4 py-2.5 cursor-pointer hover:text-autonomi-text" @click="toggleSort('cost')">
-                Cost {{ sortIndicator('cost') }}
-              </th>
-              <th class="px-4 py-2.5">Address</th>
-              <th class="px-4 py-2.5 cursor-pointer hover:text-autonomi-text" @click="toggleSort('date')">
-                Date {{ sortIndicator('date') }}
+              <th class="px-4 py-2.5">Source</th>
+              <th class="px-4 py-2.5">Saved to</th>
+              <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleDownloadSort('date')">
+                Date {{ downloadSortIndicator('date') }}
               </th>
             </tr>
           </thead>
           <tbody class="divide-y divide-autonomi-border">
             <tr
-              v-for="file in sortedFiles"
+              v-for="file in sortedDownloads"
               :key="file.id"
               class="transition-colors"
               :class="rowClass(file)"
@@ -112,10 +196,6 @@
               <td class="px-4 py-2.5 text-autonomi-muted">{{ file.size_bytes ? formatBytes(file.size_bytes) : '-' }}</td>
               <td class="px-4 py-2.5">
                 <StatusBadge :status="statusLabel(file)" />
-              </td>
-              <td class="px-4 py-2.5 text-autonomi-muted">
-                <span>{{ file.cost ?? '-' }}</span>
-                <span v-if="file.gas_cost" class="block text-[10px] text-autonomi-muted/60">+ {{ file.gas_cost }} gas</span>
               </td>
               <td class="px-4 py-2.5">
                 <span
@@ -135,12 +215,15 @@
                 </span>
                 <span v-else class="text-autonomi-muted">-</span>
               </td>
+              <td class="px-4 py-2.5 font-mono text-xs text-autonomi-muted">
+                {{ file.dest_path ? basenameOf(file.dest_path) : '-' }}
+              </td>
               <td class="px-4 py-2.5 text-autonomi-muted">{{ formatDate(file.date) }}</td>
             </tr>
           </tbody>
         </table>
       </div>
-    </div>
+    </section>
 
     <!-- Dialogs -->
     <FilesDownloadDialog
@@ -214,49 +297,93 @@ function getWagmiConfig() {
 }
 
 // ── Sorting ──
+//
+// Uploads and downloads have independent sort state: a download doesn't
+// reorder the uploads table, and vice versa. Both default to newest-first.
 
-type SortKey = 'name' | 'size_bytes' | 'cost' | 'date'
-const sortKey = ref<SortKey>('date')
-const sortAsc = ref(false) // default: newest first
+type UploadSortKey = 'name' | 'size_bytes' | 'cost' | 'date'
+type DownloadSortKey = 'name' | 'size_bytes' | 'date'
 
-function toggleSort(key: SortKey) {
-  if (sortKey.value === key) {
-    sortAsc.value = !sortAsc.value
+const uploadSortKey = ref<UploadSortKey>('date')
+const uploadSortAsc = ref(false)
+const downloadSortKey = ref<DownloadSortKey>('date')
+const downloadSortAsc = ref(false)
+
+function toggleUploadSort(key: UploadSortKey) {
+  if (uploadSortKey.value === key) {
+    uploadSortAsc.value = !uploadSortAsc.value
   } else {
-    sortKey.value = key
-    sortAsc.value = key === 'name' // name defaults ascending, others descending
+    uploadSortKey.value = key
+    uploadSortAsc.value = key === 'name'
   }
 }
 
-function sortIndicator(key: SortKey): string {
-  if (sortKey.value !== key) return ''
-  return sortAsc.value ? '↑' : '↓'
+function toggleDownloadSort(key: DownloadSortKey) {
+  if (downloadSortKey.value === key) {
+    downloadSortAsc.value = !downloadSortAsc.value
+  } else {
+    downloadSortKey.value = key
+    downloadSortAsc.value = key === 'name'
+  }
 }
 
-const sortedFiles = computed(() => {
-  const pinned = filesStore.pinnedFiles.slice().sort(
-    (a, b) => (b.transferStartedAt ?? 0) - (a.transferStartedAt ?? 0),
-  )
-  const settled = filesStore.settledFiles.slice().sort((a, b) => {
-    let cmp = 0
-    switch (sortKey.value) {
-      case 'name':
-        cmp = a.name.localeCompare(b.name)
-        break
-      case 'size_bytes':
-        cmp = a.size_bytes - b.size_bytes
-        break
-      case 'cost':
-        cmp = (a.cost ?? '').localeCompare(b.cost ?? '')
-        break
-      case 'date':
-        cmp = a.date.localeCompare(b.date)
-        break
-    }
-    return sortAsc.value ? cmp : -cmp
+function uploadSortIndicator(key: UploadSortKey): string {
+  if (uploadSortKey.value !== key) return ''
+  return uploadSortAsc.value ? '↑' : '↓'
+}
+
+function downloadSortIndicator(key: DownloadSortKey): string {
+  if (downloadSortKey.value !== key) return ''
+  return downloadSortAsc.value ? '↑' : '↓'
+}
+
+function compareEntries(
+  a: FileEntry,
+  b: FileEntry,
+  key: UploadSortKey | DownloadSortKey,
+): number {
+  switch (key) {
+    case 'name': return a.name.localeCompare(b.name)
+    case 'size_bytes': return a.size_bytes - b.size_bytes
+    case 'cost': return (a.cost ?? '').localeCompare(b.cost ?? '')
+    case 'date': return a.date.localeCompare(b.date)
+  }
+}
+
+/** Active (pinned) rows sort by when their transfer started — newest at top. */
+function byTransferStart(a: FileEntry, b: FileEntry): number {
+  return (b.transferStartedAt ?? 0) - (a.transferStartedAt ?? 0)
+}
+
+const sortedUploads = computed(() => {
+  const pinned = filesStore.pinnedUploads.slice().sort(byTransferStart)
+  const settled = filesStore.settledUploads.slice().sort((a, b) => {
+    const cmp = compareEntries(a, b, uploadSortKey.value)
+    return uploadSortAsc.value ? cmp : -cmp
   })
   return [...pinned, ...settled]
 })
+
+const sortedDownloads = computed(() => {
+  const pinned = filesStore.pinnedDownloads.slice().sort(byTransferStart)
+  const settled = filesStore.settledDownloads.slice().sort((a, b) => {
+    const cmp = compareEntries(a, b, downloadSortKey.value)
+    return downloadSortAsc.value ? cmp : -cmp
+  })
+  return [...pinned, ...settled]
+})
+
+const hasSettledUploads = computed(() =>
+  filesStore.settledUploads.some(f => f.status === 'complete' || f.status === 'failed'),
+)
+
+const hasSettledDownloads = computed(() =>
+  filesStore.settledDownloads.some(f => f.status !== 'downloading'),
+)
+
+function basenameOf(path: string): string {
+  return path.split(/[\\/]/).pop() ?? path
+}
 
 // ── Row display helpers ──
 

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -17,6 +17,12 @@
         </button>
         <button
           class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
+          @click="openDownloadByDatamap"
+        >
+          Download by Datamap
+        </button>
+        <button
+          class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
           @click="estimateCost"
         >
           Estimate Cost
@@ -113,7 +119,15 @@
               </td>
               <td class="px-4 py-2.5">
                 <span
-                  v-if="file.address"
+                  v-if="file.data_map_file"
+                  class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
+                  :title="`Reveal ${datamapBasename(file.data_map_file)} in its folder`"
+                  @click.stop="openFolder(file.data_map_file)"
+                >
+                  {{ datamapBasename(file.data_map_file) }}
+                </span>
+                <span
+                  v-else-if="file.address"
                   class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
                   @click.stop="copyAddress(file.address)"
                 >
@@ -133,6 +147,14 @@
       :open="showDownloadDialog"
       @close="showDownloadDialog = false"
       @download="handleDownload"
+    />
+
+    <FilesDownloadByDatamapDialog
+      :open="showDatamapDialog"
+      :candidates="datamapCandidates"
+      @close="showDatamapDialog = false"
+      @browse="browseForDatamap"
+      @select="startDatamapDownload"
     />
 
     <FilesUploadConfirmDialog
@@ -475,6 +497,60 @@ function waitForConnection(): Promise<boolean> {
   })
 }
 
+const showDatamapDialog = ref(false)
+
+/** Previously uploaded files for which we still hold a local datamap — the
+ *  set the user can re-download from without picking a file from disk. */
+const datamapCandidates = computed(() =>
+  filesStore.files
+    .filter(f => f.status === 'complete' && f.data_map_file)
+    .map(f => ({
+      name: f.name,
+      data_map_file: f.data_map_file!,
+      date: f.date,
+      size_bytes: f.size_bytes,
+    })),
+)
+
+function openDownloadByDatamap() {
+  showDatamapDialog.value = true
+}
+
+async function browseForDatamap() {
+  showDatamapDialog.value = false
+  let selected: string | string[] | null
+  try {
+    selected = await openFileDialog({
+      multiple: false,
+      title: 'Select a datamap file to download',
+      filters: [{ name: 'Datamap', extensions: ['datamap'] }],
+    })
+  } catch (err) {
+    console.error('File dialog error:', err)
+    return
+  }
+  if (!selected) return
+  const datamapPath = String(Array.isArray(selected) ? selected[0] : selected)
+  await startDatamapDownload(datamapPath)
+}
+
+async function startDatamapDownload(datamapPath: string) {
+  const id = await filesStore.downloadFromDatamapFile(datamapPath)
+  if (id === null) return
+
+  if (!autonomiConnected.value) {
+    invoke('retry_autonomi_client').catch(() => {})
+    const connected = await waitForConnection()
+    if (!connected) {
+      filesStore.updateEntry(id, { status: 'failed', error: 'Not connected to network' })
+      toastStore.add('Download requires network connection', 'warning')
+      return
+    }
+  }
+
+  filesStore.startRealDownload(id)
+}
+
 async function handleDownload(address: string, filename: string) {
   const downloadDir = filesStore.getDownloadDir()
   const destPath = `${downloadDir}/${filename}`
@@ -599,6 +675,10 @@ async function openFolder(path: string) {
 function copyAddress(addr: string) {
   navigator.clipboard.writeText(addr)
   toastStore.add('Address copied to clipboard', 'info')
+}
+
+function datamapBasename(path: string): string {
+  return path.split(/[\\/]/).pop() ?? path
 }
 
 function formatDate(iso: string): string {

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -177,7 +177,6 @@
                 Size {{ downloadSortIndicator('size_bytes') }}
               </th>
               <th class="px-4 py-2.5">Status</th>
-              <th class="px-4 py-2.5">Source</th>
               <th class="px-4 py-2.5">Saved to</th>
               <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleDownloadSort('date')">
                 Date {{ downloadSortIndicator('date') }}
@@ -196,24 +195,6 @@
               <td class="px-4 py-2.5 text-autonomi-muted">{{ file.size_bytes ? formatBytes(file.size_bytes) : '-' }}</td>
               <td class="px-4 py-2.5">
                 <StatusBadge :status="statusLabel(file)" />
-              </td>
-              <td class="px-4 py-2.5">
-                <span
-                  v-if="file.data_map_file"
-                  class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
-                  :title="`Reveal ${datamapBasename(file.data_map_file)} in its folder`"
-                  @click.stop="openFolder(file.data_map_file)"
-                >
-                  {{ datamapBasename(file.data_map_file) }}
-                </span>
-                <span
-                  v-else-if="file.address"
-                  class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
-                  @click.stop="copyAddress(file.address)"
-                >
-                  {{ truncateAddress(file.address, 8, 6) }}
-                </span>
-                <span v-else class="text-autonomi-muted">-</span>
               </td>
               <td class="px-4 py-2.5 font-mono text-xs text-autonomi-muted">
                 {{ file.dest_path ? basenameOf(file.dest_path) : '-' }}

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -451,16 +451,49 @@ function cancelUpload() {
 
 const showDownloadDialog = ref(false)
 
-function handleDownload(address: string, filename: string) {
+/**
+ * Resolve once the embedded ant-core client is connected, or returns false
+ * if it transitions to `failed`. No timeout — matches the upload-while-
+ * connecting flow, which just waits on a reactive watcher. A user who
+ * no longer wants to wait can close the app or dismiss the row.
+ */
+function waitForConnection(): Promise<boolean> {
+  if (autonomiConnected.value) return Promise.resolve(true)
+  return new Promise((resolve) => {
+    const stop = watch(
+      () => connectionStore.current.status,
+      (status) => {
+        if (status === 'connected') {
+          stop()
+          resolve(true)
+        } else if (status === 'failed') {
+          stop()
+          resolve(false)
+        }
+      },
+    )
+  })
+}
+
+async function handleDownload(address: string, filename: string) {
   const downloadDir = filesStore.getDownloadDir()
   const destPath = `${downloadDir}/${filename}`
   const id = filesStore.startDownload(address, filename, destPath)
-  if (autonomiConnected.value) {
-    filesStore.startRealDownload(id)
-  } else {
-    filesStore.updateEntry(id, { status: 'failed', error: 'Not connected to network' })
-    toastStore.add('Download requires network connection', 'warning')
+
+  if (!autonomiConnected.value) {
+    // Kick the connect loop (no-op if already connecting) and wait. The row
+    // already shows `downloading` — progress just stays at 0 until the
+    // client is ready.
+    invoke('retry_autonomi_client').catch(() => {})
+    const connected = await waitForConnection()
+    if (!connected) {
+      filesStore.updateEntry(id, { status: 'failed', error: 'Not connected to network' })
+      toastStore.add('Download requires network connection', 'warning')
+      return
+    }
   }
+
+  filesStore.startRealDownload(id)
 }
 
 // ── Cost estimation ──

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -218,7 +218,14 @@
       :candidates="datamapCandidates"
       @close="showDatamapDialog = false"
       @browse="browseForDatamap"
-      @select="startDatamapDownload"
+      @select="onDatamapPicked"
+    />
+
+    <FilesDatamapSaveAsDialog
+      :open="showDatamapSaveAs"
+      :default-name="pendingDatamap?.defaultName ?? ''"
+      @close="cancelDatamapSaveAs"
+      @confirm="startDatamapDownload"
     />
 
     <FilesUploadConfirmDialog
@@ -606,12 +613,17 @@ function waitForConnection(): Promise<boolean> {
 }
 
 const showDatamapDialog = ref(false)
+const showDatamapSaveAs = ref(false)
+
+/** Set between phase 1 (picker) and phase 2 (Save As) of the download-by-
+ *  datamap flow. Cleared once a download starts or the user cancels. */
+const pendingDatamap = ref<{ path: string; defaultName: string } | null>(null)
 
 /** Previously uploaded files for which we still hold a local datamap — the
  *  set the user can re-download from without picking a file from disk. */
 const datamapCandidates = computed(() =>
   filesStore.files
-    .filter(f => f.status === 'complete' && f.data_map_file)
+    .filter(f => f.kind === 'upload' && f.status === 'complete' && f.data_map_file)
     .map(f => ({
       name: f.name,
       data_map_file: f.data_map_file!,
@@ -622,6 +634,11 @@ const datamapCandidates = computed(() =>
 
 function openDownloadByDatamap() {
   showDatamapDialog.value = true
+}
+
+function onDatamapPicked(path: string, suggestedName: string) {
+  pendingDatamap.value = { path, defaultName: suggestedName }
+  showDatamapSaveAs.value = true
 }
 
 async function browseForDatamap() {
@@ -639,11 +656,24 @@ async function browseForDatamap() {
   }
   if (!selected) return
   const datamapPath = String(Array.isArray(selected) ? selected[0] : selected)
-  await startDatamapDownload(datamapPath)
+  const basename = datamapPath.split(/[\\/]/).pop() ?? 'download'
+  const defaultName = basename.replace(/\.datamap$/i, '') || basename
+  pendingDatamap.value = { path: datamapPath, defaultName }
+  showDatamapSaveAs.value = true
 }
 
-async function startDatamapDownload(datamapPath: string) {
-  const id = await filesStore.downloadFromDatamapFile(datamapPath)
+function cancelDatamapSaveAs() {
+  showDatamapSaveAs.value = false
+  pendingDatamap.value = null
+}
+
+async function startDatamapDownload(filename: string) {
+  const pending = pendingDatamap.value
+  if (!pending) return
+  showDatamapSaveAs.value = false
+  pendingDatamap.value = null
+
+  const id = await filesStore.downloadFromDatamapFile(pending.path, filename)
   if (id === null) return
 
   if (!autonomiConnected.value) {

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -716,7 +716,7 @@ async fn download_with_datamap(
     dest_path: &str,
     app: &AppHandle,
 ) -> Result<u64, String> {
-    let dest = PathBuf::from(dest_path);
+    let dest = expand_tilde(dest_path);
 
     if let Some(parent) = dest.parent() {
         tokio::fs::create_dir_all(parent)
@@ -740,13 +740,29 @@ async fn download_with_datamap(
     app.emit(
         "download-complete",
         serde_json::json!({
-            "dest_path": dest_path,
+            "dest_path": dest.to_string_lossy(),
             "bytes_written": bytes_written,
         }),
     )
     .ok();
 
     Ok(bytes_written)
+}
+
+/// Expand a leading `~` or `~/` to the user's home directory. A literal
+/// tilde in `PathBuf::from` is otherwise treated as a directory named `~`
+/// in the current working directory — in dev mode that's `src-tauri/`,
+/// which the Tauri watcher monitors and reacts to by restarting the app.
+fn expand_tilde(path: &str) -> PathBuf {
+    if path == "~" {
+        return dirs::home_dir().unwrap_or_else(|| PathBuf::from(path));
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(path)
 }
 
 /// Read a persisted DataMap file from disk and return its JSON contents.

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -677,7 +677,46 @@ pub async fn download_file(
     let data_map: DataMap =
         serde_json::from_str(&data_map_json).map_err(|e| format!("Invalid DataMap: {e}"))?;
 
-    let dest = PathBuf::from(&dest_path);
+    download_with_datamap(client, &data_map, &dest_path, &app).await
+}
+
+/// Fetch a DataMap from the network by its public chunk address, then
+/// download the referenced file. Used by "download by address" when no
+/// local datamap is known — the DataMap was stored publicly on the network
+/// at the given 32-byte chunk address.
+#[tauri::command]
+pub async fn download_public(
+    app: AppHandle,
+    state: tauri::State<'_, AutonomiState>,
+    address: String,
+    dest_path: String,
+) -> Result<u64, String> {
+    let client_lock = state.client.read().await;
+    let client = client_lock
+        .as_ref()
+        .ok_or("Autonomi client not initialized")?;
+
+    let bytes = hex::decode(address.trim().trim_start_matches("0x"))
+        .map_err(|e| format!("Invalid address hex: {e}"))?;
+    let addr: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| "Address must be exactly 32 bytes (64 hex chars)".to_string())?;
+
+    let data_map = client
+        .data_map_fetch(&addr)
+        .await
+        .map_err(|e| format!("No data map at that address: {e}"))?;
+
+    download_with_datamap(client, &data_map, &dest_path, &app).await
+}
+
+async fn download_with_datamap(
+    client: &Client,
+    data_map: &DataMap,
+    dest_path: &str,
+    app: &AppHandle,
+) -> Result<u64, String> {
+    let dest = PathBuf::from(dest_path);
 
     if let Some(parent) = dest.parent() {
         tokio::fs::create_dir_all(parent)
@@ -694,7 +733,7 @@ pub async fn download_file(
     }
 
     let bytes_written = client
-        .file_download(&data_map, &dest)
+        .file_download(data_map, &dest)
         .await
         .map_err(|e| format!("Download failed: {e}"))?;
 

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -58,11 +58,11 @@ pub enum ConnectionStatus {
     /// No connect attempt has run yet (initial state on app start).
     Idle,
     /// A connect attempt is in flight.
-    Connecting { attempt: u32, of: u32 },
+    Connecting,
     /// Successfully connected to the network.
     Connected,
-    /// All retries exhausted. `reason` is the error from the last attempt.
-    Failed { reason: String, attempts: u32 },
+    /// Connect failed. `reason` is the error from the backend.
+    Failed { reason: String },
 }
 
 pub struct AutonomiState {
@@ -82,28 +82,6 @@ pub struct InitArgs {
     pub evm_token_address: Option<String>,
     pub evm_vault_address: Option<String>,
 }
-
-/// Per-attempt timeout for building + starting the embedded P2P node.
-///
-/// `P2PNode::start()` blocks until the saorsa-core bootstrap loop has
-/// processed every configured peer. That loop is sequential (one `.await`
-/// per peer — see saorsa-core `network.rs` ~line 2022), with a 15s
-/// identity-exchange timeout per unresponsive peer. With 7 bundled
-/// bootstrap peers and IPv4-only sockets (see the `ipv6(false)` override
-/// in the connect loop) cold start is ~60-120s in practice. `ant-cli` has
-/// no timeout on this phase and relies on its spinner for progress; we
-/// give ourselves 240s, which covers the worst case we've observed
-/// without letting a genuine failure wedge the UI.
-const CONNECT_ATTEMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(240);
-/// Maximum number of connect attempts before giving up.
-///
-/// Two attempts is enough in practice: if a 4-minute attempt fails, the
-/// bootstrap peer list or the local network is actually broken, not
-/// transiently slow. A second attempt is a cheap hedge; a third just
-/// keeps the user staring at a spinner.
-const CONNECT_MAX_ATTEMPTS: u32 = 2;
-/// Backoff schedule between attempts (length must be ≥ CONNECT_MAX_ATTEMPTS - 1).
-const CONNECT_BACKOFFS: [std::time::Duration; 1] = [std::time::Duration::from_secs(5)];
 
 /// Pending uploads older than this are garbage-collected.
 const PENDING_UPLOAD_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
@@ -191,10 +169,13 @@ async fn set_connection_status(app: &AppHandle, new_status: ConnectionStatus) {
     }
 }
 
-/// Background task: try `Client::connect` up to `CONNECT_MAX_ATTEMPTS` times
-/// with a per-attempt timeout and backoff between attempts. Each transition is
-/// emitted to the frontend via `set_connection_status`. Returns silently — the
-/// frontend learns the outcome through events / `get_connection_status`.
+/// Background task: build + start the embedded P2P node once and emit status
+/// transitions via `set_connection_status`. Matches `ant-cli`'s behavior —
+/// no per-attempt timeout and no retry loop. `P2PNode::start()` blocks on
+/// the saorsa-core bootstrap loop (sequential `.await` per peer with a 15s
+/// identity-exchange timeout each), so cold start can take 1-4 minutes on
+/// a fresh connect. If it genuinely wedges, the user can hit Retry (which
+/// calls `retry_autonomi_client`) or restart the app.
 async fn run_connection_loop(app: AppHandle, args: InitArgs) {
     let peers: Vec<std::net::SocketAddr> = match &args.bootstrap_peers {
         Some(list) if !list.is_empty() => list.iter().filter_map(|s| s.parse().ok()).collect(),
@@ -205,7 +186,6 @@ async fn run_connection_loop(app: AppHandle, args: InitArgs) {
                     &app,
                     ConnectionStatus::Failed {
                         reason: format!("Could not load bootstrap peers: {e}"),
-                        attempts: 0,
                     },
                 )
                 .await;
@@ -219,7 +199,6 @@ async fn run_connection_loop(app: AppHandle, args: InitArgs) {
             &app,
             ConnectionStatus::Failed {
                 reason: "No bootstrap peers available".into(),
-                attempts: 0,
             },
         )
         .await;
@@ -232,7 +211,6 @@ async fn run_connection_loop(app: AppHandle, args: InitArgs) {
                 &app,
                 ConnectionStatus::Failed {
                     reason: "evm_token_address required with evm_rpc_url".into(),
-                    attempts: 0,
                 },
             )
             .await;
@@ -243,7 +221,6 @@ async fn run_connection_loop(app: AppHandle, args: InitArgs) {
                 &app,
                 ConnectionStatus::Failed {
                     reason: "evm_vault_address required with evm_rpc_url".into(),
-                    attempts: 0,
                 },
             )
             .await;
@@ -261,109 +238,67 @@ async fn run_connection_loop(app: AppHandle, args: InitArgs) {
     // ant-cli (see WithAutonomi/ant-client#40).
     let allow_loopback = args.evm_rpc_url.is_some();
 
-    let mut last_error = String::new();
-    for attempt in 1..=CONNECT_MAX_ATTEMPTS {
-        set_connection_status(
-            &app,
-            ConnectionStatus::Connecting {
-                attempt,
-                of: CONNECT_MAX_ATTEMPTS,
-            },
-        )
-        .await;
+    set_connection_status(&app, ConnectionStatus::Connecting).await;
 
-        let client_config = ClientConfig {
-            allow_loopback,
-            ..ClientConfig::default()
-        };
+    let client_config = ClientConfig {
+        allow_loopback,
+        ..ClientConfig::default()
+    };
 
-        // Force IPv4-only on outbound connections. Upstream `Network::new`
-        // hardcodes `ipv6(true)` (ant-client PR #33), which dual-stacks the
-        // socket and turns every peer send into a `[DUAL SEND]` that wastes
-        // ~15s per failing IPv6 leg on home networks where the ISP drops
-        // outbound v6. Measured cold-start on this machine was 100s with
-        // ipv6(false) vs 218s with ipv6(true).
-        //
-        // Temporary workaround — remove once upstream ships RFC 8305 happy
-        // eyeballs / IPv6 reachability detection so dual-stack is safe to
-        // leave on by default (see docs/ipv6-bootstrap-proposal.md in the
-        // review thread). Until then we mirror `ant-cli::create_client_node_raw`
-        // by building `CoreNodeConfig` directly and calling `Client::from_node`,
-        // bypassing `Client::connect` / `Network::new`.
-        let mut core_config = match CoreNodeConfig::builder()
-            .port(0)
-            .ipv6(false)
-            .local(allow_loopback)
-            .mode(NodeMode::Client)
-            .max_message_size(MAX_WIRE_MESSAGE_SIZE)
-            .build()
-        {
-            Ok(cfg) => cfg,
-            Err(e) => {
-                last_error = format!("core config build failed: {e}");
-                eprintln!("Autonomi connect attempt {attempt}: {last_error}");
-                if attempt < CONNECT_MAX_ATTEMPTS {
-                    let backoff = CONNECT_BACKOFFS
-                        .get((attempt - 1) as usize)
-                        .copied()
-                        .unwrap_or(std::time::Duration::from_secs(20));
-                    tokio::time::sleep(backoff).await;
-                }
-                continue;
-            }
-        };
-        core_config.bootstrap_peers = peers.iter().map(|addr| MultiAddr::quic(*addr)).collect();
-
-        let connect_fut = async move {
-            let node = P2PNode::new(core_config)
-                .await
-                .map_err(|e| format!("P2PNode::new failed: {e}"))?;
-            node.start()
-                .await
-                .map_err(|e| format!("P2PNode::start failed: {e}"))?;
-            Ok::<_, String>(std::sync::Arc::new(node))
-        };
-
-        match tokio::time::timeout(CONNECT_ATTEMPT_TIMEOUT, connect_fut).await {
-            Ok(Ok(node)) => {
-                let peer_count = node.connected_peers().await.len();
-                let client =
-                    Client::from_node(node, client_config).with_evm_network(evm_network.clone());
-                *app.state::<AutonomiState>().client.write().await = Some(client);
-                eprintln!("Autonomi connect attempt {attempt} succeeded ({peer_count} peers)");
-                set_connection_status(&app, ConnectionStatus::Connected).await;
-                return;
-            }
-            Ok(Err(e)) => {
-                last_error = format!("connect failed: {e}");
-                eprintln!("Autonomi connect attempt {attempt} failed: {e}");
-            }
-            Err(_) => {
-                last_error = format!(
-                    "connect timed out after {}s",
-                    CONNECT_ATTEMPT_TIMEOUT.as_secs()
-                );
-                eprintln!("Autonomi connect attempt {attempt} timed out");
-            }
+    // Force IPv4-only on outbound connections. Upstream `Network::new`
+    // hardcodes `ipv6(true)` (ant-client PR #33), which dual-stacks the
+    // socket and turns every peer send into a `[DUAL SEND]` that wastes
+    // ~15s per failing IPv6 leg on home networks where the ISP drops
+    // outbound v6. Measured cold-start on this machine was 100s with
+    // ipv6(false) vs 218s with ipv6(true).
+    //
+    // Temporary workaround — remove once upstream ships RFC 8305 happy
+    // eyeballs / IPv6 reachability detection so dual-stack is safe to
+    // leave on by default (see docs/ipv6-bootstrap-proposal.md in the
+    // review thread). Until then we mirror `ant-cli::create_client_node_raw`
+    // by building `CoreNodeConfig` directly and calling `Client::from_node`,
+    // bypassing `Client::connect` / `Network::new`.
+    let mut core_config = match CoreNodeConfig::builder()
+        .port(0)
+        .ipv6(false)
+        .local(allow_loopback)
+        .mode(NodeMode::Client)
+        .max_message_size(MAX_WIRE_MESSAGE_SIZE)
+        .build()
+    {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            let reason = format!("core config build failed: {e}");
+            eprintln!("Autonomi connect: {reason}");
+            set_connection_status(&app, ConnectionStatus::Failed { reason }).await;
+            return;
         }
+    };
+    core_config.bootstrap_peers = peers.iter().map(|addr| MultiAddr::quic(*addr)).collect();
 
-        if attempt < CONNECT_MAX_ATTEMPTS {
-            let backoff = CONNECT_BACKOFFS
-                .get((attempt - 1) as usize)
-                .copied()
-                .unwrap_or(std::time::Duration::from_secs(20));
-            tokio::time::sleep(backoff).await;
+    let node = match P2PNode::new(core_config).await {
+        Ok(n) => n,
+        Err(e) => {
+            let reason = format!("P2PNode::new failed: {e}");
+            eprintln!("Autonomi connect: {reason}");
+            set_connection_status(&app, ConnectionStatus::Failed { reason }).await;
+            return;
         }
+    };
+
+    if let Err(e) = node.start().await {
+        let reason = format!("P2PNode::start failed: {e}");
+        eprintln!("Autonomi connect: {reason}");
+        set_connection_status(&app, ConnectionStatus::Failed { reason }).await;
+        return;
     }
 
-    set_connection_status(
-        &app,
-        ConnectionStatus::Failed {
-            reason: last_error,
-            attempts: CONNECT_MAX_ATTEMPTS,
-        },
-    )
-    .await;
+    let node = std::sync::Arc::new(node);
+    let peer_count = node.connected_peers().await.len();
+    let client = Client::from_node(node, client_config).with_evm_network(evm_network);
+    *app.state::<AutonomiState>().client.write().await = Some(client);
+    eprintln!("Autonomi connect succeeded ({peer_count} peers)");
+    set_connection_status(&app, ConnectionStatus::Connected).await;
 }
 
 /// Spawn the connection loop if no client is already set. Returns immediately —
@@ -388,7 +323,7 @@ pub async fn init_autonomi_client(
     // Don't start a second loop if one is already in flight.
     if matches!(
         *state.connection_status.read().await,
-        ConnectionStatus::Connecting { .. }
+        ConnectionStatus::Connecting
     ) {
         return Ok(false);
     }
@@ -420,7 +355,7 @@ pub async fn retry_autonomi_client(
     }
     if matches!(
         *state.connection_status.read().await,
-        ConnectionStatus::Connecting { .. }
+        ConnectionStatus::Connecting
     ) {
         return Ok(());
     }

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -67,7 +67,7 @@ pub enum ConnectionStatus {
 
 pub struct AutonomiState {
     pub client: RwLock<Option<Client>>,
-    pub pending_uploads: RwLock<HashMap<String, (PreparedUpload, std::time::Instant)>>,
+    pub pending_uploads: RwLock<HashMap<String, PendingUpload>>,
     pub connection_status: RwLock<ConnectionStatus>,
     /// Holds the last set of args used for `init_autonomi_client`, so a manual
     /// `retry_autonomi_client` can re-run with the same configuration.
@@ -86,6 +86,16 @@ pub struct InitArgs {
 /// Pending uploads older than this are garbage-collected.
 const PENDING_UPLOAD_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
 
+/// An upload that's been prepared (encrypted + quoted) and is waiting for the
+/// frontend to complete its payment step before chunks are stored on the
+/// network. `file_name` is the basename of the original file — captured here
+/// so `confirm_upload` can name the persisted datamap after it.
+pub struct PendingUpload {
+    pub prepared: PreparedUpload,
+    pub created_at: std::time::Instant,
+    pub file_name: String,
+}
+
 impl AutonomiState {
     pub fn new() -> Self {
         Self {
@@ -102,7 +112,7 @@ impl AutonomiState {
         self.pending_uploads
             .write()
             .await
-            .retain(|_, (_, created_at)| *created_at > cutoff);
+            .retain(|_, pending| pending.created_at > cutoff);
     }
 }
 
@@ -148,6 +158,10 @@ pub struct UploadResult {
     /// Hex address derived from the DataMap (for display/sharing).
     pub address: String,
     pub chunks_stored: usize,
+    /// Absolute path to the persisted DataMap file on the local filesystem.
+    /// This is the user-visible handle for private uploads — without it, the
+    /// data is unreachable after the app restarts.
+    pub data_map_file: String,
 }
 
 #[derive(Deserialize)]
@@ -485,12 +499,22 @@ pub async fn start_upload(
     app.emit("upload-quote", &quote_event)
         .map_err(|e| format!("Failed to emit quote event: {e}"))?;
 
+    // Capture the basename so confirm_upload can name the persisted datamap
+    // after the original file.
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "upload".to_string());
+
     // Store prepared upload with timestamp for TTL cleanup
-    state
-        .pending_uploads
-        .write()
-        .await
-        .insert(request.upload_id, (prepared, std::time::Instant::now()));
+    state.pending_uploads.write().await.insert(
+        request.upload_id,
+        PendingUpload {
+            prepared,
+            created_at: std::time::Instant::now(),
+            file_name,
+        },
+    );
 
     Ok(())
 }
@@ -509,7 +533,11 @@ pub async fn confirm_upload(
         .as_ref()
         .ok_or("Autonomi client not initialized")?;
 
-    let (prepared, _created_at) = state
+    let PendingUpload {
+        prepared,
+        file_name,
+        ..
+    } = state
         .pending_uploads
         .write()
         .await
@@ -549,6 +577,9 @@ pub async fn confirm_upload(
     let data_map_json = serde_json::to_string(&result.data_map)
         .map_err(|e| format!("Failed to serialize DataMap: {e}"))?;
     let address = format!("0x{:x}", Sha256::digest(data_map_json.as_bytes()));
+    let data_map_file = crate::config::write_datamap_for(&file_name, &data_map_json)?
+        .to_string_lossy()
+        .into_owned();
 
     app.emit(
         "upload-progress",
@@ -565,6 +596,7 @@ pub async fn confirm_upload(
         data_map_json,
         address,
         chunks_stored: result.chunks_stored,
+        data_map_file,
     })
 }
 
@@ -582,7 +614,11 @@ pub async fn confirm_upload_merkle(
         .as_ref()
         .ok_or("Autonomi client not initialized")?;
 
-    let (prepared, _created_at) = state
+    let PendingUpload {
+        prepared,
+        file_name,
+        ..
+    } = state
         .pending_uploads
         .write()
         .await
@@ -602,6 +638,9 @@ pub async fn confirm_upload_merkle(
     let data_map_json = serde_json::to_string(&result.data_map)
         .map_err(|e| format!("Failed to serialize DataMap: {e}"))?;
     let address = format!("0x{:x}", Sha256::digest(data_map_json.as_bytes()));
+    let data_map_file = crate::config::write_datamap_for(&file_name, &data_map_json)?
+        .to_string_lossy()
+        .into_owned();
 
     app.emit(
         "upload-progress",
@@ -618,6 +657,7 @@ pub async fn confirm_upload_merkle(
         data_map_json,
         address,
         chunks_stored: result.chunks_stored,
+        data_map_file,
     })
 }
 
@@ -668,6 +708,22 @@ pub async fn download_file(
     .ok();
 
     Ok(bytes_written)
+}
+
+/// Read a persisted DataMap file from disk and return its JSON contents.
+///
+/// Used by the "Download by datamap" flow: the user picks a `.datamap` file
+/// via the OS file dialog, and the frontend forwards the returned JSON to
+/// `download_file`. The path is trusted (chosen by the user through the
+/// native picker); we only validate that the file parses as UTF-8.
+#[tauri::command]
+pub fn read_datamap_file(path: String) -> Result<String, String> {
+    let canonical =
+        std::fs::canonicalize(&path).map_err(|e| format!("Invalid datamap path {path}: {e}"))?;
+    if !canonical.is_file() {
+        return Err(format!("Not a regular file: {path}"));
+    }
+    std::fs::read_to_string(&canonical).map_err(|e| format!("Failed to read {path}: {e}"))
 }
 
 /// Check if the data client is currently connected.

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,5 +1,10 @@
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Extension for persisted datamap files. Kept public so the frontend's file
+/// picker and sanity checks can share a single source of truth.
+pub const DATAMAP_EXTENSION: &str = "datamap";
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct AppConfig {
@@ -33,6 +38,11 @@ pub struct UploadHistoryEntry {
     pub address: String,
     pub cost: Option<String>,
     pub uploaded_at: String,
+    /// Absolute path to the serialized DataMap JSON file persisted alongside
+    /// this history entry. `None` for legacy entries written before datamap
+    /// persistence existed.
+    #[serde(default)]
+    pub data_map_file: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -160,4 +170,76 @@ pub fn get_file_metas(paths: &[String]) -> Result<Vec<FileMetaResult>, String> {
             })
         })
         .collect()
+}
+
+/// Persist a serialized DataMap JSON string alongside `upload_history.json`.
+///
+/// The file is named after the upload's original basename (with its extension
+/// stripped) plus `.datamap` — e.g. `test.pdf` becomes `test.datamap`. When a
+/// file of that name already exists, a numeric suffix is appended so we never
+/// overwrite a prior datamap: `test (2).datamap`, `test (3).datamap`, …
+///
+/// Returns the absolute path to the written file.
+pub fn write_datamap_for(original_name: &str, json: &str) -> Result<PathBuf, String> {
+    let stem = sanitize_stem(original_name);
+    let dir = config_path();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create config dir: {e}"))?;
+
+    // Cap the number of collision attempts at a generous-but-finite limit so a
+    // pathological state (e.g. thousands of collisions) yields an error rather
+    // than an infinite loop.
+    const MAX_COLLISION_ATTEMPTS: u32 = 10_000;
+    for attempt in 0..MAX_COLLISION_ATTEMPTS {
+        let file_name = if attempt == 0 {
+            format!("{stem}.{DATAMAP_EXTENSION}")
+        } else {
+            format!("{stem} ({}).{DATAMAP_EXTENSION}", attempt + 1)
+        };
+        let path = dir.join(&file_name);
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(mut f) => {
+                f.write_all(json.as_bytes())
+                    .map_err(|e| format!("Failed to write datamap: {e}"))?;
+                return Ok(path);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(format!("Failed to create datamap file: {e}")),
+        }
+    }
+    Err("Unable to reserve a datamap filename after many attempts".into())
+}
+
+/// Reduce an arbitrary upload filename to a safe datamap filename stem: drop
+/// the final extension, replace characters that are awkward on disk across
+/// platforms with `_`, and fall back to "datamap" if the result is empty.
+fn sanitize_stem(original_name: &str) -> String {
+    let raw = Path::new(original_name)
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let cleaned: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || matches!(c, ' ' | '-' | '_' | '.' | '(' | ')') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    let trimmed = cleaned
+        .trim_matches(|c: char| c == '.' || c.is_whitespace())
+        .to_string();
+
+    if trimmed.is_empty() {
+        "datamap".to_string()
+    } else {
+        trimmed
+    }
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -105,6 +105,13 @@ pub(crate) fn config_path() -> PathBuf {
         .join("ant-gui")
 }
 
+/// Resolve the OS-appropriate default downloads directory. Returns
+/// `~/Downloads` on macOS/Linux and `C:\Users\<name>\Downloads` on Windows,
+/// falling back to `<home>/Downloads` if the platform-specific lookup fails.
+pub fn platform_default_download_dir() -> Option<PathBuf> {
+    dirs::download_dir().or_else(|| dirs::home_dir().map(|h| h.join("Downloads")))
+}
+
 impl AppConfig {
     fn config_file() -> PathBuf {
         config_path().join("config.toml")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -601,6 +601,7 @@ pub fn run() {
             autonomi_ops::confirm_upload,
             autonomi_ops::confirm_upload_merkle,
             autonomi_ops::download_file,
+            autonomi_ops::read_datamap_file,
             autonomi_ops::is_autonomi_connected,
             autonomi_ops::retry_autonomi_client,
             autonomi_ops::get_connection_status,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -478,6 +478,18 @@ fn get_node_data_dir(node_id: u32) -> Result<String, String> {
     Ok(base.to_string_lossy().into_owned())
 }
 
+/// Return the OS-appropriate default downloads directory. Used as the
+/// fallback destination when the user hasn't configured a custom one in
+/// settings. Resolves to `~/Downloads` on macOS/Linux and
+/// `C:\Users\<name>\Downloads` on Windows.
+#[tauri::command]
+fn get_default_download_dir() -> Result<String, String> {
+    dirs::download_dir()
+        .or_else(|| dirs::home_dir().map(|h| h.join("Downloads")))
+        .map(|p| p.to_string_lossy().into_owned())
+        .ok_or_else(|| "Could not determine default download directory".to_string())
+}
+
 /// Get the size of a single file in bytes.
 #[tauri::command]
 fn get_file_size(path: String) -> Result<u64, String> {
@@ -589,6 +601,7 @@ pub fn run() {
             get_file_size,
             get_dir_size,
             get_node_data_dir,
+            get_default_download_dir,
             read_file_bytes,
             load_upload_history,
             save_upload_history,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -601,6 +601,7 @@ pub fn run() {
             autonomi_ops::confirm_upload,
             autonomi_ops::confirm_upload_merkle,
             autonomi_ops::download_file,
+            autonomi_ops::download_public,
             autonomi_ops::read_datamap_file,
             autonomi_ops::is_autonomi_connected,
             autonomi_ops::retry_autonomi_client,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,7 +96,17 @@ fn find_daemon_binary() -> Option<PathBuf> {
 
 #[tauri::command]
 fn load_config() -> Result<AppConfig, String> {
-    AppConfig::load().map_err(|e| e.to_string())
+    let mut config = AppConfig::load().map_err(|e| e.to_string())?;
+    // Persist the platform's default downloads directory on first launch so
+    // it's visible in settings and used by downloads without a separate
+    // runtime fallback.
+    if config.download_dir.is_none() {
+        if let Some(default) = config::platform_default_download_dir() {
+            config.download_dir = Some(default.to_string_lossy().into_owned());
+            config.save().map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(config)
 }
 
 #[tauri::command]
@@ -478,14 +488,12 @@ fn get_node_data_dir(node_id: u32) -> Result<String, String> {
     Ok(base.to_string_lossy().into_owned())
 }
 
-/// Return the OS-appropriate default downloads directory. Used as the
-/// fallback destination when the user hasn't configured a custom one in
-/// settings. Resolves to `~/Downloads` on macOS/Linux and
-/// `C:\Users\<name>\Downloads` on Windows.
+/// Return the OS-appropriate default downloads directory. The frontend
+/// uses this to offer a "reset to default" affordance; on first launch
+/// `load_config` already persists this value into the config.
 #[tauri::command]
 fn get_default_download_dir() -> Result<String, String> {
-    dirs::download_dir()
-        .or_else(|| dirs::home_dir().map(|h| h.join("Downloads")))
+    config::platform_default_download_dir()
         .map(|p| p.to_string_lossy().into_owned())
         .ok_or_else(|| "Could not determine default download directory".to_string())
 }

--- a/stores/connection.ts
+++ b/stores/connection.ts
@@ -8,9 +8,9 @@ import { listen } from '@tauri-apps/api/event'
  */
 export type ConnectionStatus =
   | { status: 'idle' }
-  | { status: 'connecting'; attempt: number; of: number }
+  | { status: 'connecting' }
   | { status: 'connected' }
-  | { status: 'failed'; reason: string; attempts: number }
+  | { status: 'failed'; reason: string }
 
 export const useConnectionStore = defineStore('connection', {
   state: () => ({

--- a/stores/connection.ts
+++ b/stores/connection.ts
@@ -21,7 +21,9 @@ export const useConnectionStore = defineStore('connection', {
 
   getters: {
     isConnected: (state) => state.current.status === 'connected',
-    isConnecting: (state) => state.current.status === 'connecting',
+    // Treat `idle` (pre-init bootstrap) the same as `connecting` so the UI
+    // always shows a spinner while the client is being prepared.
+    isConnecting: (state) => state.current.status === 'connecting' || state.current.status === 'idle',
     hasFailed: (state) => state.current.status === 'failed',
   },
 
@@ -35,15 +37,18 @@ export const useConnectionStore = defineStore('connection', {
       if (this.listening) return
       this.listening = true
 
+      // Install the listener BEFORE fetching the current status, otherwise a
+      // state change emitted between the fetch and the subscription is lost
+      // and the UI can get stuck at `idle` indefinitely.
+      await listen<ConnectionStatus>('connection-status', (event) => {
+        this.current = event.payload
+      })
+
       try {
         this.current = await invoke<ConnectionStatus>('get_connection_status')
       } catch (e) {
         console.warn('get_connection_status failed:', e)
       }
-
-      await listen<ConnectionStatus>('connection-status', (event) => {
-        this.current = event.payload
-      })
     },
 
     /**

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -549,11 +549,13 @@ export const useFilesStore = defineStore('files', {
      * and creates a fresh download row. The matching upload row (if any)
      * is left untouched so the uploads table stays stable.
      *
-     * The output filename is derived from the datamap's basename with the
-     * `.datamap` extension stripped — not a perfect round-trip (we don't
-     * know the original file type), but good enough as a starting name.
+     * `filename` controls how the downloaded file is saved; if omitted it
+     * falls back to the datamap's basename with `.datamap` stripped.
      */
-    async downloadFromDatamapFile(datamapPath: string): Promise<number | null> {
+    async downloadFromDatamapFile(
+      datamapPath: string,
+      filename?: string,
+    ): Promise<number | null> {
       const toasts = useToastStore()
 
       let json: string
@@ -565,15 +567,16 @@ export const useFilesStore = defineStore('files', {
       }
 
       const basename = datamapPath.split(/[\\/]/).pop() ?? 'download'
-      const filename = basename.replace(/\.datamap$/i, '') || basename
+      const fallback = basename.replace(/\.datamap$/i, '') || basename
+      const finalName = filename?.trim() || fallback
       const address = await sha256Hex(json)
-      const destPath = `${this.getDownloadDir()}/${filename}`
+      const destPath = `${this.getDownloadDir()}/${finalName}`
 
       const id = this.nextId++
       this.files.unshift({
         id,
         kind: 'download',
-        name: filename,
+        name: finalName,
         size_bytes: 0,
         address,
         data_map_json: json,

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -454,15 +454,24 @@ export const useFilesStore = defineStore('files', {
      * Start a download row. Always creates a fresh entry in the downloads
      * table — uploads are never mutated in place, so the upload history
      * stays stable across download attempts.
+     *
+     * If the address matches a prior upload by this app, the new download
+     * inherits its datamap (JSON or file path). The "address" is a local
+     * SHA256 of the serialized DataMap, so without that lookup a pasted
+     * address has no way to resolve to a DataMap — the network can't be
+     * queried by this synthetic address.
      */
     startDownload(address: string, filename: string, dest_path: string): number {
       const id = this.nextId++
+      const match = this.findUploadByAddress(address)
       this.files.unshift({
         id,
         kind: 'download',
         name: filename,
         size_bytes: 0,
         address,
+        data_map_json: match?.data_map_json,
+        data_map_file: match?.data_map_file,
         status: 'downloading',
         dest_path,
         progress: 0,
@@ -470,6 +479,13 @@ export const useFilesStore = defineStore('files', {
         transferStartedAt: Date.now(),
       })
       return id
+    },
+
+    findUploadByAddress(address: string): FileEntry | undefined {
+      const needle = normalizeAddress(address)
+      return this.files.find(
+        f => f.kind === 'upload' && f.address && normalizeAddress(f.address) === needle,
+      )
     },
 
     async startRealDownload(id: number) {
@@ -492,23 +508,23 @@ export const useFilesStore = defineStore('files', {
         }
       }
 
-      if (!entry.data_map_json) {
-        this.updateEntry(id, { status: 'failed', error: 'No data map available — file must be uploaded first' })
-        toasts.add('Cannot download: no data map for this address', 'error')
-        return
-      }
-
       try {
         this.updateEntry(id, { status: 'downloading', progress: 0 })
 
-        await withTimeout(
-          invoke('download_file', {
-            dataMapJson: entry.data_map_json,
-            destPath: entry.dest_path,
-          }),
-          300_000,
-          'Download timed out',
-        )
+        // Local datamap takes priority — it's fast and doesn't require the
+        // DataMap chunk to exist on-network. Fall back to a public fetch by
+        // address when we have neither JSON nor a local file.
+        const request = entry.data_map_json
+          ? invoke('download_file', {
+              dataMapJson: entry.data_map_json,
+              destPath: entry.dest_path,
+            })
+          : invoke('download_public', {
+              address: entry.address,
+              destPath: entry.dest_path,
+            })
+
+        await withTimeout(request, 300_000, 'Download timed out')
 
         const duration = entry.transferStartedAt
           ? Math.round((Date.now() - entry.transferStartedAt) / 1000)
@@ -602,6 +618,10 @@ async function sha256Hex(text: string): Promise<string> {
     .map(b => b.toString(16).padStart(2, '0'))
     .join('')
   return `0x${hex}`
+}
+
+function normalizeAddress(address: string): string {
+  return address.trim().toLowerCase().replace(/^0x/, '')
 }
 
 function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -200,36 +200,31 @@ export const useFilesStore = defineStore('files', {
     async getUploadQuote(path: string): Promise<UploadQuote | null> {
       const uploadId = `quote-${Date.now()}-${Math.random().toString(36).slice(2)}`
 
-      // Deferred so we can resolve/reject from the listener and the timeout
-      // independently of where the Promise is awaited.
+      // Deferred so the listener can resolve independently of where the
+      // Promise is awaited.
       let resolveQuote: (value: any) => void = () => {}
-      let rejectQuote: (err: Error) => void = () => {}
-      const quotePromise = new Promise<any>((resolve, reject) => {
+      const quotePromise = new Promise<any>((resolve) => {
         resolveQuote = resolve
-        rejectQuote = reject
       })
 
       let unlisten: (() => void) | null = null
-      // The 120s timeout is registered AFTER listen() is awaited below — see
-      // explanation there. Holding the handle here so finally{} can clear it.
-      let timeoutId: ReturnType<typeof setTimeout> | null = null
 
       try {
-        // Register the listener BEFORE invoking start_upload. The previous
-        // implementation called listen() inside a `new Promise(...)` executor
-        // without awaiting it, then immediately did `await invoke(...)`. The
-        // backend can emit `upload-quote` before listen() finishes registering,
-        // in which case the event is missed and the 120s timeout eventually
-        // fires — visible in the dev console as "Uncaught (in promise) Error:
-        // Quote timeout". Awaiting listen() first eliminates the race and
-        // capturing `unlisten` lets us clean up so listeners do not pile up.
+        // Backend contract: `start_upload` emits `upload-quote` before it
+        // returns Ok. So `invoke` itself is our timing signal — when it
+        // resolves, the event has been dispatched. No separate timeout on
+        // the listener: on slow networks quote collection can legitimately
+        // take minutes, and an independent timeout just discards the
+        // result after the fact. Errors from the backend come through
+        // `invoke`'s rejection.
+        //
+        // Listener is awaited BEFORE invoke so the event cannot be emitted
+        // before we're listening.
         unlisten = await listen<any>('upload-quote', (event) => {
           if (event.payload.upload_id === uploadId) {
             resolveQuote(event.payload)
           }
         })
-
-        timeoutId = setTimeout(() => rejectQuote(new Error('Quote timeout')), 120_000)
 
         await invoke('start_upload', {
           request: { files: [path], upload_id: uploadId },
@@ -247,15 +242,9 @@ export const useFilesStore = defineStore('files', {
           merkle_pool_commitments: quote.merkle_pool_commitments,
           merkle_timestamp: quote.merkle_timestamp,
         }
-      } catch (err) {
-        // Settle the deferred so any later listener firing does not surface
-        // as an unhandled rejection; we already returned null to the caller.
-        rejectQuote(err instanceof Error ? err : new Error(String(err)))
-        // Swallow our own rejection so the deferred has a handler.
-        quotePromise.catch(() => {})
+      } catch {
         return null
       } finally {
-        if (timeoutId) clearTimeout(timeoutId)
         if (unlisten) unlisten()
       }
     },
@@ -280,39 +269,14 @@ export const useFilesStore = defineStore('files', {
           quote = preQuote
           this.updateEntry(id, { cost: preQuote.total_cost_display })
         } else {
-          // Get fresh quote from network
-          uploadId = `upload-${id}-${Date.now()}`
+          // Get fresh quote from network. Delegates to getUploadQuote so
+          // there is a single implementation of the listen+invoke dance.
+          if (!entry.path) throw new Error('Upload entry has no file path')
           this.updateEntry(id, { status: 'quoting' })
-
-          const quotePromise = new Promise<any>((resolve, reject) => {
-            const timeout = setTimeout(() => reject(new Error('Quote timeout')), 120_000)
-            listen<any>('upload-quote', (event) => {
-              if (event.payload.upload_id === uploadId) {
-                clearTimeout(timeout)
-                resolve(event.payload)
-              }
-            })
-          })
-
-          await invoke('start_upload', {
-            request: {
-              files: [entry.path],
-              upload_id: uploadId,
-            },
-          })
-
-          const raw = await quotePromise
-          quote = {
-            upload_id: uploadId,
-            payment_mode: raw.payment_mode,
-            payments: raw.payments ?? [],
-            total_cost: raw.total_cost,
-            total_cost_display: raw.payment_mode === 'merkle' ? 'Determined on-chain' : formatNanoTokens(raw.total_cost),
-            payment_required: raw.payment_required,
-            merkle_depth: raw.merkle_depth,
-            merkle_pool_commitments: raw.merkle_pool_commitments,
-            merkle_timestamp: raw.merkle_timestamp,
-          }
+          const fresh = await this.getUploadQuote(entry.path)
+          if (!fresh) throw new Error('Failed to get quote from network')
+          uploadId = fresh.upload_id
+          quote = fresh
           this.updateEntry(id, { cost: quote.total_cost_display })
         }
 
@@ -339,14 +303,14 @@ export const useFilesStore = defineStore('files', {
               gas_cost: formatGasCost(payResult.gasSpent.toString()),
             })
 
-            const result = await withTimeout(
-              invoke<{ upload_id: string; data_map_json: string; address: string; chunks_stored: number }>('confirm_upload_merkle', {
-                uploadId,
-                winnerPoolHash: payResult.winnerPoolHash,
-              }),
-              120_000,
-              'Upload timed out',
-            )
+            // No frontend timeout: the backend drives chunk storage, which
+            // can legitimately take many minutes for larger files. The CLI
+            // (which works) also has no timeout here. Backend errors still
+            // surface through invoke's rejection.
+            const result = await invoke<{ upload_id: string; data_map_json: string; address: string; chunks_stored: number }>('confirm_upload_merkle', {
+              uploadId,
+              winnerPoolHash: payResult.winnerPoolHash,
+            })
 
             const duration = entry.transferStartedAt
               ? Math.round((Date.now() - entry.transferStartedAt) / 1000)
@@ -385,14 +349,11 @@ export const useFilesStore = defineStore('files', {
 
           this.updateEntry(id, { status: 'uploading', progress: 0 })
 
-          const result = await withTimeout(
-            invoke<{ upload_id: string; data_map_json: string; address: string; chunks_stored: number }>('confirm_upload', {
-              uploadId,
-              txHashes,
-            }),
-            120_000,
-            'Upload timed out',
-          )
+          // No frontend timeout — see confirm_upload_merkle above for rationale.
+          const result = await invoke<{ upload_id: string; data_map_json: string; address: string; chunks_stored: number }>('confirm_upload', {
+            uploadId,
+            txHashes,
+          })
 
           const duration = entry.transferStartedAt
             ? Math.round((Date.now() - entry.transferStartedAt) / 1000)

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -38,6 +38,10 @@ export type FileStatus =
 export interface FileEntry {
   /** Unique ID for reactive tracking */
   id: number
+  /** Whether this row represents an upload or a download. Uploads persist
+   *  across restarts; downloads are in-memory only and a fresh session
+   *  always starts with an empty downloads table. */
+  kind: 'upload' | 'download'
   /** Display name */
   name: string
   /** Local file path (for uploads) */
@@ -70,9 +74,10 @@ export interface FileEntry {
   duration?: number
   /** Error message if failed */
   error?: string
-  /** Whether this entry existed in history before a download (vs downloaded-by-address) */
-  existedBeforeDownload?: boolean
 }
+
+const ACTIVE_STATUSES: FileStatus[] = ['quoting', 'paying', 'uploading', 'downloading', 'downloaded']
+const IN_FLIGHT_STATUSES: FileStatus[] = ['quoting', 'paying', 'uploading', 'downloading']
 
 /** Shape persisted to upload_history.json (kept for backwards compat) */
 export interface UploadHistoryEntry {
@@ -94,22 +99,32 @@ export const useFilesStore = defineStore('files', {
   }),
 
   getters: {
-    /** Rows that are actively transferring (pinned to top) */
-    pinnedFiles: (state) =>
-      state.files.filter(f =>
-        ['quoting', 'paying', 'uploading', 'downloading', 'downloaded'].includes(f.status),
-      ),
+    uploads: (state) => state.files.filter(f => f.kind === 'upload'),
+    downloads: (state) => state.files.filter(f => f.kind === 'download'),
+
+    /** Rows that are actively transferring (pinned to top of their table) */
+    pinnedUploads(): FileEntry[] {
+      return this.uploads.filter(f => ACTIVE_STATUSES.includes(f.status))
+    },
+    pinnedDownloads(): FileEntry[] {
+      return this.downloads.filter(f => ACTIVE_STATUSES.includes(f.status))
+    },
 
     /** Rows that are not active transfers (sorted normally) */
-    settledFiles: (state) =>
-      state.files.filter(f =>
-        !['quoting', 'paying', 'uploading', 'downloading', 'downloaded'].includes(f.status),
-      ),
+    settledUploads(): FileEntry[] {
+      return this.uploads.filter(f => !ACTIVE_STATUSES.includes(f.status))
+    },
+    settledDownloads(): FileEntry[] {
+      return this.downloads.filter(f => !ACTIVE_STATUSES.includes(f.status))
+    },
+
+    /** Any row in any table currently mid-transfer. Used by the header. */
+    pinnedFiles(): FileEntry[] {
+      return this.files.filter(f => ACTIVE_STATUSES.includes(f.status))
+    },
 
     hasActiveTransfers: (state) =>
-      state.files.some(f =>
-        ['quoting', 'paying', 'uploading', 'downloading'].includes(f.status),
-      ),
+      state.files.some(f => IN_FLIGHT_STATUSES.includes(f.status)),
   },
 
   actions: {
@@ -118,12 +133,13 @@ export const useFilesStore = defineStore('files', {
     async loadHistory() {
       try {
         const entries = await invoke<UploadHistoryEntry[]>('load_upload_history')
-        // Convert legacy history entries to unified FileEntry
         for (const e of entries) {
-          // Skip if we already have this address
-          if (this.files.some(f => f.address === e.address)) continue
+          // Skip if we already have this address in the uploads table — guards
+          // against double-loading on HMR without adding duplicates.
+          if (this.files.some(f => f.kind === 'upload' && f.address === e.address)) continue
           this.files.push({
             id: this.nextId++,
+            kind: 'upload',
             name: e.name,
             size_bytes: e.size_bytes,
             address: e.address,
@@ -141,9 +157,10 @@ export const useFilesStore = defineStore('files', {
     },
 
     async persistHistory() {
-      // Serialize settled complete entries back to legacy format
+      // Only uploads are persisted — downloads are intentionally in-memory
+      // so the table starts fresh each session.
       const entries: UploadHistoryEntry[] = this.files
-        .filter(f => f.status === 'complete' && f.address)
+        .filter(f => f.kind === 'upload' && f.status === 'complete' && f.address)
         .map(f => ({
           name: f.name,
           size_bytes: f.size_bytes,
@@ -166,11 +183,6 @@ export const useFilesStore = defineStore('files', {
       return this.files.find(f => f.id === id)
     },
 
-    findByAddress(address: string): FileEntry | undefined {
-      const norm = address.toLowerCase().replace(/^0x/, '')
-      return this.files.find(f => f.address?.toLowerCase().replace(/^0x/, '') === norm)
-    },
-
     updateEntry(id: number, updates: Partial<FileEntry>) {
       const entry = this.files.find(f => f.id === id)
       if (entry) Object.assign(entry, updates)
@@ -178,15 +190,25 @@ export const useFilesStore = defineStore('files', {
 
     removeEntry(id: number) {
       const idx = this.files.findIndex(f => f.id === id)
-      if (idx !== -1) {
-        this.files.splice(idx, 1)
-        this.persistHistory()
-      }
+      if (idx === -1) return
+      const wasUpload = this.files[idx].kind === 'upload'
+      this.files.splice(idx, 1)
+      if (wasUpload) this.persistHistory()
     },
 
-    clearCompleted() {
-      this.files = this.files.filter(f => f.status !== 'complete' && f.status !== 'failed')
+    /** Remove every upload row in a settled state. Persists. */
+    clearUploadHistory() {
+      this.files = this.files.filter(f =>
+        !(f.kind === 'upload' && (f.status === 'complete' || f.status === 'failed')),
+      )
       this.persistHistory()
+    },
+
+    /** Drop every download row that isn't mid-transfer. Memory-only, no persist. */
+    clearDownloads() {
+      this.files = this.files.filter(f =>
+        !(f.kind === 'download' && !IN_FLIGHT_STATUSES.includes(f.status)),
+      )
     },
 
     // ── Upload flow ──
@@ -195,6 +217,7 @@ export const useFilesStore = defineStore('files', {
       const id = this.nextId++
       this.files.unshift({
         id,
+        kind: 'upload',
         name,
         path,
         size_bytes,
@@ -428,27 +451,15 @@ export const useFilesStore = defineStore('files', {
     // ── Download flow ──
 
     /**
-     * Start a download. If the address already exists in the table,
-     * pin that row; otherwise create a new entry.
+     * Start a download row. Always creates a fresh entry in the downloads
+     * table — uploads are never mutated in place, so the upload history
+     * stays stable across download attempts.
      */
     startDownload(address: string, filename: string, dest_path: string): number {
-      const existing = this.findByAddress(address)
-      if (existing) {
-        // Re-downloading an existing upload — pin it to top
-        this.updateEntry(existing.id, {
-          status: 'downloading',
-          dest_path,
-          progress: 0,
-          transferStartedAt: Date.now(),
-          existedBeforeDownload: true,
-        })
-        return existing.id
-      }
-
-      // New download by address
       const id = this.nextId++
       this.files.unshift({
         id,
+        kind: 'download',
         name: filename,
         size_bytes: 0,
         address,
@@ -457,7 +468,6 @@ export const useFilesStore = defineStore('files', {
         progress: 0,
         date: new Date().toISOString(),
         transferStartedAt: Date.now(),
-        existedBeforeDownload: false,
       })
       return id
     },
@@ -516,30 +526,17 @@ export const useFilesStore = defineStore('files', {
     },
 
     /**
-     * Called when user clicks on a downloaded row to open the folder.
-     * Unpins the row and returns it to normal sort order.
+     * Called when the user clicks on a downloaded row to open the folder.
+     * Unpins the row and returns it to normal sort order. Downloads are
+     * memory-only, so there's nothing to persist.
      */
     acknowledgeDownload(id: number) {
       const entry = this.findById(id)
       if (!entry || entry.status !== 'downloaded') return
-
-      if (entry.existedBeforeDownload) {
-        // Was already in table — just unpin, return to complete
-        this.updateEntry(id, {
-          status: 'complete',
-          dest_path: undefined,
-          transferStartedAt: undefined,
-          existedBeforeDownload: undefined,
-        })
-      } else {
-        // Downloaded by address — keep as a complete entry
-        this.updateEntry(id, {
-          status: 'complete',
-          transferStartedAt: undefined,
-          existedBeforeDownload: undefined,
-        })
-        this.persistHistory()
-      }
+      this.updateEntry(id, {
+        status: 'complete',
+        transferStartedAt: undefined,
+      })
     },
 
     getDownloadDir(): string {
@@ -548,10 +545,9 @@ export const useFilesStore = defineStore('files', {
     },
 
     /**
-     * Download from a user-picked `.datamap` file on disk. Reads the JSON,
-     * reuses the entry for its address if one already exists, otherwise
-     * creates a fresh row. Returns the entry ID so callers can drive the
-     * actual transfer via `startRealDownload`.
+     * Download from a user-picked `.datamap` file on disk. Reads the JSON
+     * and creates a fresh download row. The matching upload row (if any)
+     * is left untouched so the uploads table stays stable.
      *
      * The output filename is derived from the datamap's basename with the
      * `.datamap` extension stripped — not a perfect round-trip (we don't
@@ -568,32 +564,15 @@ export const useFilesStore = defineStore('files', {
         return null
       }
 
-      // Derive the display/destination filename from the datamap's basename.
       const basename = datamapPath.split(/[\\/]/).pop() ?? 'download'
       const filename = basename.replace(/\.datamap$/i, '') || basename
-
-      // Compute the address the same way the backend does (sha256 of the
-      // serialized JSON) so we can find and reuse an existing entry.
       const address = await sha256Hex(json)
-
       const destPath = `${this.getDownloadDir()}/${filename}`
-      const existing = this.findByAddress(address)
-      if (existing) {
-        this.updateEntry(existing.id, {
-          status: 'downloading',
-          dest_path: destPath,
-          data_map_json: json,
-          data_map_file: datamapPath,
-          progress: 0,
-          transferStartedAt: Date.now(),
-          existedBeforeDownload: true,
-        })
-        return existing.id
-      }
 
       const id = this.nextId++
       this.files.unshift({
         id,
+        kind: 'download',
         name: filename,
         size_bytes: 0,
         address,
@@ -604,7 +583,6 @@ export const useFilesStore = defineStore('files', {
         progress: 0,
         date: new Date().toISOString(),
         transferStartedAt: Date.now(),
-        existedBeforeDownload: false,
       })
       return id
     },

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -48,6 +48,10 @@ export interface FileEntry {
   address?: string
   /** Serialized DataMap JSON — needed for download from network */
   data_map_json?: string
+  /** Absolute path to the persisted DataMap file on disk. Set for private
+   *  uploads performed by this app; `undefined` for legacy entries or for
+   *  rows that represent a pure download-by-address with no local datamap. */
+  data_map_file?: string
   /** Upload cost (ANT) */
   cost?: string
   /** Gas cost (ETH) */
@@ -77,6 +81,9 @@ export interface UploadHistoryEntry {
   address: string
   cost: string | null
   uploaded_at: string
+  /** Absolute path to the persisted DataMap file; `null`/absent for legacy
+   *  entries written before datamap persistence was added. */
+  data_map_file?: string | null
 }
 
 export const useFilesStore = defineStore('files', {
@@ -121,6 +128,7 @@ export const useFilesStore = defineStore('files', {
             size_bytes: e.size_bytes,
             address: e.address,
             cost: e.cost ?? undefined,
+            data_map_file: e.data_map_file ?? undefined,
             status: 'complete',
             date: e.uploaded_at,
           })
@@ -142,6 +150,7 @@ export const useFilesStore = defineStore('files', {
           address: f.address!,
           cost: f.cost ?? null,
           uploaded_at: f.date,
+          data_map_file: f.data_map_file ?? null,
         }))
 
       try {
@@ -307,7 +316,7 @@ export const useFilesStore = defineStore('files', {
             // can legitimately take many minutes for larger files. The CLI
             // (which works) also has no timeout here. Backend errors still
             // surface through invoke's rejection.
-            const result = await invoke<{ upload_id: string; data_map_json: string; address: string; chunks_stored: number }>('confirm_upload_merkle', {
+            const result = await invoke<{ upload_id: string; data_map_json: string; address: string; chunks_stored: number; data_map_file: string }>('confirm_upload_merkle', {
               uploadId,
               winnerPoolHash: payResult.winnerPoolHash,
             })
@@ -320,6 +329,7 @@ export const useFilesStore = defineStore('files', {
               progress: 100,
               address: result.address,
               data_map_json: result.data_map_json,
+              data_map_file: result.data_map_file,
               duration,
               transferStartedAt: undefined,
             })
@@ -350,7 +360,7 @@ export const useFilesStore = defineStore('files', {
           this.updateEntry(id, { status: 'uploading', progress: 0 })
 
           // No frontend timeout — see confirm_upload_merkle above for rationale.
-          const result = await invoke<{ upload_id: string; data_map_json: string; address: string; chunks_stored: number }>('confirm_upload', {
+          const result = await invoke<{ upload_id: string; data_map_json: string; address: string; chunks_stored: number; data_map_file: string }>('confirm_upload', {
             uploadId,
             txHashes,
           })
@@ -363,6 +373,7 @@ export const useFilesStore = defineStore('files', {
             progress: 100,
             address: result.address,
             data_map_json: result.data_map_json,
+            data_map_file: result.data_map_file,
             duration,
             transferStartedAt: undefined,
           })
@@ -456,6 +467,21 @@ export const useFilesStore = defineStore('files', {
       const entry = this.findById(id)
       if (!entry) return
 
+      // Lazy-load the serialized DataMap from disk if only its path is known —
+      // e.g. after restarting the app, history entries carry `data_map_file`
+      // but not the JSON itself. Without this, re-downloads fail even though
+      // we persisted everything we need.
+      if (!entry.data_map_json && entry.data_map_file) {
+        try {
+          const json = await invoke<string>('read_datamap_file', { path: entry.data_map_file })
+          this.updateEntry(id, { data_map_json: json })
+        } catch (e: any) {
+          this.updateEntry(id, { status: 'failed', error: `Failed to read datamap: ${e.message ?? e}` })
+          toasts.add('Cannot download: datamap file missing or unreadable', 'error')
+          return
+        }
+      }
+
       if (!entry.data_map_json) {
         this.updateEntry(id, { status: 'failed', error: 'No data map available — file must be uploaded first' })
         toasts.add('Cannot download: no data map for this address', 'error')
@@ -520,8 +546,82 @@ export const useFilesStore = defineStore('files', {
       const settings = useSettingsStore()
       return settings.downloadDir ?? '~/Downloads'
     },
+
+    /**
+     * Download from a user-picked `.datamap` file on disk. Reads the JSON,
+     * reuses the entry for its address if one already exists, otherwise
+     * creates a fresh row. Returns the entry ID so callers can drive the
+     * actual transfer via `startRealDownload`.
+     *
+     * The output filename is derived from the datamap's basename with the
+     * `.datamap` extension stripped — not a perfect round-trip (we don't
+     * know the original file type), but good enough as a starting name.
+     */
+    async downloadFromDatamapFile(datamapPath: string): Promise<number | null> {
+      const toasts = useToastStore()
+
+      let json: string
+      try {
+        json = await invoke<string>('read_datamap_file', { path: datamapPath })
+      } catch (e: any) {
+        toasts.add(`Could not read datamap: ${e.message ?? e}`, 'error')
+        return null
+      }
+
+      // Derive the display/destination filename from the datamap's basename.
+      const basename = datamapPath.split(/[\\/]/).pop() ?? 'download'
+      const filename = basename.replace(/\.datamap$/i, '') || basename
+
+      // Compute the address the same way the backend does (sha256 of the
+      // serialized JSON) so we can find and reuse an existing entry.
+      const address = await sha256Hex(json)
+
+      const destPath = `${this.getDownloadDir()}/${filename}`
+      const existing = this.findByAddress(address)
+      if (existing) {
+        this.updateEntry(existing.id, {
+          status: 'downloading',
+          dest_path: destPath,
+          data_map_json: json,
+          data_map_file: datamapPath,
+          progress: 0,
+          transferStartedAt: Date.now(),
+          existedBeforeDownload: true,
+        })
+        return existing.id
+      }
+
+      const id = this.nextId++
+      this.files.unshift({
+        id,
+        name: filename,
+        size_bytes: 0,
+        address,
+        data_map_json: json,
+        data_map_file: datamapPath,
+        status: 'downloading',
+        dest_path: destPath,
+        progress: 0,
+        date: new Date().toISOString(),
+        transferStartedAt: Date.now(),
+        existedBeforeDownload: false,
+      })
+      return id
+    },
   },
 })
+
+/** Compute `sha256(text)` as a `0x`-prefixed lowercase hex string. Matches
+ *  the address derivation in `src-tauri/src/autonomi_ops.rs` so the frontend
+ *  can recognise re-downloads of known uploads without a round-trip. */
+async function sha256Hex(text: string): Promise<string> {
+  const bytes = new TextEncoder().encode(text)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  const hex = Array.from(new Uint8Array(digest))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+  return `0x${hex}`
+}
 
 function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
   return new Promise((resolve, reject) => {

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -557,7 +557,7 @@ export const useFilesStore = defineStore('files', {
 
     getDownloadDir(): string {
       const settings = useSettingsStore()
-      return settings.downloadDir ?? settings.defaultDownloadDir ?? ''
+      return settings.downloadDir ?? ''
     },
 
     /**

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -557,7 +557,7 @@ export const useFilesStore = defineStore('files', {
 
     getDownloadDir(): string {
       const settings = useSettingsStore()
-      return settings.downloadDir ?? '~/Downloads'
+      return settings.downloadDir ?? settings.defaultDownloadDir ?? ''
     },
 
     /**

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -20,7 +20,6 @@ export const useSettingsStore = defineStore('settings', {
   state: () => ({
     storageDir: null as string | null,
     downloadDir: null as string | null,
-    defaultDownloadDir: null as string | null,
     daemonUrl: 'http://127.0.0.1:12500',
     bellOnCritical: false,
     earningsAddress: null as string | null,
@@ -56,12 +55,6 @@ export const useSettingsStore = defineStore('settings', {
         this.loaded = true
       } catch (e) {
         console.error('Failed to load config:', e)
-      }
-
-      try {
-        this.defaultDownloadDir = await invoke<string>('get_default_download_dir')
-      } catch (e) {
-        console.error('Failed to resolve default download dir:', e)
       }
     },
 

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -20,6 +20,7 @@ export const useSettingsStore = defineStore('settings', {
   state: () => ({
     storageDir: null as string | null,
     downloadDir: null as string | null,
+    defaultDownloadDir: null as string | null,
     daemonUrl: 'http://127.0.0.1:12500',
     bellOnCritical: false,
     earningsAddress: null as string | null,
@@ -55,6 +56,12 @@ export const useSettingsStore = defineStore('settings', {
         this.loaded = true
       } catch (e) {
         console.error('Failed to load config:', e)
+      }
+
+      try {
+        this.defaultDownloadDir = await invoke<string>('get_default_download_dir')
+      } catch (e) {
+        console.error('Failed to resolve default download dir:', e)
       }
     },
 

--- a/utils/payment.ts
+++ b/utils/payment.ts
@@ -13,6 +13,12 @@ const GAS_QUOTE_BASE = 25_000n
 const GAS_MERKLE_BASE = 180_000n
 const GAS_MERKLE_PER_POOL = 25_000n
 
+// Arbitrum produces blocks every ~250ms; viem's default 4s polling is tuned
+// for L1. Dropping to 2s reduces the window where we might miss a newly-mined
+// block and surface TransactionReceiptNotFoundError for txs that have
+// actually landed. viem's built-in retry handles RPC propagation lag.
+const RECEIPT_POLL_INTERVAL_MS = 2_000
+
 export type RawPayment = [string, string, string] // [quoteHash, rewardsAddress, amount]
 
 export interface PaymentResult {
@@ -103,7 +109,11 @@ export async function payForQuotes(
       ...accountOpt(),
     })
 
-    const receipt = await waitForTransactionReceipt(wagmiConfig, { hash, chainId: getActiveChainId() })
+    const receipt = await waitForTransactionReceipt(wagmiConfig, {
+      hash,
+      chainId: getActiveChainId(),
+      pollingInterval: RECEIPT_POLL_INTERVAL_MS,
+    })
     gasSpent += receiptGasCost(receipt)
 
     for (const [quoteHash] of batch) {
@@ -148,7 +158,11 @@ export async function payForMerkleTree(
     ...accountOpt(),
   })
 
-  const receipt = await waitForTransactionReceipt(wagmiConfig, { hash, chainId: getActiveChainId() })
+  const receipt = await waitForTransactionReceipt(wagmiConfig, {
+    hash,
+    chainId: getActiveChainId(),
+    pollingInterval: RECEIPT_POLL_INTERVAL_MS,
+  })
   gasSpent += receiptGasCost(receipt)
 
   // Extract winnerPoolHash from MerklePaymentMade event
@@ -201,7 +215,11 @@ async function ensureAllowance(wagmiConfig: any, needed: bigint): Promise<bigint
     ...accountOpt(),
   })
 
-  const receipt = await waitForTransactionReceipt(wagmiConfig, { hash, chainId: getActiveChainId() })
+  const receipt = await waitForTransactionReceipt(wagmiConfig, {
+    hash,
+    chainId: getActiveChainId(),
+    pollingInterval: RECEIPT_POLL_INTERVAL_MS,
+  })
   return receiptGasCost(receipt)
 }
 


### PR DESCRIPTION
## Summary

This PR bundles several related connection, upload, and download improvements:

### Connection
- Simplify connection state handling: remove per-attempt tracking and retry logic in `autonomi_ops.rs`, align with `ant-cli` behavior.
- Add a network connection status indicator in the header (`connecting` / `connected` / `failed`) with retry-on-failure, backed by a new `connectionStore`.
- Install the `connection-status` listener before fetching initial status so the `Idle → Connecting` transition can't be lost to a race, and treat `idle` like `connecting` so the header spinner shows from cold start.

### Uploads
- Streamline upload-quote logic in `stores/files.ts`: unify listener setup to prevent race conditions, remove redundant timeouts on long-running backend ops, and delegate shared logic to `getUploadQuote`.

### Downloads
- Add **Download by Datamap** flow: new dialog + backend methods to persist, read, and process `.datamap` files; file store lazy-loads JSON from disk and supports re-downloading known datamaps.
- Wait for an active network connection (with retry) before starting downloads so offline scenarios fail gracefully.
- Split uploads and downloads into separate in-memory tables — re-downloading no longer mutates upload-history rows; each table has its own sort state and clear control.
- Remove the `Source` column from the downloads table.

### Payment
- Reduce `waitForTransactionReceipt` polling interval to 2s to better match Arbitrum block time and avoid spurious `TransactionReceiptNotFoundError`.

## Test plan
- [ ] Cold start: header shows the connecting spinner immediately, then transitions to connected.
- [ ] Force a connection failure: header shows failed state and retry works.
- [ ] Trigger an upload quote on a large/slow upload: no premature timeout; cancel + re-trigger shows no listener races.
- [ ] Download by datamap: pick a `.datamap` file, confirm download starts and completes; re-download a known datamap.
- [ ] Start a download while offline: connection retry kicks in; surfaces a clean failure if it can't connect.
- [ ] Upload a file, then download it: rows appear in separate Uploads / Downloads tables with independent sort and clear.
- [ ] Run a payment flow on Arbitrum and confirm receipts are detected without the previous not-found errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)