### PR TITLE
feat: file-ops affordances

### DIFF
--- a/components/files/DownloadDialog.vue
+++ b/components/files/DownloadDialog.vue
@@ -28,6 +28,7 @@
             type="text"
             placeholder="myfile.dat"
             class="w-full rounded-md border border-autonomi-border bg-autonomi-surface px-3 py-2 text-sm text-autonomi-text focus:border-autonomi-blue focus:outline-none"
+            @input="onFilenameInput"
             @keyup.enter="confirm"
           />
         </div>
@@ -53,15 +54,22 @@
 </template>
 
 <script setup lang="ts">
+import { useFilesStore } from '~/stores/files'
+
 const props = defineProps<{ open: boolean }>()
 const emit = defineEmits<{
   close: []
   download: [address: string, filename: string]
 }>()
 
+const filesStore = useFilesStore()
+
 const inputEl = ref<HTMLInputElement | null>(null)
 const address = ref('')
 const filename = ref('')
+/** Tracks whether the user has edited the filename since the last prefill,
+ *  so a subsequent address change doesn't clobber their typing. */
+const filenameDirty = ref(false)
 
 const valid = computed(() => {
   const addr = address.value.trim()
@@ -69,17 +77,61 @@ const valid = computed(() => {
   return isHex && filename.value.trim().length > 0
 })
 
+/** Prior upload that matches the currently-typed address, if any. Drives
+ *  both the filename prefill and the extension-append fallback on submit. */
+const matchedEntry = computed(() => {
+  const addr = address.value.trim()
+  if (!/^(0x)?[0-9a-fA-F]{8,}$/.test(addr)) return undefined
+  return filesStore.findUploadByAddress(addr)
+})
+
 watch(() => props.open, (val) => {
   if (val) {
     address.value = ''
     filename.value = ''
+    filenameDirty.value = false
     nextTick(() => inputEl.value?.focus())
   }
 })
 
+watch(matchedEntry, (match) => {
+  if (!match) return
+  if (filenameDirty.value) return
+  filename.value = match.name
+})
+
+function onFilenameInput() {
+  filenameDirty.value = true
+}
+
 function confirm() {
   if (!valid.value) return
-  emit('download', address.value.trim(), filename.value.trim())
+  const typed = filename.value.trim()
+  const final = appendExtensionIfNeeded(typed, matchedEntry.value?.name)
+  emit('download', address.value.trim(), final)
   emit('close')
+}
+
+/** If the user typed a filename without an extension and we know the
+ *  original extension from a history match, append it silently. Keeps
+ *  "screenshot" → "screenshot.png" without nagging, while leaving
+ *  deliberate unextensioned names alone when there's no match to copy from. */
+function appendExtensionIfNeeded(typed: string, originalName?: string): string {
+  if (!originalName) return typed
+  if (hasExtension(typed)) return typed
+  const origExt = extensionOf(originalName)
+  if (!origExt) return typed
+  return `${typed}.${origExt}`
+}
+
+function hasExtension(name: string): boolean {
+  const dot = name.lastIndexOf('.')
+  return dot > 0 && dot < name.length - 1
+}
+
+function extensionOf(name: string): string | null {
+  const dot = name.lastIndexOf('.')
+  if (dot <= 0 || dot === name.length - 1) return null
+  return name.slice(dot + 1)
 }
 </script>

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -120,17 +120,43 @@
                   <span v-if="file.gas_cost" class="block text-[10px] text-autonomi-muted/60">+ {{ file.gas_cost }} gas</span>
                 </td>
                 <td class="px-4 py-2.5">
-                  <span
+                  <div
                     v-if="file.data_map_file"
-                    class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
-                    :title="`Reveal ${datamapBasename(file.data_map_file)} in its folder`"
-                    @click.stop="openFolder(file.data_map_file)"
+                    class="group flex items-center gap-1.5"
                   >
-                    {{ datamapBasename(file.data_map_file) }}
-                  </span>
+                    <span
+                      class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
+                      title="Reveal datamap file in Finder/Explorer"
+                      @click.stop="openFolder(file.data_map_file)"
+                    >
+                      {{ datamapBasename(file.data_map_file) }}
+                    </span>
+                    <button
+                      type="button"
+                      class="rounded p-0.5 text-autonomi-muted/60 hover:text-autonomi-blue hover:bg-autonomi-surface"
+                      title="Copy datamap file path"
+                      @click.stop="copyDatamapPath(file.data_map_file!)"
+                    >
+                      <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
+                        <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      class="rounded p-0.5 text-autonomi-muted/60 hover:text-autonomi-blue hover:bg-autonomi-surface"
+                      title="Reveal datamap file in Finder/Explorer"
+                      @click.stop="openFolder(file.data_map_file)"
+                    >
+                      <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path d="M3.75 3A1.75 1.75 0 002 4.75v10.5c0 .966.784 1.75 1.75 1.75h12.5A1.75 1.75 0 0018 15.25v-8.5A1.75 1.75 0 0016.25 5h-5.982L8.97 3.703A2.5 2.5 0 007.2 3H3.75z" />
+                      </svg>
+                    </button>
+                  </div>
                   <span
                     v-else-if="file.address"
                     class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
+                    title="Copy network address"
                     @click.stop="copyAddress(file.address)"
                   >
                     {{ truncateAddress(file.address, 8, 6) }}
@@ -808,6 +834,11 @@ async function openFolder(path: string) {
 function copyAddress(addr: string) {
   navigator.clipboard.writeText(addr)
   toastStore.add('Address copied to clipboard', 'info')
+}
+
+function copyDatamapPath(path: string) {
+  navigator.clipboard.writeText(path)
+  toastStore.add('Datamap path copied to clipboard', 'info')
 }
 
 function datamapBasename(path: string): string {

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -279,6 +279,60 @@
           </div>
         </div>
 
+        <!-- Rescue Datamaps -->
+        <div class="rounded-lg border border-autonomi-border p-4">
+          <div class="flex items-center justify-between gap-3">
+            <div class="min-w-0 flex-1">
+              <h3 class="text-sm font-medium">Rescue Datamaps</h3>
+              <p class="text-xs text-autonomi-muted">
+                Re-import private-upload datamaps that exist on disk but are no longer in your upload history
+                (e.g. after clearing history or reinstalling the app).
+              </p>
+            </div>
+            <button
+              class="shrink-0 rounded-md border border-autonomi-border px-2.5 py-1.5 text-xs text-autonomi-muted hover:text-autonomi-text disabled:opacity-50"
+              :disabled="rescueScanning"
+              @click="scanOrphans"
+            >
+              {{ rescueScanning ? 'Scanning...' : 'Scan' }}
+            </button>
+          </div>
+
+          <div v-if="rescueScanned" class="mt-3">
+            <div v-if="orphanDatamaps.length === 0" class="rounded-md border border-dashed border-autonomi-border px-3 py-4 text-center text-xs text-autonomi-muted">
+              No orphaned datamaps found.
+            </div>
+            <div v-else class="space-y-2">
+              <div class="max-h-48 overflow-y-auto rounded-md border border-autonomi-border">
+                <ul class="divide-y divide-autonomi-border">
+                  <li
+                    v-for="orphan in orphanDatamaps"
+                    :key="orphan.path"
+                    class="flex items-center justify-between gap-2 px-3 py-2 text-xs"
+                  >
+                    <div class="min-w-0">
+                      <div class="truncate text-autonomi-text">{{ orphan.suggested_name }}</div>
+                      <div class="truncate font-mono text-[11px] text-autonomi-muted">
+                        {{ orphan.path }}
+                      </div>
+                    </div>
+                    <div class="shrink-0 text-right text-[11px] text-autonomi-muted">
+                      {{ formatShortDate(orphan.modified_at) }}
+                    </div>
+                  </li>
+                </ul>
+              </div>
+              <button
+                class="rounded-md bg-autonomi-blue px-2.5 py-1.5 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
+                :disabled="rescueImporting"
+                @click="importOrphans"
+              >
+                {{ rescueImporting ? 'Importing...' : `Import ${orphanDatamaps.length} datamap${orphanDatamaps.length === 1 ? '' : 's'}` }}
+              </button>
+            </div>
+          </div>
+        </div>
+
         <!-- Diagnostics -->
         <div class="rounded-lg border border-autonomi-border p-4">
           <div class="flex items-center justify-between">
@@ -383,6 +437,7 @@ import { isValidEthAddress } from '~/utils/validators'
 import { useToastStore } from '~/stores/toasts'
 import { useErrorLogStore } from '~/stores/errorlog'
 import { useUpdaterStore } from '~/stores/updater'
+import { useFilesStore, type UploadHistoryEntry } from '~/stores/files'
 
 const settingsStore = useSettingsStore()
 const walletStore = useWalletStore()
@@ -390,6 +445,7 @@ const nodesStore = useNodesStore()
 const toasts = useToastStore()
 const errorLogStore = useErrorLogStore()
 const updaterStore = useUpdaterStore()
+const filesStore = useFilesStore()
 const showAdvanced = ref(false)
 const showLog = ref(false)
 const appVersion = ref('0.1.0')
@@ -619,5 +675,133 @@ function clearLog() {
   toasts.add('Log cleared', 'info')
 }
 
+// ── Rescue Datamaps (V2-195) ──
+
+interface OrphanDatamap {
+  path: string
+  suggested_name: string
+  modified_at: string
+}
+
+const rescueScanning = ref(false)
+const rescueScanned = ref(false)
+const rescueImporting = ref(false)
+const orphanDatamaps = ref<OrphanDatamap[]>([])
+
+async function scanOrphans() {
+  rescueScanning.value = true
+  try {
+    if (!filesStore.historyLoaded) {
+      await filesStore.loadHistory()
+    }
+    const knownPaths = filesStore.files
+      .filter(f => f.kind === 'upload' && f.data_map_file)
+      .map(f => f.data_map_file!)
+    orphanDatamaps.value = await invoke<OrphanDatamap[]>('scan_orphan_datamaps', {
+      knownPaths,
+    })
+    rescueScanned.value = true
+  } catch (e: any) {
+    toasts.add(`Scan failed: ${e.message ?? e}`, 'error')
+  } finally {
+    rescueScanning.value = false
+  }
+}
+
+async function importOrphans() {
+  rescueImporting.value = true
+  try {
+    const newEntries: UploadHistoryEntry[] = []
+    for (const orphan of orphanDatamaps.value) {
+      // Read the datamap JSON so we can compute its network address. Without
+      // the address the history row can't participate in re-download flows.
+      let json: string
+      try {
+        json = await invoke<string>('read_datamap_file', { path: orphan.path })
+      } catch {
+        // Skip datamaps we can't read — they stay as orphans for the user
+        // to re-scan later once they've fixed permissions / disk issues.
+        continue
+      }
+      const address = await sha256Hex(json)
+      newEntries.push({
+        name: orphan.suggested_name,
+        size_bytes: 0,
+        address,
+        cost: null,
+        uploaded_at: orphan.modified_at,
+        data_map_file: orphan.path,
+      })
+    }
+
+    // Append, skipping any address already in history (shouldn't happen since
+    // we filtered by known path, but a computed address could coincidentally
+    // collide with an address we already have from some other path).
+    const existingAddrs = new Set(
+      filesStore.files
+        .filter(f => f.kind === 'upload' && f.address)
+        .map(f => f.address!.toLowerCase()),
+    )
+    const toImport = newEntries.filter(e => !existingAddrs.has(e.address.toLowerCase()))
+
+    if (toImport.length === 0) {
+      toasts.add('No new datamaps to import', 'info')
+      orphanDatamaps.value = []
+      rescueScanned.value = false
+      return
+    }
+
+    // Build the full entries list (existing history + new) and persist.
+    const fullEntries: UploadHistoryEntry[] = [
+      ...filesStore.files
+        .filter(f => f.kind === 'upload' && f.status === 'complete' && f.address)
+        .map(f => ({
+          name: f.name,
+          size_bytes: f.size_bytes,
+          address: f.address!,
+          cost: f.cost ?? null,
+          uploaded_at: f.date,
+          data_map_file: f.data_map_file ?? null,
+        })),
+      ...toImport,
+    ]
+    await invoke('save_upload_history', { entries: fullEntries })
+
+    // Refresh the store so the Files page picks them up immediately.
+    filesStore.historyLoaded = false
+    filesStore.files = filesStore.files.filter(f => f.kind !== 'upload' || f.status !== 'complete')
+    await filesStore.loadHistory()
+
+    toasts.add(`Imported ${toImport.length} datamap${toImport.length === 1 ? '' : 's'}`, 'success')
+    orphanDatamaps.value = []
+    rescueScanned.value = false
+  } catch (e: any) {
+    toasts.add(`Import failed: ${e.message ?? e}`, 'error')
+  } finally {
+    rescueImporting.value = false
+  }
+}
+
+async function sha256Hex(text: string): Promise<string> {
+  const bytes = new TextEncoder().encode(text)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  const hex = Array.from(new Uint8Array(digest))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+  return `0x${hex}`
+}
+
+function formatShortDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
 
 </script>

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -145,8 +145,7 @@ pub fn scan_orphan_datamaps(known_paths: &[String]) -> Result<Vec<OrphanDatamap>
         .filter_map(|p| std::fs::canonicalize(p).ok())
         .collect();
 
-    let entries = std::fs::read_dir(&dir)
-        .map_err(|e| format!("Failed to read config dir: {e}"))?;
+    let entries = std::fs::read_dir(&dir).map_err(|e| format!("Failed to read config dir: {e}"))?;
 
     let mut orphans = Vec::new();
     for entry in entries.flatten() {
@@ -194,7 +193,10 @@ pub fn scan_orphan_datamaps(known_paths: &[String]) -> Result<Vec<OrphanDatamap>
 /// Minimal ISO-8601 UTC formatter. Avoids a chrono dep just for a label.
 fn format_iso_utc(secs: i64, nanos: u32) -> String {
     let (y, mo, d, h, mi, s) = epoch_to_ymdhms(secs);
-    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}.{:03}Z", nanos / 1_000_000)
+    format!(
+        "{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}.{:03}Z",
+        nanos / 1_000_000
+    )
 }
 
 /// Convert unix epoch seconds to (year, month, day, hour, minute, second)

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -117,6 +117,109 @@ pub(crate) fn config_path() -> PathBuf {
         .join("ant-gui")
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrphanDatamap {
+    /// Absolute path to the .datamap file on disk.
+    pub path: String,
+    /// Basename with the `.datamap` extension stripped — the original upload's
+    /// filename stem. Shown to the user to jog their memory about which file
+    /// this datamap belongs to.
+    pub suggested_name: String,
+    /// File modification time as an ISO-8601 string (UTC). Proxy for "when
+    /// you uploaded this" when the real upload timestamp is gone from history.
+    pub modified_at: String,
+}
+
+/// List `.datamap` files in the app config directory that aren't referenced by
+/// any entry in `known_paths`. Used by the Settings → Advanced rescue flow to
+/// surface datamaps orphaned by a wiped `upload_history.json` so the user can
+/// re-import them and resume downloading.
+pub fn scan_orphan_datamaps(known_paths: &[String]) -> Result<Vec<OrphanDatamap>, String> {
+    let dir = config_path();
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let known: std::collections::HashSet<PathBuf> = known_paths
+        .iter()
+        .filter_map(|p| std::fs::canonicalize(p).ok())
+        .collect();
+
+    let entries = std::fs::read_dir(&dir)
+        .map_err(|e| format!("Failed to read config dir: {e}"))?;
+
+    let mut orphans = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some(DATAMAP_EXTENSION) {
+            continue;
+        }
+        let canonical = match std::fs::canonicalize(&path) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if known.contains(&canonical) {
+            continue;
+        }
+
+        let suggested_name = path
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let modified_at = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| {
+                // Format as an ISO-8601 UTC string without pulling in chrono —
+                // just enough precision for a display label.
+                let secs = d.as_secs() as i64;
+                let nanos = d.subsec_nanos();
+                format_iso_utc(secs, nanos)
+            })
+            .unwrap_or_default();
+
+        orphans.push(OrphanDatamap {
+            path: canonical.to_string_lossy().into_owned(),
+            suggested_name,
+            modified_at,
+        });
+    }
+
+    Ok(orphans)
+}
+
+/// Minimal ISO-8601 UTC formatter. Avoids a chrono dep just for a label.
+fn format_iso_utc(secs: i64, nanos: u32) -> String {
+    let (y, mo, d, h, mi, s) = epoch_to_ymdhms(secs);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}.{:03}Z", nanos / 1_000_000)
+}
+
+/// Convert unix epoch seconds to (year, month, day, hour, minute, second)
+/// in UTC. Implements the civil-from-days algorithm so we don't pull in chrono.
+fn epoch_to_ymdhms(secs: i64) -> (i32, u8, u8, u8, u8, u8) {
+    let days = secs.div_euclid(86_400);
+    let seconds_of_day = secs.rem_euclid(86_400) as u32;
+    let h = (seconds_of_day / 3600) as u8;
+    let mi = ((seconds_of_day % 3600) / 60) as u8;
+    let s = (seconds_of_day % 60) as u8;
+
+    // Howard Hinnant's days_from_civil inverse.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = (yoe as i32) + era as i32 * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u8;
+    let mo = (if mp < 10 { mp + 3 } else { mp - 9 }) as u8;
+    let y = if mo <= 2 { y + 1 } else { y };
+    (y, mo, d, h, mi, s)
+}
+
 /// Resolve the OS-appropriate default downloads directory. Returns
 /// `~/Downloads` on macOS/Linux and `C:\Users\<name>\Downloads` on Windows,
 /// falling back to `<home>/Downloads` if the platform-specific lookup fails.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@ mod autonomi_ops;
 mod config;
 
 use autonomi_ops::AutonomiState;
-use config::{AppConfig, FileMetaResult, UploadHistory, UploadHistoryEntry};
+use config::{AppConfig, FileMetaResult, OrphanDatamap, UploadHistory, UploadHistoryEntry};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{watch, RwLock};
@@ -572,6 +572,11 @@ fn save_upload_history(entries: Vec<UploadHistoryEntry>) -> Result<(), String> {
     history.save().map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+fn scan_orphan_datamaps(known_paths: Vec<String>) -> Result<Vec<OrphanDatamap>, String> {
+    config::scan_orphan_datamaps(&known_paths)
+}
+
 pub fn run() {
     // Pipe ant-core / ant-node tracing events to stderr so the dev console
     // surfaces upload progress (encrypt → quote → store → finalize). Without
@@ -613,6 +618,7 @@ pub fn run() {
             read_file_bytes,
             load_upload_history,
             save_upload_history,
+            scan_orphan_datamaps,
             discover_daemon_url,
             ensure_daemon_running,
             connect_daemon_sse,


### PR DESCRIPTION
## Summary

Three independent file-ops UX fixes bundled in one branch. Each commit is scoped to one concern and could be reverted alone.

- **Download-by-Address filename fix** (`f073c79`) — dialog prefills the filename from the matching upload-history entry and silently appends the original extension on submit. No more `screenshot` downloads that the OS refuses to open.
- **Datamap row affordances** (`d207b51`) — uploads table rows with a persisted datamap now show explicit Copy Path and Reveal-in-Folder icons next to the filename. Previously the filename was subtly clickable and users didn't realise.
- **Rescue orphaned datamaps** (`1887ddf`) — Settings → Advanced → Rescue Datamaps scans the app config dir for orphaned `.datamap` files not referenced by upload history and lets the user re-import them in one click. Addresses are recomputed from each datamap's JSON so the imported rows are immediately usable for re-downloads.

No backend schema changes. One new Tauri command (`scan_orphan_datamaps`). No migration required.

## Why draft

Code is green (vitest 19/19, nuxi typecheck clean on app code, cargo check clean) but the UI flows have not been manually exercised. Opening as draft to unblock review of the code shape while the test plan below runs.

## Test plan

- [ ] **Filename prefill**: open Download by Address, paste an address from an existing upload → filename field prefills with the original name
- [ ] **Extension preserved**: edit the prefilled filename to drop the extension (e.g. remove `.png`) → on Download, the save name should still end with `.png`
- [ ] **No-match behaviour**: paste an address NOT in history → filename stays blank, user types freely, no append (since nothing to copy from)
- [ ] **Datamap icons render**: upload a small private file → uploads table row shows `<filename>.datamap` followed by a copy icon and a folder icon
- [ ] **Copy path**: click the copy icon → clipboard contains the absolute path; toast confirms
- [ ] **Reveal**: click the folder icon → Finder / Explorer opens focused on the datamap file
- [ ] **Non-datamap rows unchanged**: uploads without a datamap (public, or legacy rows) still show the truncated address, still clickable to copy address
- [ ] **Empty rescue scan**: fresh install or matching history → Scan returns "No orphaned datamaps found"
- [ ] **Orphan scan**: clear upload history (Clear History button), then Scan → orphaned datamaps appear in the list with sensible names and mtimes
- [ ] **Orphan import**: click Import N datamaps → toast confirms; navigating to the Files page shows the re-imported rows; rows are usable for Download by Datamap
- [ ] **Dedupe**: import orphans twice → the second import finds nothing new
- [ ] **Cross-platform**: at minimum Windows + macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)