### PR TITLE
feat(upload): use ant-core estimate_upload_cost for pre-upload quotes

### DIFF
--- a/components/files/UploadConfirmDialog.vue
+++ b/components/files/UploadConfirmDialog.vue
@@ -82,7 +82,7 @@
             <template v-else>
               <div class="flex items-center gap-2 text-sm text-autonomi-muted">
                 <div class="h-3 w-3 animate-spin rounded-full border-2 border-autonomi-blue border-t-transparent" />
-                <span>Preparing cost quote...</span>
+                <span>Estimating cost...</span>
               </div>
             </template>
           </div>
@@ -134,7 +134,7 @@
           </div>
 
           <p v-if="quotedCost && effectivePaymentMode === 'regular'" class="text-xs text-autonomi-muted">
-            Cost quoted from the Autonomi network. Gas fees apply on top.
+            Estimated from a single network quote — final cost may vary slightly. Gas fees apply on top.
           </p>
 
           <div class="flex justify-end gap-2">

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -255,8 +255,9 @@ import { invoke } from '@tauri-apps/api/core'
 import { getCurrentWebview } from '@tauri-apps/api/webview'
 import { open as openFileDialog } from '@tauri-apps/plugin-dialog'
 import { revealItemInDir } from '@tauri-apps/plugin-opener'
-import { useFilesStore, type FileEntry, type UploadQuote } from '~/stores/files'
+import { useFilesStore, type FileEntry, type UploadCostEstimate } from '~/stores/files'
 import { formatBytes, truncateAddress } from '~/utils/formatters'
+import { formatNanoTokens, formatGasCost } from '~/utils/payment'
 import { useSettingsStore } from '~/stores/settings'
 import { useToastStore } from '~/stores/toasts'
 import { useConnectionStore } from '~/stores/connection'
@@ -381,7 +382,7 @@ function statusLabel(file: FileEntry): string {
   if (file.status === 'downloaded') return 'Downloaded'
   if (file.status === 'failed') return file.error ? `Failed: ${file.error}` : 'Failed'
   if (file.status === 'complete') return 'Complete'
-  if (file.status === 'quoting') return 'Quoting'
+  if (file.status === 'quoting') return 'Preparing upload…'
   if (file.status === 'paying') return 'Paying'
   return file.status
 }
@@ -431,7 +432,6 @@ const isQuoting = ref(false)
 const quotedCostDisplay = ref<string | null>(null)
 const quotedGasEstimate = ref<string | null>(null)
 const quotedPaymentMode = ref<'wave-batch' | 'merkle' | null>(null)
