### PR TITLE
ci: override MSI wix.version for pre-release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,9 +352,34 @@ jobs:
         shell: pwsh
         run: |
           $signCmd = (Resolve-Path "sign.cmd").Path -replace '\\', '/'
-          # Tauri replaces %1 in signCommand with the file path, then executes the
-          # result as a shell command. sign.cmd receives that path as its first arg (%1).
-          npx tauri build --bundles msi,updater --config "{`"bundle`":{`"windows`":{`"signCommand`":`"$signCmd %1`"}}}"
+
+          # Windows MSI versioning rejects non-numeric pre-release identifiers
+          # (e.g. `0.6.5-rc.1`), because the MSI format inherits the 4-part
+          # numeric PE resource version. Tauri errors with: "optional pre-release
+          # identifier in app version must be numeric-only". Override wix.version
+          # with just the `major.minor.patch` portion so `rc.N` / `beta.N` tags
+          # can still ship an MSI. The app's self-reported version (CARGO_PKG_VERSION
+          # / tauri.conf.json) keeps the full semver — the override only affects
+          # MSI metadata (what Windows' Add/Remove Programs displays).
+          $conf = Get-Content src-tauri\tauri.conf.json | ConvertFrom-Json
+          $msiVersion = ($conf.version -split '-')[0]
+          Write-Host "MSI wix.version override: $msiVersion (from tauri.conf.json '$($conf.version)')"
+
+          $overrideJson = @{
+            bundle = @{
+              windows = @{
+                signCommand = "$signCmd %1"
+                wix = @{
+                  version = $msiVersion
+                }
+              }
+            }
+          } | ConvertTo-Json -Depth 5 -Compress
+
+          # Tauri replaces %1 in signCommand with the file path, then executes
+          # the result as a shell command. sign.cmd receives that path as its
+          # first arg (%1).
+          npx tauri build --bundles msi,updater --config $overrideJson
           Remove-Item -Path "sign.cmd" -ErrorAction SilentlyContinue
 
       - name: verify MSI signature


### PR DESCRIPTION
## Summary

Tauri's MSI bundler rejects non-numeric pre-release identifiers, which blocked the v0.6.5-rc.1 release workflow run (mac + linux built fine, but Windows MSI errored with _"optional pre-release identifier in app version must be numeric-only"_). With Windows failing, \`compose-latest-json\` (which needs: build-windows) never ran, so PR #23's release-workflow fix was not actually validated.

## Fix

Compute \`wix.version\` at build time by stripping the pre-release suffix from \`tauri.conf.json\`'s version — \`0.6.5-rc.1\` → \`0.6.5\` for MSI metadata only. Passed into \`tauri build\` via the same \`--config\` override that already sets \`signCommand\`.

- Override is Windows-only (MSI inherits the 4-part numeric PE resource version, a Windows constraint).
- App's embedded semver is untouched — \`env!("CARGO_PKG_VERSION")\`, the updater comparator, and mac/linux bundle versions all still see \`0.6.5-rc.1\`.
- Only affects what Windows' Add/Remove Programs displays.

## After this merges

1. Delete the failed draft release and the \`v0.6.5-rc.1\` tag.
2. Re-push the tag to re-run the release workflow.
3. Inspect the produced \`latest.json\` against PR #23's integrity assertions (no \`__VERSION__\`, no \`/releases/download/untagged-\`, 9 platform entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)