### PR TITLE
feat: wire public-visibility uploads through the external-signer flow

### DIFF
--- a/components/files/UploadConfirmDialog.vue
+++ b/components/files/UploadConfirmDialog.vue
@@ -138,21 +138,26 @@
                 </p>
               </button>
 
-              <!-- Public (disabled — not yet implemented in backend) -->
+              <!-- Public -->
               <button
                 type="button"
-                disabled
-                aria-disabled="true"
-                title="Public uploads are not yet available"
-                class="flex-1 cursor-not-allowed rounded-lg border border-autonomi-border p-3 text-left opacity-50"
+                class="flex-1 rounded-lg border p-3 text-left transition-all"
+                :class="visibility === 'public'
+                  ? 'border-autonomi-blue bg-autonomi-blue/10'
+                  : 'border-autonomi-border hover:border-autonomi-blue/30'"
+                @click="visibility = 'public'"
               >
                 <div class="flex items-center gap-2">
-                  <div class="flex h-4 w-4 items-center justify-center rounded-full border-2 border-autonomi-muted" />
+                  <div
+                    class="flex h-4 w-4 items-center justify-center rounded-full border-2"
+                    :class="visibility === 'public' ? 'border-autonomi-blue' : 'border-autonomi-muted'"
+                  >
+                    <div v-if="visibility === 'public'" class="h-2 w-2 rounded-full bg-autonomi-blue" />
+                  </div>
                   <span class="text-sm font-medium">Public</span>
-                  <span class="ml-auto rounded bg-autonomi-border/60 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-autonomi-muted">Coming soon</span>
                 </div>
                 <p class="mt-1.5 pl-6 text-xs text-autonomi-muted">
-                  Not yet available. All uploads are currently private.
+                  Data map is published to the network. Share a single address so anyone can retrieve the file.
                 </p>
               </button>
             </div>
@@ -219,6 +224,12 @@ const emit = defineEmits<{
   approve: [options: { visibility: 'private' | 'public'; paymentMode: 'regular' | 'merkle' }]
   cancelUpload: []
   close: []
+  /**
+   * Fired whenever the user flips the Private/Public selector. The parent
+   * re-quotes against the network since the prepared payment batch differs
+   * — public uploads pay for one extra chunk (the data map itself).
+   */
+  'visibility-change': [visibility: 'private' | 'public']
 }>()
 
 const filesStore = useFilesStore()
@@ -295,6 +306,10 @@ const effectivePaymentMode = computed<'regular' | 'merkle' | null>(() => {
 })
 
 const visibility = ref<'private' | 'public'>('private')
