### PR TITLE
chore: bump version to 0.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.5-rc.1",
+  "version": "0.6.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.5-rc.1"
+version = "0.6.5"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.5-rc.1"
+version = "0.6.5"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.5-rc.1",
+  "version": "0.6.5",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Promotes v0.6.5-rc.1 to a full release. rc.1's draft produced a clean \`latest.json\` (all 9 platform entries, correct URLs, no \`__VERSION__\` / \`untagged-*\` leakage) which validated the release-workflow fix in #23.

## What this release includes

- #22 — Network connection UX, download-by-datamap, connect/upload simplification
- #23 — Release workflow fix for \`latest.json\` generation
- #24 — Settings: light-mode toggle + manual update check + UploadHistoryEntry schema forward-compat
- #26 — Download: drop 5-min frontend timeout that wrongly flagged completed downloads as failed
- #27 — MSI wix.version override so pre-release tags can ship the Windows installer

## After merge

1. Pull main, push tag \`v0.6.5\`.
2. Release workflow runs, produces a draft release with all platform installers + \`latest.json\`.
3. Publish the draft → auto-updater serves v0.6.5 to all v0.6.4 users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)