### PR TITLE
chore: bump version to 0.6.5-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.4",
+  "version": "0.6.5-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.4"
+version = "0.6.5-rc.1"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.4"
+version = "0.6.5-rc.1"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.4",
+  "version": "0.6.5-rc.1",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release candidate tag for v0.6.5. Cuts a GitHub pre-release to validate the release-workflow fix that landed in #23 without serving a broken updater manifest to real users on the auto-updater path.

## What happens next

1. Merge this PR into main.
2. Push tag \`v0.6.5-rc.1\`.
3. The release workflow runs — expect the new \`compose-latest-json\` job to fail fast if anything contains \`__VERSION__\` or \`/releases/download/untagged-\`.
4. Inspect the generated draft release manually: latest.json should have all 9 platform entries pointing at \`/releases/download/v0.6.5-rc.1/…\`.
5. If clean, promote by cutting \`v0.6.5\` (straight tag, same workflow re-runs, ships as the latest release).

## Includes (via recent merges into main)

- #22 feat: network connection UX, download-by-datamap, and connect/upload simplification
- #23 ci: fix latest.json generation in release workflow
- #24 feat(settings): light mode toggle + manual update check + UploadHistoryEntry schema forward-compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)