### PR TITLE
feat(settings): light mode toggle + manual update check

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -7,6 +7,7 @@
 <script setup lang="ts">
 import { invoke } from '@tauri-apps/api/core'
 import { useWallet } from '~/composables/useWallet'
+import { useTheme } from '~/composables/useTheme'
 import { useSettingsStore } from '~/stores/settings'
 import { useUpdaterStore } from '~/stores/updater'
 import { useNodesStore } from '~/stores/nodes'
@@ -15,9 +16,13 @@ import { useConnectionStore } from '~/stores/connection'
 
 useHead({
   title: 'Autonomi',
-  htmlAttrs: { class: 'dark' },
   bodyAttrs: { class: 'bg-autonomi-dark text-autonomi-text' },
 })
+
+// Reactively sync html class + AppKit theme with settingsStore.themeMode.
+// Dark is the default — the class only flips once loadConfig resolves with
+// a persisted light preference, so the first paint always uses dark values.
+useTheme()
 
 // Load persisted config on startup, then init nodes (needs daemon URL from config)
 const settingsStore = useSettingsStore()

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,3 +1,18 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/*
+ * Light-mode overrides. Dark values live in tailwind.config.cjs as the
+ * fallback on each `var(--autonomi-*)`, so the absence of a `.light` class
+ * on <html> yields the dark palette without needing a `:root` block here.
+ *
+ * Toggle: add/remove `light` class on <html>. See composables/useTheme.ts.
+ */
+:root.light {
+  --autonomi-dark: #F8FAFC;
+  --autonomi-surface: #FFFFFF;
+  --autonomi-border: #CBD5E1;
+  --autonomi-text: #0F172A;
+  --autonomi-muted: #64748B;
+}

--- a/composables/useTheme.ts
+++ b/composables/useTheme.ts
@@ -1,0 +1,26 @@
+import { watchEffect } from 'vue'
+import { useSettingsStore } from '~/stores/settings'
+
+/**
+ * Syncs the theme class on <html> and the AppKit modal theme with the
+ * settings store. Tokens are defined as CSS custom properties in
+ * tailwind.config.cjs + assets/css/main.css — dark values are the fallback
+ * and `html.light` activates the light overrides.
+ */
+export function useTheme() {
+  const settings = useSettingsStore()
+  const nuxt = useNuxtApp()
+
+  watchEffect(() => {
+    if (typeof document === 'undefined') return
+    const root = document.documentElement
+    if (settings.themeMode === 'light') {
+      root.classList.add('light')
+    } else {
+      root.classList.remove('light')
+    }
+
+    const appkit = nuxt.$appkit as { setThemeMode?: (m: 'dark' | 'light') => void } | null
+    appkit?.setThemeMode?.(settings.themeMode)
+  })
+}

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -81,6 +81,27 @@
       </button>
     </div>
 
+    <!-- Appearance -->
+    <div class="flex items-center justify-between rounded-lg border border-autonomi-border p-4">
+      <div>
+        <h3 class="text-sm font-medium">Light Mode</h3>
+        <p class="text-xs text-autonomi-muted">Switch between dark and light themes</p>
+      </div>
+      <button
+        role="switch"
+        :aria-checked="settingsStore.themeMode === 'light'"
+        aria-label="Toggle light mode"
+        class="relative h-6 w-11 rounded-full transition-colors"
+        :class="settingsStore.themeMode === 'light' ? 'bg-autonomi-blue' : 'bg-autonomi-border'"
+        @click="settingsStore.setThemeMode(settingsStore.themeMode === 'light' ? 'dark' : 'light')"
+      >
+        <span
+          class="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white transition-transform"
+          :class="settingsStore.themeMode === 'light' ? 'translate-x-5' : ''"
+        />
+      </button>
+    </div>
+
     <!-- Advanced -->
     <div>
       <button
@@ -308,16 +329,35 @@
       </div>
     </div>
 
