### PR TITLE
fix(download): drop 5-min frontend timeout that wrongly failed completed downloads

### DIFF
--- a/stores/files.ts
+++ b/stores/files.ts
@@ -514,6 +514,12 @@ export const useFilesStore = defineStore('files', {
         // Local datamap takes priority — it's fast and doesn't require the
         // DataMap chunk to exist on-network. Fall back to a public fetch by
         // address when we have neither JSON nor a local file.
+        //
+        // No frontend timeout: large downloads can legitimately take many
+        // minutes, and the backend has no timeout either. A UI-side timeout
+        // marks the row Failed while the Rust download keeps running and
+        // writes the file successfully. Backend errors still surface through
+        // invoke's rejection.
         const request = entry.data_map_json
           ? invoke('download_file', {
               dataMapJson: entry.data_map_json,
@@ -524,7 +530,7 @@ export const useFilesStore = defineStore('files', {
               destPath: entry.dest_path,
             })
 
-        await withTimeout(request, 300_000, 'Download timed out')
+        await request
 
         const duration = entry.transferStartedAt
           ? Math.round((Date.now() - entry.transferStartedAt) / 1000)


### PR DESCRIPTION
## Summary
- Remove the 5-minute `withTimeout` wrapper around the download `invoke()` in `stores/files.ts`. Large downloads can legitimately exceed 5 min; the backend has no timeout and kept streaming chunks and writing the file successfully while the UI had already flipped the row to **Failed: Download timed out**.
- Matches the no-frontend-timeout pattern already used for uploads (`confirm_upload` / `confirm_upload_merkle`) — same rationale, same fix.
- `withTimeout` is still used for the two wallet-approval paths, where a 5-min cap is appropriate because the user is interactively approving a tx.

## Test plan
- [ ] Download a large file whose transfer takes >5 min; confirm the row ends up **Downloaded**, not **Failed**.
- [ ] Trigger a backend download error (e.g. bad datamap) and confirm the row still flips to **Failed** with the backend error message — rejection still surfaces.
- [ ] Vitest: `npx vitest run` — 19 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)