+
+watch(visibility, (val) => {
+  emit('visibility-change', val)
+})
 
 const approveButtonLabel = computed(() => {
   const n = needsApprovalEntries.value.length

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -136,7 +136,16 @@
                 </td>
                 <td class="px-4 py-2.5">
                   <span
-                    v-if="file.data_map_file"
+                    v-if="file.public_address"
+                    class="inline-flex cursor-pointer items-center gap-1.5 font-mono text-xs text-autonomi-blue hover:text-autonomi-blue/80"
+                    title="Public upload — click to copy the shareable network address"
+                    @click.stop="copyPublicAddress(file.public_address)"
+                  >
+                    <span class="rounded bg-autonomi-blue/15 px-1 py-px text-[9px] font-sans uppercase tracking-wider">Public</span>
+                    {{ truncateAddress(file.public_address, 8, 6) }}
+                  </span>
+                  <span
+                    v-else-if="file.data_map_file"
                     class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
                     :title="`Reveal ${datamapBasename(file.data_map_file)} in its folder`"
                     @click.stop="openFolder(file.data_map_file)"
@@ -294,6 +303,7 @@
       @approve="approveUpload"
       @cancel-upload="cancelPendingUploads"
       @close="closeUploadDialog"
+      @visibility-change="onVisibilityChange"
     />
 
     <FilesCostEstimateDialog
@@ -655,6 +665,16 @@ function reopenUploadDialog(id: number) {
   showUploadConfirm.value = true
 }
 
+// Public uploads pay for one extra chunk (the data map itself), so the quote
+// has to be redone when the user flips visibility. We update each selected
+// entry; the scheduler re-quotes any that aren't yet awaiting_approval, and
+// the Approve handler picks up the final visibility regardless.
+function onVisibilityChange(visibility: 'private' | 'public') {
+  for (const id of selectedFileIds.value) {
+    filesStore.updateEntry(id, { visibility })
+  }
+}
+
 function approveUpload(options: { visibility: 'private' | 'public'; paymentMode: 'regular' | 'merkle' }) {
   showUploadConfirm.value = false
   const ids = selectedFileIds.value.slice()
@@ -1006,6 +1026,11 @@ async function openFolder(path: string) {
 function copyAddress(addr: string) {
   navigator.clipboard.writeText(addr)
   toastStore.add('Address copied to clipboard', 'info')
+}
+
+function copyPublicAddress(addr: string) {
+  navigator.clipboard.writeText(addr)
+  toastStore.add('Public address copied — share to let others download this file', 'info')
 }
 
 function datamapBasename(path: string): string {

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -1,6 +1,6 @@
 use ant_core::data::{
     Client, ClientConfig, CustomNetwork, DataMap, DownloadEvent, EvmNetwork, ExternalPaymentInfo,
-    PaymentMode, PreparedUpload, UploadCostEstimate, UploadEvent,
+    PaymentMode, PreparedUpload, UploadCostEstimate, UploadEvent, Visibility,
 };
 use evmlib::common::{QuoteHash, TxHash};
 use evmlib::wallet::Wallet;
@@ -167,12 +167,21 @@ pub struct UploadResult {
     /// This is the user-visible handle for private uploads — without it, the
     /// data is unreachable after the app restarts.
     pub data_map_file: String,
+    /// On-network chunk address of the published `DataMap`, set only for
+    /// public uploads. A shareable 32-byte hex string anyone can pass to
+    /// `download_public` to retrieve the file without a local datamap.
+    pub public_address: Option<String>,
 }
 
 #[derive(Deserialize)]
 pub struct StartUploadRequest {
     pub files: Vec<String>,
     pub upload_id: String,
+    /// Upload visibility — "private" (default) keeps the data map local,
+    /// "public" bundles the serialized data map into the payment batch so
+    /// a single on-network chunk address can be shared for retrieval.
+    #[serde(default)]
+    pub visibility: Option<String>,
 }
 
 // ── Progress forwarders ──
@@ -568,16 +577,21 @@ pub async fn start_upload(
     }
     let path = canonical;
 
+    let visibility = match request.visibility.as_deref() {
+        Some("public") => Visibility::Public,
+        _ => Visibility::Private,
+    };
+
     // Phase 1: Encrypt file and prepare chunks (gets quotes from network).
+    // For a public upload, ant-core bundles the serialized DataMap into the
+    // payment batch as one extra chunk so it's paid for and stored alongside
+    // the data chunks. The resulting chunk address is surfaced via
+    // `FileUploadResult.data_map_address` after finalize.
     // The forwarder turns ant-core's UploadEvent stream (Encrypting / Encrypted /
     // ChunkQuoted) into Tauri `upload-progress` events keyed by the row id.
     let progress_tx = spawn_upload_progress_forwarder(app.clone(), request.upload_id.clone());
     let prepared = client
-        .file_prepare_upload_with_progress(
-            &path,
-            ant_core::data::Visibility::Private,
-            Some(progress_tx),
-        )
+        .file_prepare_upload_with_progress(&path, visibility, Some(progress_tx))
         .await
         .map_err(|e| format!("Failed to prepare upload: {e}"))?;
 
@@ -773,6 +787,9 @@ pub async fn confirm_upload(
     let data_map_file = crate::config::write_datamap_for(&file_name, &data_map_json)?
         .to_string_lossy()
         .into_owned();
+    let public_address = result
+        .data_map_address
+        .map(|addr| format!("0x{}", hex::encode(addr)));
 
     app.emit(
         "upload-progress",
@@ -790,6 +807,7 @@ pub async fn confirm_upload(
         address,
         chunks_stored: result.chunks_stored,
         data_map_file,
+        public_address,
     })
 }
 
@@ -835,6 +853,9 @@ pub async fn confirm_upload_merkle(
     let data_map_file = crate::config::write_datamap_for(&file_name, &data_map_json)?
         .to_string_lossy()
         .into_owned();
+    let public_address = result
+        .data_map_address
+        .map(|addr| format!("0x{}", hex::encode(addr)));
 
     app.emit(
         "upload-progress",
@@ -852,6 +873,7 @@ pub async fn confirm_upload_merkle(
         address,
         chunks_stored: result.chunks_stored,
         data_map_file,
+        public_address,
     })
 }
 
@@ -960,6 +982,9 @@ pub async fn wallet_upload(
     let data_map_file = crate::config::write_datamap_for(&file_name, &data_map_json)?
         .to_string_lossy()
         .into_owned();
+    let public_address = result
+        .data_map_address
+        .map(|addr| format!("0x{}", hex::encode(addr)));
 
     app.emit(
         "upload-progress",
@@ -977,6 +1002,7 @@ pub async fn wallet_upload(
         address,
         chunks_stored: result.chunks_stored,
         data_map_file,
+        public_address,
     })
 }
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -61,6 +61,10 @@ pub struct UploadHistoryEntry {
     /// uploads where no payment tx ran.
     #[serde(default)]
     pub gas_cost: Option<String>,
+    /// On-network chunk address of the published `DataMap` for public
+    /// uploads. `None` for private uploads and for legacy entries.
+    #[serde(default)]
+    pub public_address: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -81,6 +81,10 @@ export interface FileEntry {
   size_bytes: number
   /** Network address (hex) — for display / sharing */
   address?: string
+  /** On-network chunk address of the published DataMap, set for public
+   *  uploads. This is the single shareable handle — anyone with it can
+   *  fetch the DataMap via `download_public` and decrypt the file. */
+  public_address?: string
   /** Serialized DataMap JSON — needed for download from network */
   data_map_json?: string
   /** Absolute path to the persisted DataMap file on disk. Set for private
@@ -156,6 +160,9 @@ export interface UploadHistoryEntry {
    *  written before gas was tracked, or for already-stored uploads where
    *  no payment tx ran. */
   gas_cost?: string | null
+  /** On-network chunk address of the published DataMap for public uploads.
+   *  `null`/absent for private uploads and for legacy entries. */
+  public_address?: string | null
 }
 
 export const useFilesStore = defineStore('files', {
@@ -241,6 +248,7 @@ export const useFilesStore = defineStore('files', {
             name: e.name,
             size_bytes: e.size_bytes,
             address: e.address,
+            public_address: e.public_address ?? undefined,
             cost: e.cost ?? undefined,
             gas_cost: e.gas_cost ?? undefined,
             data_map_file: e.data_map_file ?? undefined,
@@ -268,6 +276,7 @@ export const useFilesStore = defineStore('files', {
           uploaded_at: f.date,
           data_map_file: f.data_map_file ?? null,
           gas_cost: f.gas_cost ?? null,
+          public_address: f.public_address ?? null,
         }))
 
       try {
@@ -470,8 +479,23 @@ export const useFilesStore = defineStore('files', {
     /** Get a real network quote for a file. Parks a `PreparedUpload` in the
      *  daemon. Used internally by `startRealUpload` after the user clicks
      *  Confirm — not for display. For pre-upload cost display, use
-     *  `estimateFileCost` instead. */
-    async getUploadQuote(path: string, transferRowId?: number): Promise<UploadQuote | null> {
+     *  `estimateFileCost` instead.
+     *
+     *  `visibility` controls whether ant-core bundles the serialized DataMap
+     *  into the payment batch. Public quotes cost slightly more than private
+     *  ones because the DataMap is billed as one extra chunk. A quote obtained
+     *  with one visibility must be finalized with the same visibility — the
+     *  prepared chunks on the backend differ — so callers re-quote if the
+     *  user changes their selection.
+     *
+     *  `transferRowId` registers the transfer_id → row mapping before invoke
+     *  so quote-phase upload-progress events route to the right uploads-table
+     *  row from the very first event. */
+    async getUploadQuote(
+      path: string,
+      visibility: 'private' | 'public' = 'private',
+      transferRowId?: number,
+    ): Promise<UploadQuote | null> {
       const uploadId = `quote-${Date.now()}-${Math.random().toString(36).slice(2)}`
 
       // If the caller has a row to drive a progress bar on, register the
@@ -510,7 +534,7 @@ export const useFilesStore = defineStore('files', {
         })
 
         await invoke('start_upload', {
-          request: { files: [path], upload_id: uploadId },
+          request: { files: [path], upload_id: uploadId, visibility },
         })
 
         const quote = await quotePromise
@@ -594,7 +618,10 @@ export const useFilesStore = defineStore('files', {
         let quote: UploadQuote
 
         if (preQuote) {
-          // Use pre-obtained quote (from dialog phase)
+          // Use pre-obtained quote (from dialog phase). The caller is
+          // responsible for ensuring its visibility matches `options.visibility`
+          // — `pages/files.vue` drops the pre-quote when the user changes
+          // visibility so we always re-quote with the matching batch.
           uploadId = preQuote.upload_id
           quote = preQuote
           this.updateEntry(id, { cost: preQuote.total_cost_display })
@@ -603,7 +630,7 @@ export const useFilesStore = defineStore('files', {
           // there is a single implementation of the listen+invoke dance.
           if (!entry.path) throw new Error('Upload entry has no file path')
           this.updateEntry(id, { status: 'quoting' })
-          const fresh = await this.getUploadQuote(entry.path, id)
+          const fresh = await this.getUploadQuote(entry.path, options.visibility, id)
           if (!fresh) throw new Error('Failed to get quote from network')
           uploadId = fresh.upload_id
           quote = fresh
@@ -644,7 +671,7 @@ export const useFilesStore = defineStore('files', {
             // can legitimately take many minutes for larger files. The CLI
             // (which works) also has no timeout here. Backend errors still
             // surface through invoke's rejection.
-            const result = await invoke<{ upload_id: string; data_map_json: string; address: string; chunks_stored: number; data_map_file: string }>('confirm_upload_merkle', {
+            const result = await invoke<{ upload_id: string; data_map_json: string; address: string; chunks_stored: number; data_map_file: string; public_address: string | null }>('confirm_upload_merkle', {
               uploadId,
               winnerPoolHash: payResult.winnerPoolHash,
             })
@@ -656,6 +683,7 @@ export const useFilesStore = defineStore('files', {
               status: 'complete',
               progress: 100,
               address: result.address,
+              public_address: result.public_address ?? undefined,
               data_map_json: result.data_map_json,
               data_map_file: result.data_map_file,
               duration,
@@ -688,7 +716,7 @@ export const useFilesStore = defineStore('files', {
           this.updateEntry(id, { status: 'uploading', progress: 0 })
 
           // No frontend timeout — see confirm_upload_merkle above for rationale.
-          const result = await invoke<{ upload_id: string; data_map_json: string; address: string; chunks_stored: number; data_map_file: string }>('confirm_upload', {
+          const result = await invoke<{ upload_id: string; data_map_json: string; address: string; chunks_stored: number; data_map_file: string; public_address: string | null }>('confirm_upload', {
             uploadId,
             txHashes,
           })
@@ -700,6 +728,7 @@ export const useFilesStore = defineStore('files', {
             status: 'complete',
             progress: 100,
             address: result.address,
+            public_address: result.public_address ?? undefined,
             data_map_json: result.data_map_json,
             data_map_file: result.data_map_file,
             duration,


### PR DESCRIPTION
## Summary

Re-enables the Public visibility option in the upload dialog (currently disabled with "Coming soon") by threading a `visibility` flag through the external-signer flow. Public uploads yield a single shareable on-network chunk address (the published DataMap); the `public_address` is surfaced on `UploadResult` so the UI can show / copy it.

- **Why not `data_map_store` after `finalize_upload`?** That path hard-requires `require_wallet()?`; ant-gui has no Rust-side wallet on the WalletConnect path — all signing goes via the frontend. `store_paid_chunks` and friends are `pub(crate)`. Upstream's `file_prepare_upload_with_visibility` bundles the DataMap chunk into the existing one-signature payment batch, which is what lets ant-gui thread a `visibility` flag through its existing code path.

## Changes

### Backend (`src-tauri`)

- `autonomi_ops.rs`
  - Imports `ant_core::data::Visibility`.
  - `StartUploadRequest` gets an optional `visibility: Option<String>` (serde default → `Private`).
  - `start_upload` calls `client.file_prepare_upload_with_visibility(&path, visibility)`.
  - `confirm_upload` and `confirm_upload_merkle` extract `result.data_map_address` into `UploadResult.public_address` (hex-encoded, `0x…`, or `None` for private uploads).
  - `wallet_upload` (direct-key path) also populates `UploadResult.public_address` defensively from `result.data_map_address`. Today this is always `None` because direct-key mode doesn't thread visibility yet — wiring it through `wallet_upload` is a small follow-up if you want devnet/direct-key Public uploads too.
- `config.rs` — `UploadHistoryEntry.public_address: Option<String>` persisted to `upload_history.json`.

### Frontend

- `stores/files.ts`
  - `getUploadQuote(path, visibility = 'private')` accepts visibility and forwards it to `start_upload`. Docstring explains the prepared-batch / visibility-pinning constraint.
  - `FileEntry.visibility` and `UploadHistoryEntry.public_address` propagated through history load/save.
- `components/files/UploadConfirmDialog.vue`
  - Public radio re-enabled as a real option (was disabled).
  - New `visibility-change` emit fires on toggle so the parent can re-quote (public batches cost one extra chunk).
- `pages/files.vue`
  - `onVisibilityChange(visibility)` updates each selected entry's `visibility` in the store. The store-driven scheduler / Approve handler already pass visibility through, so the per-entry state stays synced when the user toggles in the dialog.
  - Uploads table shows a "Public" badge on rows with a `public_address`; clicking copies the address.

## Test plan

- [x] `cargo check --all-targets` clean against `ant-core-v0.2.2`
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI green (Linux). Local Windows `vitest` is hitting a known npm optional-deps flake unrelated to this PR.
- [ ] Manual: upload a file with Public selected → verify a 64-char hex address appears on the row with a Public badge → click it → verify clipboard contents.
- [ ] Manual: upload with Private selected → row still shows the datamap filename (existing behaviour unchanged).
- [ ] Manual: fresh download of a public upload via "Download by Address" using the copied address → verify `download_public` fetches the DataMap off-network and decrypts correctly.

## Rebase notes

This branch was rebased onto post-bump main (which now includes the live-progress work from #65 + the ant-core 0.2.2 dep bump) and lost a couple of segments that were superseded:

- **Pre-quote machinery** (`pendingUploadFiles`, `pendingQuotes`, `quotedVisibility`, `startQuoting`, the `watch(autonomiConnected)` re-quote trigger) was dropped in favour of main's store-driven scheduler.
- **The "drop pre-quote if visibility flipped after Approve" guard** was dropped along with the pre-quote state — main re-queries through the store rather than pinning a single pre-quote per dialog session. Public/Private cost-difference UX could be added back as a follow-up.
- **`effectivePaymentMode`** in the dialog now uses main's per-entry estimate; the `AVG_CHUNK_SIZE`/`MERKLE_THRESHOLD` heuristic from this branch was removed.
- The two stale `fix(nodes): …` commits that were sitting on this branch locally were dropped during rebase — they're already on main via #34.