+    <!-- Software -->
+    <div class="rounded-lg border border-autonomi-border p-4">
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0 flex-1">
+          <h3 class="text-sm font-medium">Software</h3>
+          <div class="mt-1 flex items-baseline gap-2 text-xs">
+            <span class="text-autonomi-muted">Version</span>
+            <span class="font-mono">{{ appVersion }}</span>
+          </div>
+          <p v-if="lastCheckedLabel" class="mt-0.5 text-xs text-autonomi-muted">
+            Last checked {{ lastCheckedLabel }}
+          </p>
+        </div>
+        <button
+          :disabled="updaterStore.checking"
+          class="shrink-0 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted hover:text-autonomi-text disabled:opacity-50"
+          @click="checkForUpdates"
+        >
+          {{ updaterStore.checking ? 'Checking…' : 'Check for Updates' }}
+        </button>
+      </div>
+    </div>
+
     <!-- About -->
     <div class="rounded-lg border border-autonomi-border p-4">
       <h3 class="text-sm font-medium">About</h3>
       <div class="mt-3 space-y-1.5 text-xs">
         <div class="flex justify-between">
-          <span class="text-autonomi-muted">App version</span>
-          <span class="font-mono">{{ appVersion }}</span>
-        </div>
-        <div class="flex justify-between">
-          <span class="text-autonomi-muted">Node version</span>
+          <span class="text-autonomi-muted">Node daemon version</span>
           <span class="font-mono">{{ nodeVersion }}</span>
         </div>
       </div>
@@ -342,15 +382,56 @@ import { useSettingsStore } from '~/stores/settings'
 import { isValidEthAddress } from '~/utils/validators'
 import { useToastStore } from '~/stores/toasts'
 import { useErrorLogStore } from '~/stores/errorlog'
+import { useUpdaterStore } from '~/stores/updater'
 
 const settingsStore = useSettingsStore()
 const walletStore = useWalletStore()
 const nodesStore = useNodesStore()
 const toasts = useToastStore()
 const errorLogStore = useErrorLogStore()
+const updaterStore = useUpdaterStore()
 const showAdvanced = ref(false)
 const showLog = ref(false)
 const appVersion = ref('0.1.0')
