### PR TITLE
fix(updater): point endpoint at correct repo and humanise errors

### DIFF
--- a/components/ToastContainer.vue
+++ b/components/ToastContainer.vue
@@ -27,6 +27,7 @@ function toastClass(level: string) {
   switch (level) {
     case 'error': return 'border-autonomi-error bg-red-950 text-autonomi-error'
     case 'warning': return 'border-autonomi-warning bg-yellow-950 text-autonomi-warning'
+    case 'success': return 'border-green-500/40 bg-green-950 text-green-400'
     default: return 'border-autonomi-blue bg-blue-950 text-autonomi-blue'
   }
 }
@@ -35,6 +36,7 @@ function toastIcon(level: string) {
   switch (level) {
     case 'error': return '✖'
     case 'warning': return '⚠'
+    case 'success': return '✓'
     default: return 'ℹ'
   }
 }

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -429,7 +429,7 @@ async function checkForUpdates() {
     toasts.add(`Update available: v${updaterStore.version}`, 'info')
     updaterStore.showDialog = true
   } else {
-    toasts.add(`You're on the latest version (v${appVersion.value})`, 'info')
+    toasts.add(`You're on the latest version (v${appVersion.value})`, 'success')
   }
 }
 const nodeVersion = computed(() => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/WithAutonomi/ant-gui/releases/latest/download/latest.json"
+        "https://github.com/WithAutonomi/ant-ui/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEIzQkZDNDhGOUU3NkMyRDEKUldUUnduYWVqOFMvc3dXbHFiK2F4SGdHNVlCV2l3Q2RoMG9ENW8zNTRGdTl6WmRrWC9iZno2RloK"
     }

--- a/stores/toasts.ts
+++ b/stores/toasts.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { useErrorLogStore } from './errorlog'
 
-export type ToastLevel = 'info' | 'warning' | 'error'
+export type ToastLevel = 'info' | 'success' | 'warning' | 'error'
 
 export interface Toast {
   id: number
@@ -13,6 +13,7 @@ let nextId = 0
 
 const DURATIONS: Record<ToastLevel, number> = {
   info: 3000,
+  success: 3000,
   warning: 5000,
   error: 8000,
 }

--- a/stores/toasts.ts
+++ b/stores/toasts.ts
@@ -28,9 +28,10 @@ export const useToastStore = defineStore('toasts', {
       const id = nextId++
       this.toasts.push({ id, message, level })
 
-      // Also log to persistent error log
+      // Also log to persistent error log. 'success' isn't a diagnostic
+      // level — downgrade it to 'info' for the log.
       const errorLog = useErrorLogStore()
-      errorLog.log(level, 'toast', message)
+      errorLog.log(level === 'success' ? 'info' : level, 'toast', message)
 
       // Keep max 5
       if (this.toasts.length > 5) {

--- a/stores/updater.ts
+++ b/stores/updater.ts
@@ -7,6 +7,19 @@ export interface CheckResult {
   error?: string
 }
 
+function humaniseUpdateError(raw: string): string {
+  if (/did not respond with a successful status code|404|not found/i.test(raw)) {
+    return 'Cannot find latest version'
+  }
+  if (/network|fetch|connect|dns|timeout/i.test(raw)) {
+    return 'Could not reach update server'
+  }
+  if (/signature|invalid key|verify/i.test(raw)) {
+    return 'Update manifest failed signature check — please report'
+  }
+  return `Update check failed: ${raw}`
+}
+
 export const useUpdaterStore = defineStore('updater', {
   state: () => ({
     available: false,
@@ -45,7 +58,8 @@ export const useUpdaterStore = defineStore('updater', {
         return { ok: true, available: false }
       } catch (e: any) {
         console.error('Update check failed:', e)
-        return { ok: false, available: false, error: e?.message ?? String(e) }
+        const raw = e?.message ?? String(e)
+        return { ok: false, available: false, error: humaniseUpdateError(raw) }
       } finally {
         this.checking = false
       }

--- a/stores/updater.ts
+++ b/stores/updater.ts
@@ -8,10 +8,13 @@ export interface CheckResult {
 }
 
 function humaniseUpdateError(raw: string): string {
-  if (/did not respond with a successful status code|404|not found/i.test(raw)) {
+  // tauri-plugin-updater surfaces `ReleaseNotFound` for any non-success HTTP
+  // response (404, 403, 500, …) with this exact string, so pin to it. The
+  // other phrases catch older plugin versions and direct log messages.
+  if (/could not fetch a valid release json|release not found|did not respond with a successful status code|\b404\b|\bnot found\b/i.test(raw)) {
     return 'Cannot find latest version'
   }
-  if (/network|fetch|connect|dns|timeout/i.test(raw)) {
+  if (/network|connect|dns|timeout|tcp|tls|unreachable/i.test(raw)) {
     return 'Could not reach update server'
   }
   if (/signature|invalid key|verify/i.test(raw)) {


### PR DESCRIPTION
## Summary
- Fix updater endpoint URL: was `WithAutonomi/ant-gui` (404), now `WithAutonomi/ant-ui` — this is why internal users on 0.6.2/0.6.4 never saw update banners
- Humanise `updaterStore.checkForUpdate()` errors (404/network/signature → friendly strings) instead of surfacing raw tauri-plugin-updater messages
- Add a green `success` toast variant and use it for "You're on the latest version"

## Caveat
The endpoint is baked into each binary at build time, so users already on 0.6.2/0.6.4/0.6.5 will keep hitting 404 silently. They need a manual distribution of 0.6.6 before auto-updates start working for them.

## Test plan
- [ ] Local dev build starts and reaches the network
- [ ] Settings → Check for Updates on a 0.6.5 binary shows "Cannot find latest version" (the humanised 404)
- [ ] Settings → Check for Updates on latest build hitting the correct endpoint shows a green "You're on the latest version" toast when no update is available
- [ ] Sidebar update banner appears when a newer release exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)