-const pendingQuotes = ref<Map<string, UploadQuote>>(new Map())
 
 async function getFileMetas(paths: string[]): Promise<FileMeta[]> {
   try {
@@ -467,7 +467,6 @@ async function showUploadConfirmForPaths(paths: string[]) {
   quotedCostDisplay.value = null
   quotedGasEstimate.value = null
   quotedPaymentMode.value = null
-  pendingQuotes.value = new Map()
   showUploadConfirm.value = true
 
   const metas = await getFileMetas(paths)
@@ -508,47 +507,32 @@ watch(
 async function startQuoting(metas: FileMeta[]) {
   isQuoting.value = true
   try {
-    // Quote each file (sequentially to avoid overwhelming the network)
-    const quotes = new Map<string, UploadQuote>()
-    for (const meta of metas) {
-      const quote = await filesStore.getUploadQuote(meta.path)
-      if (quote) {
-        quotes.set(meta.path, quote)
-      }
-    }
-    pendingQuotes.value = quotes
+    // Use the light-weight `estimate_file_cost` path: encrypts locally, samples
+    // one quote per file, no chunks parked. Confirm click runs the real
+    // `start_upload` (which does park). Each estimate is independent, so
+    // parallelize — cuts dialog-open latency for multi-file uploads.
+    const estimates = await Promise.all(
+      metas.map(meta => filesStore.estimateFileCost(meta.path)),
+    )
+    const valid = estimates.filter((e): e is UploadCostEstimate => e !== null)
 
-    if (quotes.size > 0) {
-      const quoteValues = Array.from(quotes.values())
-      quotedPaymentMode.value = quoteValues[0].payment_mode
+    if (valid.length > 0) {
+      // ant-core PaymentMode 'single' maps to the frontend's 'wave-batch'.
+      const mode = valid[0].payment_mode === 'merkle' ? 'merkle' : 'wave-batch'
+      quotedPaymentMode.value = mode
 
-      if (quotedPaymentMode.value === 'merkle') {
-        quotedCostDisplay.value = 'Determined on-chain'
-      } else {
-        const totalNanos = quoteValues.reduce(
-          (sum, q) => sum + BigInt(q.total_cost), 0n,
-        )
-        const whole = totalNanos / 1_000_000_000_000_000_000n
-        const frac = (totalNanos % 1_000_000_000_000_000_000n) / 1_000_000_000_000_000n
-        quotedCostDisplay.value = frac > 0n ? `${whole}.${frac.toString().padStart(3, '0')} ANT` : `${whole} ANT`
-      }
+      const totalStorageAtto = valid.reduce(
+        (sum, e) => sum + BigInt(e.storage_cost_atto), 0n,
+      )
+      quotedCostDisplay.value = formatNanoTokens(totalStorageAtto.toString())
 
-      // Estimate gas cost
-      const wagmiConfig = getWagmiConfig()
-      if (wagmiConfig) {
-        const totalPayments = quoteValues.reduce((sum, q) => sum + q.payments.length, 0)
-        const poolCount = quoteValues[0].merkle_pool_commitments?.length
-        const est = await estimatePaymentGasCost(
-          wagmiConfig,
-          quotedPaymentMode.value,
-          totalPayments,
-          poolCount,
-        )
-        quotedGasEstimate.value = est
-      }
+      const totalGasWei = valid.reduce(
+        (sum, e) => sum + BigInt(e.estimated_gas_cost_wei), 0n,
+      )
+      quotedGasEstimate.value = formatGasCost(totalGasWei.toString())
     }
   } catch {
-    // Quoting failed — user can still proceed (will re-quote during upload)
+    // Estimate failed — user can still proceed (real quote runs at upload time).
   } finally {
     isQuoting.value = false
   }
@@ -560,26 +544,26 @@ function confirmUpload(options: { visibility: 'private' | 'public'; paymentMode:
 
   for (const file of pendingUploadFiles.value) {
     const id = filesStore.addUpload(file.name, file.path, file.size)
-    const preQuote = pendingQuotes.value.get(file.path)
 
     if (settingsStore.indelibleConnected && !settingsStore.devnetActive) {
       filesStore.startIndelibleUpload(id)
     } else if ((autonomiConnected.value || settingsStore.devnetActive) && wagmiConfig) {
-      filesStore.startRealUpload(id, wagmiConfig, options, preQuote ?? undefined)
+      // No preQuote handoff: the dialog showed a light estimate (no chunks
+      // parked). `startRealUpload` fetches a fresh real quote via
+      // `start_upload`, which is what parks chunks — only on confirm.
+      filesStore.startRealUpload(id, wagmiConfig, options)
     } else {
       filesStore.updateEntry(id, { status: 'failed', error: 'Not connected to network or wallet' })
       toastStore.add('Upload requires network connection and wallet', 'warning')
     }
   }
   pendingUploadFiles.value = []
-  pendingQuotes.value = new Map()
   quotedCostDisplay.value = null
 }
 
 function cancelUpload() {
   showUploadConfirm.value = false
   pendingUploadFiles.value = []
-  pendingQuotes.value = new Map()
   quotedCostDisplay.value = null
   isQuoting.value = false
 }
@@ -763,15 +747,20 @@ async function runCostEstimateQuotes(metas: FileMeta[]) {
   if (costEstimateQuoting.value) return
   costEstimateQuoting.value = true
   try {
-    for (const meta of metas) {
-      const quote = await filesStore.getUploadQuote(meta.path)
-      if (!quote) continue
+    // Parallel: each estimate is independent, and this is display-only.
+    const results = await Promise.all(
+      metas.map(async (meta) => ({
+        meta,
+        estimate: await filesStore.estimateFileCost(meta.path),
+      })),
+    )
+    for (const { meta, estimate } of results) {
+      if (!estimate) continue
       const idx = costFiles.value.findIndex(f => f.name === meta.name)
       if (idx === -1) continue
-      // Mutate the entry in place so the dialog's reactive `:files` re-renders.
       costFiles.value[idx] = {
         ...costFiles.value[idx],
-        cost: quote.total_cost_display,
+        cost: formatNanoTokens(estimate.storage_cost_atto),
       }
     }
   } finally {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 [[package]]
 name = "ant-core"
 version = "0.1.1"
-source = "git+https://github.com/WithAutonomi/ant-client?rev=f88c95daa003d9e5aee3c76eb67914ed1d907ccb#f88c95daa003d9e5aee3c76eb67914ed1d907ccb"
+source = "git+https://github.com/WithAutonomi/ant-client?rev=b0c501a163c1a95bdbfc703892b88a8a91f7e482#b0c501a163c1a95bdbfc703892b88a8a91f7e482"
 dependencies = [
  "ant-node",
  "async-stream",
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716cbaf63c0fb090667e8db0c87364ad3293ffc04396999c6ec1a5b394af8989"
+checksum = "dac042e69f7dff2136deee542d66fceb5631474869ea4da9875185a9ad3329cc"
 dependencies = [
  "aes-gcm-siv",
  "blake3",
@@ -6689,14 +6689,15 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eefc3539465111e2769b9b8334ddd4d7071e12c183de4a9fee7d9bfbdb3da23"
+checksum = "d459ba0e4f1a3ac918a1d6b17db392cccde2ee74569545d171d7644fc6463cc7"
 dependencies = [
  "anyhow",
  "async-trait",
  "blake3",
  "bytes",
+ "dashmap",
  "dirs 6.0.0",
  "futures",
  "hex",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,11 +25,10 @@ toml = "0.8"
 tauri-plugin-updater = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-# Pinned to the merge commit of WithAutonomi/ant-client#40 (allow_loopback
-# fix). Repoint to the next `ant-cli-vX.Y.Z` tag once it ships — the fix
-# can't go into the v0.1.2 tag because that's what the deployed daemon
-# uses and we don't want drift.
-ant-core = { git = "https://github.com/WithAutonomi/ant-client", rev = "f88c95daa003d9e5aee3c76eb67914ed1d907ccb" }
+# Pinned to the merge commit of WithAutonomi/ant-client#44, which adds
+# `Client::estimate_upload_cost` (file cost estimation without parking
+# chunks). Repoint to the next `ant-cli-vX.Y.Z` tag once it ships.
+ant-core = { git = "https://github.com/WithAutonomi/ant-client", rev = "b0c501a163c1a95bdbfc703892b88a8a91f7e482" }
 evmlib = "0.8"
 hex = "0.4"
 sha2 = "0.10"

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -1,5 +1,6 @@
 use ant_core::data::{
-    Client, ClientConfig, CustomNetwork, DataMap, EvmNetwork, ExternalPaymentInfo, PreparedUpload,
+    Client, ClientConfig, CustomNetwork, DataMap, EvmNetwork, ExternalPaymentInfo, PaymentMode,
+    PreparedUpload, UploadCostEstimate,
 };
 use evmlib::common::{QuoteHash, TxHash};
 use serde::{Deserialize, Serialize};
@@ -477,6 +478,46 @@ pub async fn start_upload(
     );
 
     Ok(())
+}
+
+/// Estimate the cost of uploading a file without parking any chunks.
+///
+/// Wraps `Client::estimate_upload_cost` (ant-core #44): encrypts the file to a
+/// local spill, samples a single network quote for a representative chunk, and
+/// extrapolates total storage cost. Gas is a documented heuristic. No wallet
+/// required, no `PreparedUpload` parked in `pending_uploads`.
+///
+/// `mode` accepts "auto" (default), "single", or "merkle". Unknown values
+/// fall back to "auto".
+#[tauri::command]
+pub async fn estimate_file_cost(
+    state: tauri::State<'_, AutonomiState>,
+    path: String,
+    mode: Option<String>,
+) -> Result<UploadCostEstimate, String> {
+    let client_lock = state.client.read().await;
+    let client = client_lock
+        .as_ref()
+        .ok_or("Autonomi client not initialized")?;
+
+    let path_buf = PathBuf::from(&path);
+    let canonical = tokio::fs::canonicalize(&path_buf)
+        .await
+        .map_err(|e| format!("Invalid file path: {e}"))?;
+    if !canonical.is_file() {
+        return Err("Path is not a regular file".into());
+    }
+
+    let payment_mode = match mode.as_deref().unwrap_or("auto") {
+        "single" => PaymentMode::Single,
+        "merkle" => PaymentMode::Merkle,
+        _ => PaymentMode::Auto,
+    };
+
+    client
+        .estimate_upload_cost(&canonical, payment_mode, None)
+        .await
+        .map_err(|e| format!("Failed to estimate upload cost: {e}"))
 }
 
 /// Confirm wave-batch upload after frontend has paid on-chain.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -619,6 +619,7 @@ pub fn run() {
             disconnect_daemon_sse,
             autonomi_ops::init_autonomi_client,
             autonomi_ops::start_upload,
+            autonomi_ops::estimate_file_cost,
             autonomi_ops::confirm_upload,
             autonomi_ops::confirm_upload_merkle,
             autonomi_ops::download_file,

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -3,8 +3,18 @@ import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { useToastStore } from './toasts'
 import { useSettingsStore } from './settings'
-import { payForQuotes, payForMerkleTree, formatNanoTokens, formatGasCost, estimatePaymentGasCost, type RawPayment, type SerializedPoolCommitment } from '~/utils/payment'
+import { payForQuotes, payForMerkleTree, formatNanoTokens, formatGasCost, type RawPayment, type SerializedPoolCommitment } from '~/utils/payment'
 import { indelibleApi } from '~/utils/indelible-api'
+
+// ── Lightweight cost estimate (no chunks parked) ──
+// Matches ant_core::data::UploadCostEstimate.
+export interface UploadCostEstimate {
+  file_size: number
+  chunk_count: number
+  storage_cost_atto: string
+  estimated_gas_cost_wei: string
+  payment_mode: 'auto' | 'single' | 'merkle'
+}
 
 // ── Pre-obtained quote from network ──
 
@@ -226,6 +236,20 @@ export const useFilesStore = defineStore('files', {
         transferStartedAt: Date.now(),
       })
       return id
+    },
+
+    /** Light-touch cost estimate — wraps ant-core `estimate_upload_cost`.
+     *  Encrypts the file locally, samples one network quote, extrapolates cost.
+     *  Does NOT park a `PreparedUpload`, so the user can cancel without orphaning
+     *  hundreds of chunks in the daemon's pending_uploads map. Display-only;
+     *  actual uploads must still go through `getUploadQuote`/`start_upload`. */
+    async estimateFileCost(path: string): Promise<UploadCostEstimate | null> {
+      try {
+        return await invoke<UploadCostEstimate>('estimate_file_cost', { path })
+      } catch (e) {
+        console.warn('estimate_file_cost failed:', e)
+        return null
+      }
     },
 
     /** Get a real network quote for a file. Used by the upload dialog to show real costs. */

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -252,7 +252,10 @@ export const useFilesStore = defineStore('files', {
       }
     },
 
-    /** Get a real network quote for a file. Used by the upload dialog to show real costs. */
+    /** Get a real network quote for a file. Parks a `PreparedUpload` in the
+     *  daemon. Used internally by `startRealUpload` after the user clicks
+     *  Confirm — not for display. For pre-upload cost display, use
+     *  `estimateFileCost` instead. */
     async getUploadQuote(path: string): Promise<UploadQuote | null> {
       const uploadId = `quote-${Date.now()}-${Math.random().toString(36).slice(2)}`
 

--- a/utils/payment.ts
+++ b/utils/payment.ts
@@ -1,17 +1,10 @@
-import { readContract, writeContract, waitForTransactionReceipt, getGasPrice, getAccount } from '@wagmi/core'
+import { readContract, writeContract, waitForTransactionReceipt, getAccount } from '@wagmi/core'
 import { getTokenAddress, getVaultAddress, getActiveChainId } from '~/utils/wallet-config'
 import paymentVaultAbi from '~/assets/abi/IPaymentVault.json'
 import paymentTokenAbi from '~/assets/abi/PaymentToken.json'
-import { decodeEventLog, formatEther, encodeFunctionData } from 'viem'
+import { decodeEventLog, formatEther } from 'viem'
 
 const MAX_PAYMENTS_PER_BATCH = 256
-
-// Typical gas units per operation (conservative estimates)
-const GAS_APPROVE = 50_000n
-const GAS_PER_QUOTE_PAYMENT = 38_000n
-const GAS_QUOTE_BASE = 25_000n
-const GAS_MERKLE_BASE = 180_000n
-const GAS_MERKLE_PER_POOL = 25_000n
 
 // Arbitrum produces blocks every ~250ms; viem's default 4s polling is tuned
 // for L1. Dropping to 2s reduces the window where we might miss a newly-mined
@@ -221,43 +214,6 @@ async function ensureAllowance(wagmiConfig: any, needed: bigint): Promise<bigint
     pollingInterval: RECEIPT_POLL_INTERVAL_MS,
   })
   return receiptGasCost(receipt)
-}
-
-/**
- * Estimate gas cost for an upload payment before executing it.
- * Uses current chain gas price and conservative gas unit estimates.
- *
- * @returns Estimated gas cost formatted as ETH string, or null if estimation fails.
- */
-export async function estimatePaymentGasCost(
-  wagmiConfig: any,
-  paymentMode: 'wave-batch' | 'merkle',
-  paymentCount: number,
-  poolCount?: number,
-): Promise<string | null> {
-  try {
-    const gasPrice = await Promise.race([
-      getGasPrice(wagmiConfig, { chainId: getActiveChainId() }),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Gas price timeout')), 10_000)),
-    ])
-
-    let totalGas: bigint
-    if (paymentMode === 'merkle') {
-      // Merkle: one approve + one payForMerkleTree call
-      totalGas = GAS_APPROVE + GAS_MERKLE_BASE + GAS_MERKLE_PER_POOL * BigInt(poolCount ?? 4)
-    } else {
-      // Wave-batch: one approve + N batches of payForQuotes
-      const batches = Math.ceil(paymentCount / MAX_PAYMENTS_PER_BATCH)
-      const paymentsGas = GAS_PER_QUOTE_PAYMENT * BigInt(paymentCount)
-      const batchOverhead = GAS_QUOTE_BASE * BigInt(batches)
-      totalGas = GAS_APPROVE + paymentsGas + batchOverhead
-    }
-
-    const costWei = totalGas * gasPrice
-    return formatGasCost(costWei.toString())
-  } catch {
-    return null
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Both the Estimate Cost button and the Upload dialog pre-quote used to call `start_upload` → `file_prepare_upload`, which encrypts the whole file to disk and parks a `PreparedUpload` for 30 minutes. Every cancelled estimate leaked hundreds of encrypted chunks into memory.
- Switch both to the new lightweight `Client::estimate_upload_cost` (ant-core PR #44, merge `b0c501a`): samples a single network quote for a representative chunk and extrapolates. No encryption-to-spill, no parked upload, no wallet required.
- Multi-file estimates now run in parallel (`Promise.all`), so dialog-open latency tracks the slowest single quote instead of the sum.
- Confirm click still runs the real `start_upload` via `startRealUpload`, so the heavy work happens only on commit. Dropped the `preQuote` handoff plumbing and the `pendingQuotes` map.
- Renamed the `'quoting'` status label to "Preparing upload…" now that the heavy phase sits post-Confirm.
- Removed `utils/payment.ts::estimatePaymentGasCost` — PR #44's gas heuristic replaces it. Its leftover `GAS_*` constants and `getGasPrice` import go with it.

## Dependency bump
`ant-core` pin `f88c95d` → `b0c501a` (PR #44 merge). Cascades to `ant-node 0.10.0 → 0.10.1` and `saorsa-core 0.23.0 → 0.23.1` via the resolver.

## Test plan
- [x] `cargo check` clean
- [x] `vitest` — 19/19 pass
- [ ] Dev app smoke test on live network before tomorrow's release:
  - [ ] Estimate Cost (top-bar) on 3 files shows a cost within ~5 s and leaves `pending_uploads` empty
  - [ ] Open Upload dialog → see "Estimating cost…" → cost appears → Cancel → `pending_uploads` empty
  - [ ] Open Upload dialog → Confirm → "Preparing upload…" visible → upload lands on network
  - [ ] Indelible path: estimate is skipped (Indelible is server-driven cost) — verify nothing regressed
  - [ ] Tiny file (<3 bytes) rejection surfaces with a sensible error, not a crash

## Known follow-ups
- If public-uploads (`Visibility` arg) merges upstream, `estimate_file_cost` needs a `visibility` hint so the chunk count includes the DataMap chunk for public uploads.
- `CostEstimationInconclusive` error path currently reaches the frontend as a generic `warn` + `null` return. A friendlier toast ("Cost estimate unavailable, try another file") would be nicer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)