### PR TITLE
chore: bump version to 0.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Bump `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json` from 0.6.5 → 0.6.6

## ⚠️ Do not merge until #29 lands
This PR only contains the version bump. The updater endpoint fix lives in #29 — if that doesn't merge first, 0.6.6 will ship with the same broken `WithAutonomi/ant-gui` URL as 0.6.5. Rebase this branch on `main` after #29 merges, then merge to trigger the release CI.

## Test plan
- [ ] #29 merged to main first
- [ ] Rebase and verify the four version strings all match 0.6.6
- [ ] On merge, confirm `v0.6.6` tag push triggers the release workflow and produces draft release with correct `latest.json` at `WithAutonomi/ant-ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)