### PR TITLE
fix(updater): wrap Update instance in markRaw to unblock install

### DIFF
--- a/stores/updater.ts
+++ b/stores/updater.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { markRaw } from 'vue'
 import { check, type Update } from '@tauri-apps/plugin-updater'
 
 export interface CheckResult {
@@ -55,7 +56,9 @@ export const useUpdaterStore = defineStore('updater', {
           this.available = true
           this.version = update.version
           this.body = update.body ?? null
-          this._update = update
+          // markRaw: Update has private fields that break when wrapped in
+          // Pinia's reactive Proxy — downloadAndInstall() silently no-ops.
+          this._update = markRaw(update)
           return { ok: true, available: true }
         }
         return { ok: true, available: false }


### PR DESCRIPTION
## Summary
- `stores/updater.ts` stored the `Update` instance returned by `@tauri-apps/plugin-updater` into Pinia state. Pinia's reactive Proxy wrapping breaks the class's private fields, so `_update.downloadAndInstall()` silently no-ops — the dialog opens, user clicks Update & Restart, and nothing happens.
- One-line fix: `markRaw(update)` opts the object out of the Proxy wrapping so the class methods execute against the real instance.

## How this was found
Built a local 0.6.2 binary pointed at the production `latest.json` on GitHub (on throwaway branch `test/updater-older-version`). Banner and dialog both showed v0.6.6 as available. Clicking Update & Restart did nothing. No stderr output, no network activity. Applied the `markRaw` fix, rebuilt, relaunched 0.6.2 — installer downloaded, v0.6.6 landed in `C:\Program Files\Autonomi\`.

## Test plan
- [x] Local 0.6.2 build → updater detects 0.6.6 → button triggers download → installs to Program Files
- [ ] Same test from a real MSI install of 0.6.2 (not a portable exe) — the auto-relaunch hand-off only works for MSI/NSIS-installed copies; I verified the download+install half, not the relaunch half
- [ ] Smoke test 0.6.6 updater → 0.6.7 once tomorrow's release ships, to catch any regressions

## Known limitation (not in scope)
If a user launches a portable `.exe` directly (not installed via MSI/NSIS), the updater downloads and runs the installer but can't find the right relaunch target. Real users install the MSI/NSIS so this doesn't affect them. Documented only for internal testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)