### PR TITLE
fix(nodes): honour storage dir setting + show real storage usage

### DIFF
--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -31,18 +31,23 @@
     </div>
 
     <!-- Storage Directory -->
-    <div class="flex items-center justify-between rounded-lg border border-autonomi-border p-4">
-      <div class="min-w-0 flex-1">
-        <h3 class="text-sm font-medium">Storage Directory</h3>
-        <p class="text-xs text-autonomi-muted">Where node data is stored on disk</p>
-        <p class="mt-0.5 truncate font-mono text-xs text-autonomi-muted">{{ settingsStore.storageDir ?? 'Default' }}</p>
+    <div class="rounded-lg border border-autonomi-border p-4">
+      <div class="flex items-center justify-between">
+        <div class="min-w-0 flex-1">
+          <h3 class="text-sm font-medium">Storage Directory</h3>
+          <p class="text-xs text-autonomi-muted">Where node data is stored on disk</p>
+          <p class="mt-0.5 truncate font-mono text-xs text-autonomi-muted">{{ settingsStore.storageDir ?? 'Default' }}</p>
+        </div>
+        <button
+          class="ml-3 shrink-0 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted hover:text-autonomi-text"
+          @click="pickStorageDir"
+        >
+          Browse
+        </button>
       </div>
-      <button
-        class="ml-3 shrink-0 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted hover:text-autonomi-text"
-        @click="pickStorageDir"
-      >
-        Browse
-      </button>
+      <p class="mt-2 text-xs text-autonomi-warning">
+        Only applies to newly added nodes. Existing nodes keep their current directory.
+      </p>
     </div>
 
     <!-- Downloads Directory -->

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -505,6 +505,37 @@ fn get_file_size(path: String) -> Result<u64, String> {
     Ok(meta.len())
 }
 