+
+// Re-compute "Last checked X ago" every 30s so the label stays fresh while
+// the settings page is visible, without paying for a global ticker.
+const nowTick = ref(Date.now())
+let tickHandle: ReturnType<typeof setInterval> | null = null
+onMounted(() => {
+  tickHandle = setInterval(() => { nowTick.value = Date.now() }, 30_000)
+})
+onUnmounted(() => {
+  if (tickHandle) clearInterval(tickHandle)
+})
+
+const lastCheckedLabel = computed(() => {
+  const ts = updaterStore.lastCheckedAt
+  if (!ts) return ''
+  const secs = Math.max(0, Math.round((nowTick.value - ts) / 1000))
+  if (secs < 10) return 'just now'
+  if (secs < 60) return `${secs}s ago`
+  const mins = Math.round(secs / 60)
+  if (mins < 60) return `${mins} min ago`
+  const hours = Math.round(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  return `${days}d ago`
+})
+
+async function checkForUpdates() {
+  const result = await updaterStore.checkForUpdate()
+  if (!result.ok) {
+    toasts.add(result.error ?? 'Update check failed', 'error')
+    return
+  }
+  if (result.available) {
+    toasts.add(`Update available: v${updaterStore.version}`, 'info')
+    updaterStore.showDialog = true
+  } else {
+    toasts.add(`You're on the latest version (v${appVersion.value})`, 'info')
+  }
+}
 const nodeVersion = computed(() => {
   const versions = nodesStore.nodes.map(n => n.version).filter(Boolean)
   return versions.length > 0 ? versions[0] : '-'

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -22,6 +22,8 @@ pub struct AppConfig {
     pub indelible_url: Option<String>,
     #[serde(default)]
     pub indelible_api_key: Option<String>,
+    #[serde(default = "default_theme_mode")]
+    pub theme_mode: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,6 +51,10 @@ pub struct UploadHistoryEntry {
 pub struct UploadHistory {
     #[serde(default)]
     pub entries: Vec<UploadHistoryEntry>,
+}
+
+fn default_theme_mode() -> String {
+    "dark".to_string()
 }
 
 fn default_daemon_url() -> String {
@@ -94,6 +100,7 @@ impl Default for AppConfig {
             earnings_address: None,
             indelible_url: None,
             indelible_api_key: None,
+            theme_mode: default_theme_mode(),
         }
     }
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -35,10 +35,15 @@ pub struct FileMetaResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UploadHistoryEntry {
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub size_bytes: u64,
+    #[serde(default)]
     pub address: String,
+    #[serde(default)]
     pub cost: Option<String>,
+    #[serde(default)]
     pub uploaded_at: String,
     /// Absolute path to the serialized DataMap JSON file persisted alongside
     /// this history entry. `None` for legacy entries written before datamap

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -6,6 +6,8 @@ let _walletKey: string | null = null
 export function setDevnetWalletKey(key: string | null) { _walletKey = key }
 export function getDevnetWalletKey(): string | null { return _walletKey }
 
+export type ThemeMode = 'dark' | 'light'
+
 interface AppConfig {
   storage_dir: string | null
   download_dir: string | null
@@ -14,6 +16,7 @@ interface AppConfig {
   earnings_address: string | null
   indelible_url: string | null
   indelible_api_key: string | null
+  theme_mode: string
 }
 
 export const useSettingsStore = defineStore('settings', {
@@ -28,6 +31,7 @@ export const useSettingsStore = defineStore('settings', {
     indelibleConnected: false,
     indelibleOrgName: null as string | null,
     indelibleUserEmail: null as string | null,
+    themeMode: 'dark' as ThemeMode,
     loaded: false,
     // Devnet/testnet mode (auto-detected from manifest file)
     devnetActive: false,
@@ -52,6 +56,7 @@ export const useSettingsStore = defineStore('settings', {
         this.earningsAddress = config.earnings_address
         this.indelibleUrl = config.indelible_url
         this.indelibleApiKey = config.indelible_api_key
+        this.themeMode = config.theme_mode === 'light' ? 'light' : 'dark'
         this.loaded = true
       } catch (e) {
         console.error('Failed to load config:', e)
@@ -68,6 +73,7 @@ export const useSettingsStore = defineStore('settings', {
           earnings_address: this.earningsAddress,
           indelible_url: this.indelibleUrl,
           indelible_api_key: this.indelibleApiKey,
+          theme_mode: this.themeMode,
         }
         await invoke('save_config', { config })
       } catch (e) {
@@ -97,6 +103,11 @@ export const useSettingsStore = defineStore('settings', {
 
     async toggleBell() {
       this.bellOnCritical = !this.bellOnCritical
+      await this.saveConfig()
+    },
+
+    async setThemeMode(mode: ThemeMode) {
+      this.themeMode = mode
       await this.saveConfig()
     },
 

--- a/stores/updater.ts
+++ b/stores/updater.ts
@@ -1,6 +1,12 @@
 import { defineStore } from 'pinia'
 import { check, type Update } from '@tauri-apps/plugin-updater'
 
+export interface CheckResult {
+  ok: boolean
+  available: boolean
+  error?: string
+}
+
 export const useUpdaterStore = defineStore('updater', {
   state: () => ({
     available: false,
@@ -10,6 +16,8 @@ export const useUpdaterStore = defineStore('updater', {
     showDialog: false,
     downloadTotal: null as number | null,
     downloadedBytes: 0,
+    checking: false,
+    lastCheckedAt: null as number | null,
     _update: null as Update | null,
   }),
 
@@ -21,17 +29,25 @@ export const useUpdaterStore = defineStore('updater', {
   },
 
   actions: {
-    async checkForUpdate() {
+    async checkForUpdate(): Promise<CheckResult> {
+      if (this.checking) return { ok: false, available: false, error: 'Check already in progress' }
+      this.checking = true
       try {
         const update = await check()
+        this.lastCheckedAt = Date.now()
         if (update) {
           this.available = true
           this.version = update.version
           this.body = update.body ?? null
           this._update = update
+          return { ok: true, available: true }
         }
-      } catch (e) {
+        return { ok: true, available: false }
+      } catch (e: any) {
         console.error('Update check failed:', e)
+        return { ok: false, available: false, error: e?.message ?? String(e) }
+      } finally {
+        this.checking = false
       }
     },
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -10,13 +10,17 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        // Theme-aware tokens: resolved via CSS custom properties. Dark values
+        // are the fallback (no `light` class on <html>) so the app renders
+        // correctly before settings load. Light-mode overrides live in
+        // assets/css/main.css under `:root.light`.
         autonomi: {
           blue: '#4A9FE5',
-          dark: '#0A0F1C',
-          surface: '#141B2D',
-          border: '#1E2A3F',
-          text: '#E2E8F0',
-          muted: '#64748B',
+          dark: 'var(--autonomi-dark, #0A0F1C)',
+          surface: 'var(--autonomi-surface, #141B2D)',
+          border: 'var(--autonomi-border, #1E2A3F)',
+          text: 'var(--autonomi-text, #E2E8F0)',
+          muted: 'var(--autonomi-muted, #64748B)',
           success: '#22C55E',
           warning: '#EAB308',
           error: '#EF4444',


### PR DESCRIPTION
Rebased onto main (`32e7a94`, post PR #22 merge). Closes two TODO-list items from `MEMORY.md`, plus a small robustness fix.

## Summary

**1. Appearance — Light Mode toggle**
- New toggle in Settings flips dark ↔ light at runtime
- `autonomi-*` Tailwind tokens now resolve through CSS custom properties; dark is the fallback (no `light` class on `<html>`), light-mode values live in `assets/css/main.css` under `:root.light`
- Zero changes to component markup — every existing `bg-autonomi-dark`, `text-autonomi-text`, etc. remaps at runtime
- Preference persists via `load_config` / `save_config` (new `theme_mode` field, `#[serde(default)]` so existing configs upgrade cleanly)
- Small `useTheme` composable keeps `<html>.classList` and AppKit's `themeMode` in sync

**2. Software — Check for Updates**
- Settings now has a Software block with current version + "Check for Updates" button
- Previously the updater only ran once on `app.vue` mount — long-running sessions never saw new releases
- `updaterStore.checkForUpdate()` now tracks `checking` / `lastCheckedAt`, returns a `CheckResult` so the button can toast "Update available", "You're on the latest version", or the error
- Sidebar's existing "Update Available" button + the shared `UpdateDialog` keep working unchanged

**3. Config robustness — retrofit `#[serde(default)]` across `UploadHistoryEntry`** (second commit)
- Only `data_map_file` had the attribute. Every other field (`name`, `size_bytes`, `address`, `cost`, `uploaded_at`) lacked it.
- If a future field rename/removal or new required field is added without the attribute, the whole `upload_history.json` would fail to deserialize and user's history gets silently wiped on upgrade.
- Applying the attribute to every field makes the struct fully forward-compatible. Missing fields parse as their type's default (empty String, 0, None) rather than erroring out the whole load.

## Test plan

Automated:
- [x] `npx nuxi typecheck` — clean
- [x] `npm run test:run` — 19/19 passing
- [x] `cargo check` (src-tauri) — compiles clean

Manual (pre-merge):
- [ ] Settings → toggle Light Mode: background / cards / text all flip; WalletConnect modal matches; reload persists the choice
- [ ] Click Check for Updates — toast "You're on the latest version" on latest, "Update available" if stale
- [ ] Upgrade an app that has an older `upload_history.json` (missing `data_map_file`) — history loads, rows show with empty datamap link

## Notes

- First paint in light mode briefly shows dark values until `loadConfig` resolves. Acceptable for v1; can be fixed later with a localStorage mirror.
- PR branched onto post-#22 main so the download-by-datamap / connection UX work is included in the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)