+/// Report the actual on-disk bytes consumed by a file, not its logical size.
+///
+/// This matters for LMDB's `data.mdb`: when ant-node grows its store, the file
+/// may be sparse — a logical size equal to the configured `map_size` (dozens
+/// of MB to many GB) backed by only the pages that actually hold chunks.
+/// `get_file_size` returns the logical size, which would over-report storage
+/// used; this command returns the bytes the filesystem has actually allocated.
+///
+/// - **Unix (Linux / macOS):** `stat.st_blocks * 512`. Matches `du -B1`. Works
+///   on all UNIX filesystems, including APFS, ext4, btrfs, ZFS.
+/// - **Windows:** falls back to `metadata.len()` for now. NTFS doesn't flag
+///   LMDB `data.mdb` as sparse by default — LMDB extends the file as chunks
+///   are written, so logical == on-disk in practice. If that changes we'll
+///   need `GetCompressedFileSizeW` via `windows-sys` (tracked as upstream
+///   TODO: expose node storage via the daemon status endpoint instead).
+#[tauri::command]
+fn get_disk_usage(path: String) -> Result<u64, String> {
+    let meta = std::fs::metadata(&path).map_err(|e| format!("{e}"))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Ok(meta.blocks() * 512)
+    }
+
+    #[cfg(not(unix))]
+    {
+        Ok(meta.len())
+    }
+}
+
 #[tauri::command]
 fn get_file_sizes(paths: Vec<String>) -> Result<Vec<FileMetaResult>, String> {
     config::get_file_metas(&paths)
@@ -607,6 +638,7 @@ pub fn run() {
             daemon_request,
             get_file_sizes,
             get_file_size,
+            get_disk_usage,
             get_dir_size,
             get_node_data_dir,
             get_default_download_dir,

--- a/stores/nodes.ts
+++ b/stores/nodes.ts
@@ -130,10 +130,8 @@ export const useNodesStore = defineStore('nodes', {
       }
     },
 
-    /** Enrich nodes with storage usage from chunks.mdb. */
+    /** Enrich nodes with storage usage from the LMDB payload file. */
     async enrichNodeDetails() {
-      const EMPTY_LMDB_SIZE = 16384
-
       for (const node of this.nodes) {
         if (node.id < 0) continue // skip placeholders
 
@@ -162,9 +160,16 @@ export const useNodesStore = defineStore('nodes', {
         }
 
         if (dataDir) {
+          // ant-node uses LMDB's default subdir layout: `chunks.mdb/` is a
+          // directory containing `data.mdb` (the real payload) and a small
+          // `lock.mdb`. `get_disk_usage` reports the filesystem-allocated
+          // bytes of `data.mdb` (not its logical size), so a sparse LMDB map
+          // reports real chunks-stored rather than the configured map size.
+          // Upstream follow-up: expose this via the daemon status endpoint
+          // so we don't depend on the on-disk file layout at all.
           try {
-            const raw = await invoke<number>('get_file_size', { path: `${dataDir}/chunks.mdb` })
-            node.storage_bytes = Math.max(0, raw - EMPTY_LMDB_SIZE)
+            const raw = await invoke<number>('get_disk_usage', { path: `${dataDir}/chunks.mdb/data.mdb` })
+            node.storage_bytes = raw
           } catch {
             node.storage_bytes = 0
           }

--- a/stores/nodes.ts
+++ b/stores/nodes.ts
@@ -350,6 +350,7 @@ export const useNodesStore = defineStore('nodes', {
       const opts = {
         count,
         rewards_address: settings.earningsAddress ?? '',
+        data_dir_path: settings.storageDir ?? null,
         network_id: 1,
         binary_source: { type: 'latest' as const },
         bootstrap_peers: [],
@@ -361,6 +362,7 @@ export const useNodesStore = defineStore('nodes', {
         // Remove placeholders and add real nodes
         this.nodes = this.nodes.filter(n => !placeholderIds.includes(n.id))
         await this.fetchNodes()
+        this.enrichNodeDetails() // fire-and-forget — populates data_dir/ports without waiting for the detail poll
         toasts.add(`Added ${result.nodes_added.length} node(s)`, 'info')
       } catch (e: any) {
         // Remove placeholders on failure


### PR DESCRIPTION
Closes #33

## Summary

Two related node-management fixes that shipped broken:

1. **`storage_dir` setting was ignored.** Every new node landed in the daemon's default data dir because `stores/nodes.ts::addNodes` never passed `data_dir_path` on the request, even though the setting was persisted to `config.toml` and ant-core's add endpoint already accepts it. Also makes it explicit in the Settings UI that the directory only applies to newly added nodes (existing nodes aren't migrated). As a small follow-on, `addNodes` now fires `enrichNodeDetails` right after the add so the node tile shows its `data_dir` without needing a refresh.

2. **Per-node Storage field always read 0 B.** We were pointing `get_file_size` at `chunks.mdb`, which under LMDB's default layout is a *directory*, not a file — `metadata.len()` on a directory returns a trivial value that the old baseline subtraction clamped to zero. We now read `chunks.mdb/data.mdb` via a new `get_disk_usage` Tauri command that reports the filesystem-allocated bytes (sparse-aware on Unix, `metadata.len()` on Windows).

**Supersedes #31** — this branch contains the same storage-display fix plus the storage-dir fix on top. Please merge this and close #31 as duplicate.

## Test plan

- [x] Settings → Storage Directory shows the "only applies to newly added nodes" warning.
- [x] After changing the storage dir and adding a node, the new node's `data_dir` lives under `<new-dir>/node-<id>/` (verified on local release build).
- [x] Node tile's Storage field reports non-zero (baseline 8 KB on empty LMDB; grows once chunks land — awaiting first chunks to visually confirm growth, but the on-disk value is correct).
- [ ] Once upstream daemon exposes storage via its status endpoint (see `project_todo_daemon_storage_api.md`), drop the on-disk workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
