### PR TITLE
feat(upload): non-blocking dialog, concurrency queue, honest states

### DIFF
--- a/components/StatusBadge.vue
+++ b/components/StatusBadge.vue
@@ -23,6 +23,7 @@ const statusMap: Record<string, { dot: string; label: string; color: string }> =
   'Queued: uploading': { dot: '○', label: 'Queued: uploading', color: 'text-autonomi-muted' },
   'Connecting to network…': { dot: '◐', label: 'Connecting to network…', color: 'text-autonomi-warning' },
   'Obtaining quote…': { dot: '◐', label: 'Obtaining quote…', color: 'text-autonomi-warning' },
+  'Saving datamap…': { dot: '◐', label: 'Saving datamap…', color: 'text-autonomi-warning' },
   'Network unavailable': { dot: '✖', label: 'Network unavailable', color: 'text-autonomi-error' },
   'Ready to approve': { dot: '●', label: 'Ready to approve', color: 'text-autonomi-blue' },
   Paying: { dot: '◐', label: 'Paying', color: 'text-autonomi-warning' },

--- a/components/StatusBadge.vue
+++ b/components/StatusBadge.vue
@@ -19,6 +19,12 @@ const statusMap: Record<string, { dot: string; label: string; color: string }> =
   // File transfer statuses
   Pending: { dot: '○', label: 'Pending', color: 'text-autonomi-muted' },
   Quoting: { dot: '◐', label: 'Quoting', color: 'text-autonomi-warning' },
+  'Queued: quoting': { dot: '○', label: 'Queued: quoting', color: 'text-autonomi-muted' },
+  'Queued: uploading': { dot: '○', label: 'Queued: uploading', color: 'text-autonomi-muted' },
+  'Connecting to network…': { dot: '◐', label: 'Connecting to network…', color: 'text-autonomi-warning' },
+  'Obtaining quote…': { dot: '◐', label: 'Obtaining quote…', color: 'text-autonomi-warning' },
+  'Network unavailable': { dot: '✖', label: 'Network unavailable', color: 'text-autonomi-error' },
+  'Ready to approve': { dot: '●', label: 'Ready to approve', color: 'text-autonomi-blue' },
   Paying: { dot: '◐', label: 'Paying', color: 'text-autonomi-warning' },
   Uploading: { dot: '●', label: 'Uploading', color: 'text-autonomi-blue' },
   Downloading: { dot: '●', label: 'Downloading', color: 'text-autonomi-blue' },

--- a/components/files/CostEstimateDialog.vue
+++ b/components/files/CostEstimateDialog.vue
@@ -12,7 +12,11 @@
           <p class="text-sm text-autonomi-muted">Estimating cost...</p>
         </div>
 
-        <div v-else-if="files.length > 0" class="space-y-3">
+        <div v-else-if="files.length === 0" class="py-4 text-center text-sm text-autonomi-muted">
+          No files selected
+        </div>
+
+        <div v-else class="space-y-3">
           <div
             v-for="file in files"
             :key="file.name"
@@ -20,32 +24,51 @@
           >
             <span class="max-w-[200px] truncate">{{ file.name }}</span>
             <div class="text-right">
-              <span v-if="file.size" class="text-autonomi-muted">{{ file.size ? formatBytes(file.size) : '-' }}</span>
-              <span class="ml-2 text-autonomi-blue">
-                {{ file.cost ? file.cost : `~${estimateCost(file.size)} ANT` }}
-              </span>
+              <span v-if="file.size" class="text-autonomi-muted">{{ formatBytes(file.size) }}</span>
+              <span v-if="file.cost" class="ml-2 text-autonomi-blue">{{ file.cost }}</span>
+              <span v-else class="ml-2 text-autonomi-muted">—</span>
               <span v-if="file.gas_cost" class="ml-1 text-autonomi-muted">+ {{ file.gas_cost }} gas</span>
             </div>
           </div>
 
-          <div v-if="!hasRealCosts" class="border-t border-autonomi-border pt-3">
-            <div class="flex items-center justify-between text-sm font-medium">
-              <span>Total</span>
-              <div>
-                <span class="text-autonomi-muted">{{ totalSize ? formatBytes(totalSize) : '-' }}</span>
-                <span class="ml-2 text-autonomi-blue">~{{ estimateCost(totalSize) }} ANT</span>
+          <!-- Status line while (or after) quotes arrive. Connection-error is
+               checked first so a failed connect surfaces even if some files
+               happened to get quoted before the failure. -->
+          <div v-if="!allCostsReal" class="border-t border-autonomi-border pt-3">
+            <template v-if="connectionStore.hasFailed">
+              <div class="space-y-2">
+                <p class="text-sm text-yellow-500/80">
+                  Not connected to the Autonomi network — cost estimate unavailable.
+                </p>
+                <p v-if="failedReason" class="text-xs text-autonomi-muted break-words">
+                  {{ failedReason }}
+                </p>
+                <button
+                  type="button"
+                  class="rounded-md border border-autonomi-blue/40 px-2.5 py-1 text-xs font-medium text-autonomi-blue hover:bg-autonomi-blue/10"
+                  @click="connectionStore.retry()"
+                >
+                  Retry connection
+                </button>
               </div>
-            </div>
+            </template>
+            <template v-else-if="connectionStore.isConnecting">
+              <div class="flex items-center gap-2 text-sm text-autonomi-muted">
+                <div class="h-3 w-3 animate-spin rounded-full border-2 border-yellow-500 border-t-transparent" />
+                <span>Connecting to the Autonomi network…</span>
+              </div>
+            </template>
+            <template v-else>
+              <div class="flex items-center gap-2 text-sm text-autonomi-muted">
+                <div class="h-3 w-3 animate-spin rounded-full border-2 border-autonomi-blue border-t-transparent" />
+                <span>Obtaining quotes from network…</span>
+              </div>
+            </template>
           </div>
 
-          <p class="text-xs text-autonomi-muted">
-            {{ hasRealCosts ? 'Costs queried from the Autonomi network.' : 'Estimates are approximate and may vary based on network conditions.' }}
-            Gas fees (ETH) apply on top of storage costs.
+          <p v-if="allCostsReal" class="text-xs text-autonomi-muted">
+            Costs queried from the Autonomi network. Gas fees (ETH) apply on top of storage costs.
           </p>
-        </div>
-
-        <div v-else class="py-4 text-center text-sm text-autonomi-muted">
-          No files selected
         </div>
 
         <div class="mt-4 flex justify-end">
@@ -63,6 +86,7 @@
 
 <script setup lang="ts">
 import { formatBytes } from '~/utils/formatters'
+import { useConnectionStore } from '~/stores/connection'
 
 const props = defineProps<{
   open: boolean
@@ -72,12 +96,11 @@ const props = defineProps<{
 
 defineEmits<{ close: [] }>()
 
-const totalSize = computed(() => props.files.reduce((sum, f) => sum + f.size, 0))
-const hasRealCosts = computed(() => props.files.some(f => f.cost))
-
-/** Rough client-side estimate — real cost is determined by network quotes during upload. */
-function estimateCost(bytes: number) {
-  return (bytes / 1_048_576 * 0.05).toFixed(4)
-}
-
+const connectionStore = useConnectionStore()
+const allCostsReal = computed(() =>
+  props.files.length > 0 && props.files.every(f => f.cost),
+)
+const failedReason = computed(() =>
+  connectionStore.current.status === 'failed' ? connectionStore.current.reason : null,
+)
 </script>

--- a/components/files/UploadConfirmDialog.vue
+++ b/components/files/UploadConfirmDialog.vue
@@ -26,7 +26,15 @@
               :key="entry.id"
               class="flex items-center justify-between text-sm"
             >
-              <span class="max-w-[280px] truncate">{{ entry.name }}</span>
+              <span class="flex min-w-0 items-center gap-2">
+                <span class="max-w-[200px] truncate">{{ entry.name }}</span>
+                <span
+                  v-if="entry.alreadyStored"
+                  class="shrink-0 rounded bg-green-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-green-400"
+                >
+                  Already stored
+                </span>
+              </span>
               <span class="text-autonomi-muted">{{ entry.size_bytes ? formatBytes(entry.size_bytes) : '-' }}</span>
             </div>
           </div>
@@ -49,7 +57,18 @@
                quote spinner so users aren't left watching a spinner that will
                never resolve. No heuristic / placeholder values. -->
           <div class="rounded-md border border-autonomi-border bg-autonomi-surface/50 p-3 space-y-2">
-            <template v-if="quotedCost">
+            <template v-if="allAlreadyStored">
+              <div class="flex items-center gap-2 text-sm font-medium text-green-400">
+                <svg class="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span>Already stored on the network — free</span>
+              </div>
+              <p class="text-xs text-autonomi-muted">
+                Every chunk is already present. No ANT or gas will be spent.
+              </p>
+            </template>
+            <template v-else-if="quotedCost">
               <div class="flex items-center justify-between text-sm font-medium">
                 <span>Network storage cost</span>
                 <span class="text-autonomi-blue">{{ quotedCost }}</span>
@@ -58,6 +77,9 @@
                 <span>Estimated gas</span>
                 <span>{{ quotedGas ?? '—' }}</span>
               </div>
+              <p v-if="someAlreadyStored" class="text-xs text-green-400">
+                Some files are already stored — that portion costs nothing.
+              </p>
             </template>
             <template v-else-if="connectionStore.hasFailed">
               <div class="space-y-2">
@@ -136,7 +158,7 @@
             </div>
           </div>
 
-          <p v-if="quotedCost && effectivePaymentMode === 'regular'" class="text-xs text-autonomi-muted">
+          <p v-if="quotedCost && !allAlreadyStored && effectivePaymentMode === 'regular'" class="text-xs text-autonomi-muted">
             Estimated from a single network quote — final cost may vary slightly. Gas fees apply on top.
           </p>
 
@@ -210,6 +232,12 @@ const entries = computed<FileEntry[]>(() =>
 
 const allEstimated = computed(() =>
   entries.value.length > 0 && entries.value.every(e => e.estimate),
+)
+const allAlreadyStored = computed(() =>
+  entries.value.length > 0 && entries.value.every(e => e.alreadyStored),
+)
+const someAlreadyStored = computed(() =>
+  entries.value.some(e => e.alreadyStored),
 )
 const anyQuoting = computed(() =>
   entries.value.some(e => e.status === 'quoting' || e.status === 'queued_for_quote'),

--- a/components/files/UploadConfirmDialog.vue
+++ b/components/files/UploadConfirmDialog.vue
@@ -3,42 +3,51 @@
     <div
       v-if="open"
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      @click.self="$emit('cancel')"
+      @click.self="$emit('close')"
     >
       <div role="dialog" aria-modal="true" aria-labelledby="upload-confirm-title" class="w-[36rem] rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl">
-        <h2 id="upload-confirm-title" class="mb-4 text-lg font-medium">Confirm Upload</h2>
+        <h2 id="upload-confirm-title" class="mb-3 text-lg font-medium">Confirm Upload</h2>
 
-        <div v-if="loading" class="flex flex-col items-center py-8">
-          <p class="text-sm text-autonomi-muted">Estimating costs...</p>
+        <!-- Info banner: dialog is dismissible, job keeps running -->
+        <div class="mb-4 flex items-start gap-2 rounded-md border border-autonomi-blue/30 bg-autonomi-blue/5 px-3 py-2">
+          <svg class="mt-0.5 h-4 w-4 shrink-0 text-autonomi-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <p class="text-xs text-autonomi-muted">
+            You can close this window and come back when the quote is in. The upload stays pending until you approve or cancel it.
+          </p>
         </div>
 
-        <div v-else class="space-y-5">
+        <div class="space-y-5">
           <!-- File list -->
           <div class="max-h-32 space-y-1.5 overflow-y-auto">
             <div
-              v-for="file in files"
-              :key="file.name"
+              v-for="entry in entries"
+              :key="entry.id"
               class="flex items-center justify-between text-sm"
             >
-              <span class="max-w-[280px] truncate">{{ file.name }}</span>
-              <span class="text-autonomi-muted">{{ file.size ? formatBytes(file.size) : '-' }}</span>
+              <span class="max-w-[280px] truncate">{{ entry.name }}</span>
+              <span class="text-autonomi-muted">{{ entry.size_bytes ? formatBytes(entry.size_bytes) : '-' }}</span>
             </div>
           </div>
 
-          <!-- Payment mode -->
-          <div class="flex items-baseline justify-between">
+          <!-- Payment mode — only shown once the network has quoted the files.
+               Never guessed from chunk count: that was a fallback lie. -->
+          <div v-if="effectivePaymentMode" class="flex items-baseline justify-between">
             <span class="text-sm text-autonomi-muted">Payment</span>
             <div class="text-right">
               <span class="text-sm font-medium">{{ effectivePaymentMode === 'merkle' ? 'Merkle tree' : 'Regular' }}</span>
               <p class="text-xs text-autonomi-muted">
                 {{ effectivePaymentMode === 'merkle'
-                  ? `Single transaction for ${estimatedChunks} chunks — lower gas.`
-                  : `Per-batch payment for ${estimatedChunks} chunk${estimatedChunks !== 1 ? 's' : ''}.` }}
+                  ? `Single transaction for ${quotedChunks} chunks — lower gas.`
+                  : `Per-batch payment for ${quotedChunks} chunk${quotedChunks !== 1 ? 's' : ''}.` }}
               </p>
             </div>
           </div>
 
-          <!-- Cost breakdown -->
+          <!-- Cost breakdown. Connection-error takes priority over any in-flight
+               quote spinner so users aren't left watching a spinner that will
+               never resolve. No heuristic / placeholder values. -->
           <div class="rounded-md border border-autonomi-border bg-autonomi-surface/50 p-3 space-y-2">
             <template v-if="quotedCost">
               <div class="flex items-center justify-between text-sm font-medium">
@@ -47,25 +56,13 @@
               </div>
               <div class="flex items-center justify-between text-xs text-autonomi-muted">
                 <span>Estimated gas</span>
-                <span>{{ quotedGas ?? 'Estimating...' }}</span>
-              </div>
-            </template>
-            <template v-else-if="quoting">
-              <div class="flex items-center gap-2 text-sm text-autonomi-muted">
-                <div class="h-3 w-3 animate-spin rounded-full border-2 border-autonomi-blue border-t-transparent" />
-                <span>Getting cost quote from network...</span>
-              </div>
-            </template>
-            <template v-else-if="connectionStore.isConnecting">
-              <div class="flex items-center gap-2 text-sm text-autonomi-muted">
-                <div class="h-3 w-3 animate-spin rounded-full border-2 border-yellow-500 border-t-transparent" />
-                <span>Connecting to the Autonomi network...</span>
+                <span>{{ quotedGas ?? '—' }}</span>
               </div>
             </template>
             <template v-else-if="connectionStore.hasFailed">
               <div class="space-y-2">
                 <div class="text-sm text-yellow-500/80">
-                  Could not connect to the Autonomi network.
+                  Not connected to the Autonomi network — cost estimate unavailable.
                 </div>
                 <div v-if="failedReason" class="text-xs text-autonomi-muted break-words">
                   {{ failedReason }}
@@ -75,14 +72,20 @@
                   class="rounded-md border border-autonomi-blue/40 px-2.5 py-1 text-xs font-medium text-autonomi-blue hover:bg-autonomi-blue/10"
                   @click="connectionStore.retry()"
                 >
-                  Retry
+                  Retry connection
                 </button>
               </div>
             </template>
-            <template v-else>
+            <template v-else-if="connectionStore.isConnecting">
+              <div class="flex items-center gap-2 text-sm text-autonomi-muted">
+                <div class="h-3 w-3 animate-spin rounded-full border-2 border-yellow-500 border-t-transparent" />
+                <span>Connecting to the Autonomi network…</span>
+              </div>
+            </template>
+            <template v-else-if="anyQuoting">
               <div class="flex items-center gap-2 text-sm text-autonomi-muted">
                 <div class="h-3 w-3 animate-spin rounded-full border-2 border-autonomi-blue border-t-transparent" />
-                <span>Estimating cost...</span>
+                <span>Obtaining quote from network…</span>
               </div>
             </template>
           </div>
@@ -137,19 +140,39 @@
             Estimated from a single network quote — final cost may vary slightly. Gas fees apply on top.
           </p>
 
-          <div class="flex justify-end gap-2">
-            <button
-              class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
-              @click="$emit('cancel')"
-            >
-              Cancel
-            </button>
-            <button
-              class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
-              @click="handleConfirm"
-            >
-              Upload {{ files.length }} file{{ files.length !== 1 ? 's' : '' }}
-            </button>
+          <!-- Buttons grouped by intent: both "back out" actions on the left,
+               the money-spending Approve isolated on the right so no
+               fat-finger can land on it from a dismiss attempt. -->
+          <div class="flex items-center justify-between gap-2">
+            <div class="flex gap-2">
+              <button
+                class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
+                @click="$emit('close')"
+              >
+                Close
+              </button>
+              <button
+                class="rounded-md border border-red-500/40 px-3 py-1.5 text-sm text-red-400 hover:bg-red-500/10"
+                @click="$emit('cancelUpload')"
+              >
+                Cancel Upload
+              </button>
+            </div>
+            <div class="flex items-center gap-2">
+              <span
+                v-if="!canApprove && entries.length > 1"
+                class="text-xs text-autonomi-muted"
+              >
+                Ready: {{ readyCount }} of {{ entries.length }}
+              </span>
+              <button
+                class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                :disabled="!canApprove"
+                @click="handleApprove"
+              >
+                {{ approveButtonLabel }}
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -159,46 +182,89 @@
 
 <script setup lang="ts">
 import { formatBytes } from '~/utils/formatters'
-import { MERKLE_THRESHOLD, AVG_CHUNK_SIZE } from '~/utils/constants'
 import { useConnectionStore } from '~/stores/connection'
+import { useFilesStore, type FileEntry } from '~/stores/files'
+import { formatNanoTokens, formatGasCost } from '~/utils/payment'
 
 const props = defineProps<{
   open: boolean
-  files: { name: string; size: number; path: string }[]
-  loading: boolean
-  /** Real cost from network quote (e.g. "0.0234 ANT" or "Determined on-chain") */
-  quotedCost?: string | null
-  /** Estimated gas cost (e.g. "0.000142 ETH") */
-  quotedGas?: string | null
-  /** Whether a network quote is in progress */
-  quoting?: boolean
-  /** Payment mode selected by the backend (null if no quote yet) */
-  quotedPaymentMode?: 'wave-batch' | 'merkle' | null
-  /**
-   * Kept for backward compatibility with the parent — the dialog now reads
-   * the connection state directly from useConnectionStore() so it can show
-   * a Retry button when the connect fails.
-   */
-  networkConnected?: boolean
+  /** IDs of FileEntry rows this dialog is bound to. Dialog is a thin view —
+   *  all quote/estimate state lives on the entries themselves. */
+  fileIds: number[]
 }>()
 
 const emit = defineEmits<{
-  confirm: [options: { visibility: 'private' | 'public'; paymentMode: 'regular' | 'merkle' }]
-  cancel: []
+  approve: [options: { visibility: 'private' | 'public'; paymentMode: 'regular' | 'merkle' }]
+  cancelUpload: []
+  close: []
 }>()
 
+const filesStore = useFilesStore()
 const connectionStore = useConnectionStore()
+
+const entries = computed<FileEntry[]>(() =>
+  props.fileIds
+    .map(id => filesStore.findById(id))
+    .filter((e): e is FileEntry => e !== undefined),
+)
+
+const allEstimated = computed(() =>
+  entries.value.length > 0 && entries.value.every(e => e.estimate),
+)
+const anyQuoting = computed(() =>
+  entries.value.some(e => e.status === 'quoting' || e.status === 'queued_for_quote'),
+)
+const readyCount = computed(() =>
+  entries.value.filter(e => e.status === 'awaiting_approval').length,
+)
+/** Approve is gated on every entry being `awaiting_approval`. Partial
+ *  approve would leave some files silently queued and invite mis-clicks;
+ *  block until the whole batch is ready. */
+const canApprove = computed(() =>
+  entries.value.length > 0 && readyCount.value === entries.value.length,
+)
+
+/** Sum of estimate costs across entries. Null unless every entry has a real
+ *  estimate — partial or fake totals would mislead the user. */
+const quotedCost = computed<string | null>(() => {
+  if (!allEstimated.value) return null
+  const totalAtto = entries.value.reduce(
+    (sum, e) => sum + BigInt(e.estimate!.storage_cost_atto), 0n,
+  )
+  return formatNanoTokens(totalAtto.toString())
+})
+
+const quotedGas = computed<string | null>(() => {
+  if (!allEstimated.value) return null
+  const totalGas = entries.value.reduce(
+    (sum, e) => sum + BigInt(e.estimate!.estimated_gas_cost_wei), 0n,
+  )
+  return formatGasCost(totalGas.toString())
+})
+
+/** Real chunk count from the network estimates. Null until all entries have
+ *  been quoted — no client-side size-based fallback. */
+const quotedChunks = computed<number | null>(() => {
+  if (!allEstimated.value) return null
+  return entries.value.reduce((sum, e) => sum + e.estimate!.chunk_count, 0)
+})
+
+/** Payment mode is reported by the network — we do not guess it from size.
+ *  Null until all entries are quoted, so the template can hide the Payment
+ *  row entirely instead of showing a misleading prediction. */
+const effectivePaymentMode = computed<'regular' | 'merkle' | null>(() => {
+  if (!allEstimated.value) return null
+  const modes = entries.value.map(e => e.paymentMode).filter(Boolean) as ('regular' | 'merkle')[]
+  if (modes.length !== entries.value.length) return null
+  return modes.includes('merkle') ? 'merkle' : 'regular'
+})
 
 const visibility = ref<'private' | 'public'>('private')
 
-const totalSize = computed(() => props.files.reduce((sum, f) => sum + f.size, 0))
-const estimatedChunks = computed(() => Math.max(1, Math.ceil(totalSize.value / AVG_CHUNK_SIZE)))
-
-/** Payment mode — determined by backend quote, or estimated from file size */
-const effectivePaymentMode = computed(() => {
-  if (props.quotedPaymentMode === 'merkle') return 'merkle'
-  if (props.quotedPaymentMode === 'wave-batch') return 'regular'
-  return estimatedChunks.value >= MERKLE_THRESHOLD ? 'merkle' : 'regular'
+const approveButtonLabel = computed(() => {
+  const n = entries.value.length
+  if (n <= 1) return 'Approve Upload'
+  return `Approve ${n} Uploads`
 })
 
 const failedReason = computed(() =>
@@ -214,11 +280,14 @@ watch(
   },
 )
 
-function handleConfirm() {
-  emit('confirm', {
+function handleApprove() {
+  if (!canApprove.value) return
+  // Fall back to 'regular' when the estimate failed — backend redetermines
+  // the real payment mode from the live quote's chunk count anyway, so the
+  // frontend's guess is only used for status display during paying.
+  emit('approve', {
     visibility: visibility.value,
-    paymentMode: effectivePaymentMode.value,
+    paymentMode: effectivePaymentMode.value ?? 'regular',
   })
 }
-
 </script>

--- a/components/files/UploadConfirmDialog.vue
+++ b/components/files/UploadConfirmDialog.vue
@@ -182,10 +182,10 @@
             </div>
             <div class="flex items-center gap-2">
               <span
-                v-if="!canApprove && entries.length > 1"
+                v-if="!canApprove && needsApprovalEntries.length > 1"
                 class="text-xs text-autonomi-muted"
               >
-                Ready: {{ readyCount }} of {{ entries.length }}
+                Ready: {{ readyCount }} of {{ needsApprovalEntries.length }}
               </span>
               <button
                 class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
@@ -242,14 +242,21 @@ const someAlreadyStored = computed(() =>
 const anyQuoting = computed(() =>
   entries.value.some(e => e.status === 'quoting' || e.status === 'queued_for_quote'),
 )
-const readyCount = computed(() =>
-  entries.value.filter(e => e.status === 'awaiting_approval').length,
+/** Entries that still require a user decision — already-stored files auto-
+ *  process through the scheduler and never see `awaiting_approval`, so they
+ *  don't count toward the approve gate. */
+const needsApprovalEntries = computed(() =>
+  entries.value.filter(e => !e.alreadyStored),
 )
-/** Approve is gated on every entry being `awaiting_approval`. Partial
- *  approve would leave some files silently queued and invite mis-clicks;
- *  block until the whole batch is ready. */
+const readyCount = computed(() =>
+  needsApprovalEntries.value.filter(e => e.status === 'awaiting_approval').length,
+)
+/** Approve is gated on every non-stored entry being `awaiting_approval`.
+ *  Partial approve would leave some files silently queued and invite
+ *  mis-clicks; block until the whole approvable batch is ready. */
 const canApprove = computed(() =>
-  entries.value.length > 0 && readyCount.value === entries.value.length,
+  needsApprovalEntries.value.length > 0
+  && readyCount.value === needsApprovalEntries.value.length,
 )
 
 /** Sum of estimate costs across entries. Null unless every entry has a real
@@ -290,7 +297,7 @@ const effectivePaymentMode = computed<'regular' | 'merkle' | null>(() => {
 const visibility = ref<'private' | 'public'>('private')
 
 const approveButtonLabel = computed(() => {
-  const n = entries.value.length
+  const n = needsApprovalEntries.value.length
   if (n <= 1) return 'Approve Upload'
   return `Approve ${n} Uploads`
 })

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -375,6 +375,17 @@ function basenameOf(path: string): string {
 // ── Row display helpers ──
 
 function statusLabel(file: FileEntry): string {
+  // Already-stored uploads collapse every state after the initial estimate
+  // into a single honest label. The real backend still cycles through
+  // quoting → paying → uploading for ant-core's bookkeeping, but it's all
+  // a no-op sub-second dance in terms of user-visible work.
+  if (
+    file.alreadyStored
+    && (file.status === 'quoting' || file.status === 'queued_for_upload' || file.status === 'paying' || file.status === 'uploading')
+  ) {
+    return 'Saving datamap…'
+  }
+
   if (file.status === 'uploading') return 'Uploading'
   if (file.status === 'downloading') return 'Downloading'
   if (file.status === 'downloaded') return 'Downloaded'
@@ -594,6 +605,28 @@ watchEffect(() => {
   void settingsStore.devnetActive
   kickScheduler()
 })
+
+// Auto-dismiss the confirm dialog when every selected entry was detected as
+// already stored on the network. Those entries bypass `awaiting_approval`
+// (no user decision left to make) and flow through the scheduler on their
+// own, so leaving the dialog open waiting for an Approve that can never
+// enable is just clutter.
+watch(
+  () => selectedFileIds.value.map(id => filesStore.findById(id)?.alreadyStored),
+  (flags) => {
+    if (!showUploadConfirm.value) return
+    if (flags.length === 0) return
+    if (flags.some(f => f === undefined)) return
+    if (!flags.every(f => f === true)) return
+    const n = flags.length
+    showUploadConfirm.value = false
+    selectedFileIds.value = []
+    toastStore.add(
+      `${n} file${n !== 1 ? 's' : ''} already stored — saving datamap`,
+      'info',
+    )
+  },
+)
 
 function cancelPendingUploads() {
   for (const id of selectedFileIds.value) filesStore.cancelPendingUpload(id)

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -114,8 +114,13 @@
                   <StatusBadge :status="statusLabel(file)" />
                 </td>
                 <td class="px-4 py-2.5 text-autonomi-muted">
-                  <span>{{ file.cost ?? '-' }}</span>
-                  <span v-if="file.gas_cost" class="block text-[10px] text-autonomi-muted/60">+ {{ file.gas_cost }} gas</span>
+                  <template v-if="file.alreadyStored">
+                    <span class="text-green-400">Free — already stored</span>
+                  </template>
+                  <template v-else>
+                    <span>{{ file.cost ?? '-' }}</span>
+                    <span v-if="file.gas_cost" class="block text-[10px] text-autonomi-muted/60">+ {{ file.gas_cost }} gas</span>
+                  </template>
                 </td>
                 <td class="px-4 py-2.5">
                   <span

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -540,7 +540,9 @@ function kickScheduler() {
   const budget = settingsStore.uploadConcurrency
 
   while (true) {
-    const active = filesStore.quotingCount + filesStore.uploadingCount
+    const quotingCount = filesStore.quotingCount
+    const uploadingCount = filesStore.uploadingCount
+    const active = quotingCount + uploadingCount
     if (active >= budget) break
 
     const quoteHead = filesStore.queuedForQuote[0]
@@ -572,21 +574,21 @@ function kickScheduler() {
   }
 }
 
-// React whenever any of the scheduler's inputs change: the budget, the
-// active counts (slots freed), the queue lengths (new work enqueued), or
-// the connection state flipping to online.
-watch(
-  () => [
-    settingsStore.uploadConcurrency,
-    filesStore.quotingCount,
-    filesStore.uploadingCount,
-    filesStore.queuedForQuote.length,
-    filesStore.queuedForUpload.length,
-    autonomiConnected.value,
-    settingsStore.devnetActive,
-  ],
-  () => { kickScheduler() },
-)
+// Auto-track every reactive dep the scheduler reads via watchEffect. Runs
+// once on setup and re-runs whenever any of the store getters / connection
+// state change. watchEffect is more robust here than the array-source form
+// of watch because we don't have to remember to list every dep by hand.
+watchEffect(() => {
+  // Touch every reactive input so it's registered, then kick.
+  void settingsStore.uploadConcurrency
+  void filesStore.quotingCount
+  void filesStore.uploadingCount
+  void filesStore.queuedForQuote.length
+  void filesStore.queuedForUpload.length
+  void autonomiConnected.value
+  void settingsStore.devnetActive
+  kickScheduler()
+})
 
 function cancelPendingUploads() {
   for (const id of selectedFileIds.value) filesStore.cancelPendingUpload(id)

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -11,6 +11,15 @@
         </button>
         <button
           class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
+          @click="estimateCost"
+        >
+          Estimate Cost
+        </button>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <button
+          class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
           @click="showDownloadDialog = true"
         >
           Download by Address
@@ -21,18 +30,6 @@
         >
           Download by Datamap
         </button>
-        <button
-          class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
-          @click="estimateCost"
-        >
-          Estimate Cost
-        </button>
-      </div>
-
-      <div class="flex items-center gap-3">
-        <span v-if="filesStore.files.length" class="text-xs text-autonomi-muted">
-          {{ filesStore.files.length }} file{{ filesStore.files.length !== 1 ? 's' : '' }}
-        </span>
       </div>
     </div>
 
@@ -109,6 +106,7 @@
                 :key="file.id"
                 class="transition-colors"
                 :class="rowClass(file)"
+                @click="onRowClick(file)"
               >
                 <td class="px-4 py-2.5">{{ file.name }}</td>
                 <td class="px-4 py-2.5 text-autonomi-muted">{{ file.size_bytes ? formatBytes(file.size_bytes) : '-' }}</td>
@@ -230,15 +228,10 @@
 
     <FilesUploadConfirmDialog
       :open="showUploadConfirm"
-      :files="pendingUploadFiles"
-      :loading="uploadEstimating"
-      :quoted-cost="quotedCostDisplay"
-      :quoted-gas="quotedGasEstimate"
-      :quoting="isQuoting"
-      :quoted-payment-mode="quotedPaymentMode"
-      :network-connected="autonomiConnected"
-      @confirm="confirmUpload"
-      @cancel="cancelUpload"
+      :file-ids="selectedFileIds"
+      @approve="approveUpload"
+      @cancel-upload="cancelPendingUploads"
+      @close="closeUploadDialog"
     />
 
     <FilesCostEstimateDialog
@@ -255,7 +248,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { getCurrentWebview } from '@tauri-apps/api/webview'
 import { open as openFileDialog } from '@tauri-apps/plugin-dialog'
 import { revealItemInDir } from '@tauri-apps/plugin-opener'
-import { useFilesStore, type FileEntry, type UploadCostEstimate } from '~/stores/files'
+import { useFilesStore, type FileEntry } from '~/stores/files'
 import { formatBytes, truncateAddress } from '~/utils/formatters'
 import { formatNanoTokens, formatGasCost } from '~/utils/payment'
 import { useSettingsStore } from '~/stores/settings'
@@ -382,19 +375,40 @@ function statusLabel(file: FileEntry): string {
   if (file.status === 'downloaded') return 'Downloaded'
   if (file.status === 'failed') return file.error ? `Failed: ${file.error}` : 'Failed'
   if (file.status === 'complete') return 'Complete'
-  if (file.status === 'quoting') return 'Preparing upload…'
+  if (file.status === 'queued_for_quote') return 'Queued: quoting'
+  if (file.status === 'queued_for_upload') return 'Queued: uploading'
+  if (file.status === 'quoting') {
+    if (connectionStore.hasFailed) return 'Network unavailable'
+    if (!connectionStore.isConnected) return 'Connecting to network…'
+    return 'Obtaining quote…'
+  }
+  if (file.status === 'awaiting_approval') return 'Ready to approve'
   if (file.status === 'paying') return 'Paying'
   return file.status
 }
 
+function isReopenable(file: FileEntry): boolean {
+  if (file.kind !== 'upload') return false
+  return (
+    file.status === 'queued_for_quote'
+    || file.status === 'quoting'
+    || file.status === 'awaiting_approval'
+    || file.status === 'queued_for_upload'
+  )
+}
 
 function rowClass(file: FileEntry): string {
   if (file.status === 'downloaded') return 'hover:bg-autonomi-surface/50 cursor-pointer bg-autonomi-blue/5'
+  if (isReopenable(file)) return 'hover:bg-autonomi-surface/50 cursor-pointer'
   if (file.status === 'failed') return 'hover:bg-autonomi-surface/50 opacity-60'
   return 'hover:bg-autonomi-surface/50'
 }
 
 function onRowClick(file: FileEntry) {
+  if (isReopenable(file)) {
+    reopenUploadDialog(file.id)
+    return
+  }
   if (file.status === 'downloaded' && file.dest_path) {
     openFolder(file.dest_path)
     filesStore.acknowledgeDownload(file.id)
@@ -423,15 +437,14 @@ async function setupDragDrop() {
 }
 
 // ── Upload flow ──
+//
+// The dialog is a thin view bound to FileEntry ids. Quote state lives on the
+// entries themselves (stores/files.ts), which means the dialog can be closed
+// and reopened mid-flight without losing anything. Row click on a pending
+// entry in the uploads table reopens the dialog for that entry.
 
 const showUploadConfirm = ref(false)
-const uploadEstimating = ref(false)
-const pendingUploadFiles = ref<{ name: string; size: number; path: string }[]>([])
-const pendingMetas = ref<FileMeta[]>([])
-const isQuoting = ref(false)
-const quotedCostDisplay = ref<string | null>(null)
-const quotedGasEstimate = ref<string | null>(null)
-const quotedPaymentMode = ref<'wave-batch' | 'merkle' | null>(null)
+const selectedFileIds = ref<number[]>([])
 
 async function getFileMetas(paths: string[]): Promise<FileMeta[]> {
   try {
@@ -461,111 +474,129 @@ async function uploadFiles() {
 }
 
 async function showUploadConfirmForPaths(paths: string[]) {
-  uploadEstimating.value = true
-  pendingUploadFiles.value = []
-  pendingMetas.value = []
-  quotedCostDisplay.value = null
-  quotedGasEstimate.value = null
-  quotedPaymentMode.value = null
+  // Entries enter `queued_for_quote`; the scheduler promotes them to
+  // `quoting` as concurrency slots open. Dialog renders off the entries,
+  // so rows appear immediately and reactively update as the scheduler
+  // works through them.
+  const metas = await getFileMetas(paths)
+  const ids = metas.map(m => filesStore.addUpload(m.name, m.path, m.size))
+  selectedFileIds.value = ids
   showUploadConfirm.value = true
 
-  const metas = await getFileMetas(paths)
-  pendingMetas.value = metas
-  pendingUploadFiles.value = metas.map(m => ({
-    name: m.name,
-    size: m.size,
-    path: m.path,
-  }))
-  uploadEstimating.value = false
-
-  // Start real quoting in background (only when connected to network).
-  // The watcher below picks up the case where connection completes after the
-  // dialog is already open.
-  if ((autonomiConnected.value || settingsStore.devnetActive) && !settingsStore.indelibleConnected) {
-    startQuoting(metas)
+  // Indelible bypass: the remote gateway handles pricing, so skip the
+  // quote phase entirely — entries jump straight to `awaiting_approval`.
+  if (settingsStore.indelibleConnected && !settingsStore.devnetActive) {
+    for (const id of ids) filesStore.updateEntry(id, { status: 'awaiting_approval' })
+    return
   }
+
+  kickScheduler()
 }
 
-// If the embedded ant-core client connects (or finishes retrying) while the
-// upload dialog is open and we don't yet have a quote, kick off quoting now.
-// Without this, opening the dialog before the network is ready leaves the
-// dialog stuck on the misleading "Cost will be quoted from the network when
-// upload starts" fallback even after the connection succeeds.
-watch(
-  () => autonomiConnected.value,
-  (connected) => {
-    if (!connected) return
-    if (!showUploadConfirm.value) return
-    if (settingsStore.indelibleConnected) return
-    if (isQuoting.value) return
-    if (quotedCostDisplay.value) return
-    if (pendingMetas.value.length === 0) return
-    startQuoting(pendingMetas.value)
-  },
-)
-
-async function startQuoting(metas: FileMeta[]) {
-  isQuoting.value = true
-  try {
-    // Use the light-weight `estimate_file_cost` path: encrypts locally, samples
-    // one quote per file, no chunks parked. Confirm click runs the real
-    // `start_upload` (which does park). Each estimate is independent, so
-    // parallelize — cuts dialog-open latency for multi-file uploads.
-    const estimates = await Promise.all(
-      metas.map(meta => filesStore.estimateFileCost(meta.path)),
-    )
-    const valid = estimates.filter((e): e is UploadCostEstimate => e !== null)
-
-    if (valid.length > 0) {
-      // ant-core PaymentMode 'single' maps to the frontend's 'wave-batch'.
-      const mode = valid[0].payment_mode === 'merkle' ? 'merkle' : 'wave-batch'
-      quotedPaymentMode.value = mode
-
-      const totalStorageAtto = valid.reduce(
-        (sum, e) => sum + BigInt(e.storage_cost_atto), 0n,
-      )
-      quotedCostDisplay.value = formatNanoTokens(totalStorageAtto.toString())
-
-      const totalGasWei = valid.reduce(
-        (sum, e) => sum + BigInt(e.estimated_gas_cost_wei), 0n,
-      )
-      quotedGasEstimate.value = formatGasCost(totalGasWei.toString())
-    }
-  } catch {
-    // Estimate failed — user can still proceed (real quote runs at upload time).
-  } finally {
-    isQuoting.value = false
-  }
+// Reopen the confirm dialog for an entry the user clicked in the uploads
+// table. Supports the four pre-payment stalls; `paying`/`uploading` rows
+// stay non-clickable (nothing actionable there).
+function reopenUploadDialog(id: number) {
+  selectedFileIds.value = [id]
+  showUploadConfirm.value = true
 }
 
-function confirmUpload(options: { visibility: 'private' | 'public'; paymentMode: 'regular' | 'merkle' }) {
+function approveUpload(options: { visibility: 'private' | 'public'; paymentMode: 'regular' | 'merkle' }) {
   showUploadConfirm.value = false
-  const wagmiConfig = getWagmiConfig()
+  const ids = selectedFileIds.value.slice()
+  selectedFileIds.value = []
 
-  for (const file of pendingUploadFiles.value) {
-    const id = filesStore.addUpload(file.name, file.path, file.size)
+  for (const id of ids) {
+    const entry = filesStore.findById(id)
+    if (!entry || entry.status !== 'awaiting_approval') continue
+
+    filesStore.updateEntry(id, { visibility: options.visibility })
 
     if (settingsStore.indelibleConnected && !settingsStore.devnetActive) {
       filesStore.startIndelibleUpload(id)
-    } else if ((autonomiConnected.value || settingsStore.devnetActive) && wagmiConfig) {
-      // No preQuote handoff: the dialog showed a light estimate (no chunks
-      // parked). `startRealUpload` fetches a fresh real quote via
-      // `start_upload`, which is what parks chunks — only on confirm.
-      filesStore.startRealUpload(id, wagmiConfig, options)
     } else {
-      filesStore.updateEntry(id, { status: 'failed', error: 'Not connected to network or wallet' })
-      toastStore.add('Upload requires network connection and wallet', 'warning')
+      // Autonomi path — queue for the scheduler to dispatch.
+      filesStore.enqueueForUpload(id)
     }
   }
-  pendingUploadFiles.value = []
-  quotedCostDisplay.value = null
+  kickScheduler()
 }
 
-function cancelUpload() {
+// ── Upload concurrency scheduler ──
+//
+// Single budget `settingsStore.uploadConcurrency` covers both quoting and
+// uploading (they both hit the network; Autonomi throughput degrades non-
+// linearly so serial-by-default is the safe choice).
+//
+// Priority: promote `queued_for_quote` first so the dialog can enable the
+// Approve button ASAP; then drain `queued_for_upload` post-approval. Offline
+// → skip all promotions (entries stay queued and resume when the watcher
+// sees `autonomiConnected` flip).
+function kickScheduler() {
+  if (settingsStore.indelibleConnected && !settingsStore.devnetActive) return
+  const online = autonomiConnected.value || settingsStore.devnetActive
+  if (!online) return
+
+  const budget = settingsStore.uploadConcurrency
+
+  while (true) {
+    const active = filesStore.quotingCount + filesStore.uploadingCount
+    if (active >= budget) break
+
+    const quoteHead = filesStore.queuedForQuote[0]
+    if (quoteHead) {
+      // beginQuoting synchronously flips status to `quoting`, then awaits
+      // the estimate; we count the slot from the status change.
+      filesStore.beginQuoting(quoteHead.id)
+      continue
+    }
+
+    const uploadHead = filesStore.queuedForUpload[0]
+    if (!uploadHead) break
+
+    const wagmiConfig = getWagmiConfig()
+    if (!wagmiConfig) {
+      filesStore.updateEntry(uploadHead.id, {
+        status: 'failed',
+        error: 'Wallet not connected',
+      })
+      toastStore.add('Upload requires a wallet', 'warning')
+      continue
+    }
+
+    const opts = {
+      visibility: uploadHead.visibility ?? 'private' as const,
+      paymentMode: uploadHead.paymentMode ?? 'regular' as const,
+    }
+    filesStore.startRealUpload(uploadHead.id, wagmiConfig, opts)
+  }
+}
+
+// React whenever any of the scheduler's inputs change: the budget, the
+// active counts (slots freed), the queue lengths (new work enqueued), or
+// the connection state flipping to online.
+watch(
+  () => [
+    settingsStore.uploadConcurrency,
+    filesStore.quotingCount,
+    filesStore.uploadingCount,
+    filesStore.queuedForQuote.length,
+    filesStore.queuedForUpload.length,
+    autonomiConnected.value,
+    settingsStore.devnetActive,
+  ],
+  () => { kickScheduler() },
+)
+
+function cancelPendingUploads() {
+  for (const id of selectedFileIds.value) filesStore.cancelPendingUpload(id)
+  selectedFileIds.value = []
   showUploadConfirm.value = false
-  pendingUploadFiles.value = []
-  quotedCostDisplay.value = null
-  isQuoting.value = false
+}
+
+function closeUploadDialog() {
+  showUploadConfirm.value = false
+  selectedFileIds.value = []
 }
 
 // ── Download flow ──

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -118,6 +118,30 @@
       </button>
       <div v-if="showAdvanced" class="mt-2 space-y-4">
 
+        <!-- Upload concurrency -->
+        <div class="rounded-lg border border-autonomi-border p-4">
+          <div class="flex items-center justify-between gap-3">
+            <div class="min-w-0 flex-1">
+              <h3 class="text-sm font-medium">Upload concurrency</h3>
+              <p class="mt-1 text-xs text-autonomi-muted">
+                This controls how many quotes/uploads can be running at the same time.
+              </p>
+              <p class="mt-1 text-xs text-autonomi-muted">
+                Note that this has a very large impact on performance.
+              </p>
+            </div>
+            <input
+              :value="settingsStore.uploadConcurrency"
+              type="number"
+              :min="UPLOAD_CONCURRENCY_MIN"
+              :max="UPLOAD_CONCURRENCY_MAX"
+              step="1"
+              class="w-16 shrink-0 rounded-md border border-autonomi-border bg-autonomi-dark px-2 py-1 text-center text-sm text-autonomi-text focus:border-autonomi-blue focus:outline-none"
+              @change="onConcurrencyChange(($event.target as HTMLInputElement).value)"
+            />
+          </div>
+        </div>
+
         <!-- Indelible Enterprise Connection (only show setup when not connected) -->
         <div v-if="!settingsStore.indelibleConnected" class="rounded-lg border border-autonomi-border p-4">
           <div class="flex items-center justify-between">
@@ -383,7 +407,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { open } from '@tauri-apps/plugin-dialog'
 import { openUrl as tauriOpenUrl } from '@tauri-apps/plugin-opener'
 import { arbitrum, arbitrumSepolia } from 'viem/chains'
-import { setDevnetWalletKey } from '~/stores/settings'
+import { setDevnetWalletKey, UPLOAD_CONCURRENCY_MIN, UPLOAD_CONCURRENCY_MAX } from '~/stores/settings'
 import { useSettingsStore } from '~/stores/settings'
 import { isValidEthAddress } from '~/utils/validators'
 import { useToastStore } from '~/stores/toasts'
@@ -610,6 +634,12 @@ async function saveDaemon() {
   await settingsStore.setDaemonUrl(val)
   editingDaemon.value = false
   toasts.add('Daemon URL updated', 'info')
+}
+
+async function onConcurrencyChange(raw: string) {
+  const n = Number.parseInt(raw, 10)
+  if (!Number.isFinite(n)) return
+  await settingsStore.setUploadConcurrency(n)
 }
 
 async function copyDiagnostics() {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -24,6 +24,12 @@ pub struct AppConfig {
     pub indelible_api_key: Option<String>,
     #[serde(default = "default_theme_mode")]
     pub theme_mode: String,
+    /// Max concurrent quote/upload operations. Defaults to 1 — testing shows
+    /// concurrent uploads slow down non-linearly (2 files ≠ 2× time, often
+    /// 4–12× on real networks), so serial is the safe default. Power users
+    /// can tune up to 8 via Settings → Advanced.
+    #[serde(default = "default_upload_concurrency")]
+    pub upload_concurrency: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,6 +66,10 @@ pub struct UploadHistory {
 
 fn default_theme_mode() -> String {
     "dark".to_string()
+}
+
+fn default_upload_concurrency() -> u32 {
+    1
 }
 
 fn default_daemon_url() -> String {
@@ -106,6 +116,7 @@ impl Default for AppConfig {
             indelible_url: None,
             indelible_api_key: None,
             theme_mode: default_theme_mode(),
+            upload_concurrency: default_upload_concurrency(),
         }
     }
 }

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -1,4 +1,4 @@
-import { defineStore } from 'pinia'
+import { acceptHMRUpdate, defineStore } from 'pinia'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import { useToastStore } from './toasts'
@@ -37,13 +37,16 @@ export interface UploadQuote {
 // ── Unified file entry ──
 
 export type FileStatus =
-  | 'complete'      // Normal row, no active transfer
-  | 'quoting'       // Upload: getting cost estimate
-  | 'paying'        // Upload: wallet payment in progress
-  | 'uploading'     // Upload: data being sent to network
-  | 'downloading'   // Download: fetching from network
-  | 'downloaded'    // Download complete, waiting for user to open folder
-  | 'failed'        // Transfer failed
+  | 'complete'           // Normal row, no active transfer
+  | 'queued_for_quote'   // Upload: waiting in queue for a quoting slot
+  | 'quoting'            // Upload: getting cost estimate
+  | 'awaiting_approval'  // Upload: estimate in, waiting for user to click Approve
+  | 'queued_for_upload'  // Upload: approved, waiting in queue for an upload slot
+  | 'paying'             // Upload: wallet payment in progress
+  | 'uploading'          // Upload: data being sent to network
+  | 'downloading'        // Download: fetching from network
+  | 'downloaded'         // Download complete, waiting for user to open folder
+  | 'failed'             // Transfer failed
 
 export interface FileEntry {
   /** Unique ID for reactive tracking */
@@ -84,9 +87,29 @@ export interface FileEntry {
   duration?: number
   /** Error message if failed */
   error?: string
+  /** Raw light-estimate result (held while the entry is in the confirm dialog) */
+  estimate?: UploadCostEstimate
+  /** Payment mode derived from the estimate; carried through to the real upload */
+  paymentMode?: 'regular' | 'merkle'
+  /** Visibility chosen in the confirm dialog */
+  visibility?: 'private' | 'public'
 }
 
-const ACTIVE_STATUSES: FileStatus[] = ['quoting', 'paying', 'uploading', 'downloading', 'downloaded']
+// Pinned rows (top of the table, independent sort). Includes the two queued
+// states and awaiting_approval because the user must still see them and be
+// able to reopen the dialog — they just aren't doing network work yet.
+const ACTIVE_STATUSES: FileStatus[] = [
+  'queued_for_quote',
+  'quoting',
+  'awaiting_approval',
+  'queued_for_upload',
+  'paying',
+  'uploading',
+  'downloading',
+  'downloaded',
+]
+// Entries with live network activity. Excludes the queued/awaiting_approval
+// stalls (they don't need progress bars or spinners in the header).
 const IN_FLIGHT_STATUSES: FileStatus[] = ['quoting', 'paying', 'uploading', 'downloading']
 
 /** Shape persisted to upload_history.json (kept for backwards compat) */
@@ -135,6 +158,29 @@ export const useFilesStore = defineStore('files', {
 
     hasActiveTransfers: (state) =>
       state.files.some(f => IN_FLIGHT_STATUSES.includes(f.status)),
+
+    /** Uploads currently holding a quoting slot. Used by the page scheduler
+     *  to decide whether to promote the next `queued_for_quote` entry. */
+    quotingCount: (state) =>
+      state.files.filter(f => f.kind === 'upload' && f.status === 'quoting').length,
+
+    /** Uploads currently holding an upload slot (payment or chunk storage). */
+    uploadingCount: (state) =>
+      state.files.filter(
+        f => f.kind === 'upload' && (f.status === 'paying' || f.status === 'uploading'),
+      ).length,
+
+    /** FIFO list (oldest first, by row id) of entries waiting for a quote slot. */
+    queuedForQuote: (state) =>
+      state.files
+        .filter(f => f.kind === 'upload' && f.status === 'queued_for_quote')
+        .sort((a, b) => a.id - b.id),
+
+    /** FIFO list of entries waiting for an upload slot (post-approval). */
+    queuedForUpload: (state) =>
+      state.files
+        .filter(f => f.kind === 'upload' && f.status === 'queued_for_upload')
+        .sort((a, b) => a.id - b.id),
   },
 
   actions: {
@@ -223,6 +269,8 @@ export const useFilesStore = defineStore('files', {
 
     // ── Upload flow ──
 
+    /** Create a new upload row. Entry starts in `queued_for_quote`; the page
+     *  scheduler promotes it to `quoting` when a concurrency slot opens. */
     addUpload(name: string, path: string, size_bytes: number): number {
       const id = this.nextId++
       this.files.unshift({
@@ -231,11 +279,62 @@ export const useFilesStore = defineStore('files', {
         name,
         path,
         size_bytes,
-        status: 'quoting',
+        status: 'queued_for_quote',
         date: new Date().toISOString(),
         transferStartedAt: Date.now(),
       })
       return id
+    },
+
+    /** Run the light estimate for an entry that's ready to quote. Promotes
+     *  `queued_for_quote` → `quoting` on entry (so concurrency accounting is
+     *  consistent while the async estimate is in flight), then transitions
+     *  to `awaiting_approval` when the estimate returns — even if the
+     *  estimate itself failed, so the real quote can surface a clearer
+     *  error on `startRealUpload`. */
+    async beginQuoting(id: number) {
+      const entry = this.findById(id)
+      if (!entry || entry.kind !== 'upload' || !entry.path) return
+      if (entry.status !== 'quoting' && entry.status !== 'queued_for_quote') return
+
+      this.updateEntry(id, { status: 'quoting' })
+
+      const estimate = await this.estimateFileCost(entry.path)
+      if (estimate) {
+        this.updateEntry(id, {
+          estimate,
+          paymentMode: estimate.payment_mode === 'merkle' ? 'merkle' : 'regular',
+          cost: formatNanoTokens(estimate.storage_cost_atto),
+          gas_cost: formatGasCost(estimate.estimated_gas_cost_wei),
+          status: 'awaiting_approval',
+        })
+      } else {
+        this.updateEntry(id, { status: 'awaiting_approval' })
+      }
+    },
+
+    /** Mark an approved entry as waiting for an upload slot. Caller is
+     *  responsible for kicking the scheduler. */
+    enqueueForUpload(id: number) {
+      const entry = this.findById(id)
+      if (!entry || entry.status !== 'awaiting_approval') return
+      this.updateEntry(id, { status: 'queued_for_upload' })
+    },
+
+    /** Cancel a pending upload that hasn't started paying yet. Covers the
+     *  four pre-payment stalls: both queued states plus quoting and
+     *  awaiting_approval. Once payment begins the backend owns the flow. */
+    cancelPendingUpload(id: number) {
+      const entry = this.findById(id)
+      if (!entry) return
+      const cancellable: FileStatus[] = [
+        'queued_for_quote',
+        'quoting',
+        'awaiting_approval',
+        'queued_for_upload',
+      ]
+      if (!cancellable.includes(entry.status)) return
+      this.removeEntry(id)
     },
 
     /** Light-touch cost estimate — wraps ant-core `estimate_upload_cost`.
@@ -640,6 +739,10 @@ export const useFilesStore = defineStore('files', {
     },
   },
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useFilesStore, import.meta.hot))
+}
 
 /** Compute `sha256(text)` as a `0x`-prefixed lowercase hex string. Matches
  *  the address derivation in `src-tauri/src/autonomi_ops.rs` so the frontend

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -314,13 +314,17 @@ export const useFilesStore = defineStore('files', {
           && estimate.storage_cost_atto === '0'
           && estimate.estimated_gas_cost_wei === '0'
 
+        // Already-stored entries skip awaiting_approval entirely — there's
+        // no user decision to make (no payment, no real upload). Route them
+        // straight into the upload queue so the scheduler drives them through
+        // to `complete` without a ceremonial Approve click.
         this.updateEntry(id, {
           estimate,
           paymentMode: estimate.payment_mode === 'merkle' ? 'merkle' : 'regular',
           cost: formatNanoTokens(estimate.storage_cost_atto),
           gas_cost: formatGasCost(estimate.estimated_gas_cost_wei),
           alreadyStored,
-          status: 'awaiting_approval',
+          status: alreadyStored ? 'queued_for_upload' : 'awaiting_approval',
         })
       } else {
         this.updateEntry(id, { status: 'awaiting_approval' })

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -93,6 +93,10 @@ export interface FileEntry {
   paymentMode?: 'regular' | 'merkle'
   /** Visibility chosen in the confirm dialog */
   visibility?: 'private' | 'public'
+  /** True when ant-core's estimator reported every chunk already stored on
+   *  the network (`storage_cost_atto === "0"` with a positive `chunk_count`).
+   *  Distinguishes a genuinely free re-upload from a suspiciously cheap quote. */
+  alreadyStored?: boolean
 }
 
 // Pinned rows (top of the table, independent sort). Includes the two queued
@@ -301,11 +305,21 @@ export const useFilesStore = defineStore('files', {
 
       const estimate = await this.estimateFileCost(entry.path)
       if (estimate) {
+        // ant-core returns "0" for both fields when every sampled chunk is
+        // already on the network (see ant-core file.rs::estimate_upload_cost).
+        // That's a legitimate signal, not a failed estimate — flag it so the
+        // UI can say "already stored" instead of rendering "0 ANT" as if it
+        // were any other cheap quote.
+        const alreadyStored = estimate.chunk_count > 0
+          && estimate.storage_cost_atto === '0'
+          && estimate.estimated_gas_cost_wei === '0'
+
         this.updateEntry(id, {
           estimate,
           paymentMode: estimate.payment_mode === 'merkle' ? 'merkle' : 'regular',
           cost: formatNanoTokens(estimate.storage_cost_atto),
           gas_cost: formatGasCost(estimate.estimated_gas_cost_wei),
+          alreadyStored,
           status: 'awaiting_approval',
         })
       } else {

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -1,4 +1,4 @@
-import { defineStore } from 'pinia'
+import { acceptHMRUpdate, defineStore } from 'pinia'
 import { invoke } from '@tauri-apps/api/core'
 import { arbitrumSepolia } from 'viem/chains'
 import { ANVIL_CHAIN_ID } from '~/utils/constants'
@@ -19,6 +19,16 @@ interface AppConfig {
   indelible_url: string | null
   indelible_api_key: string | null
   theme_mode: string
+  upload_concurrency: number
+}
+
+/** Allowed range for upload_concurrency (see AppConfig in Rust). */
+export const UPLOAD_CONCURRENCY_MIN = 1
+export const UPLOAD_CONCURRENCY_MAX = 8
+
+function clampConcurrency(n: number): number {
+  if (!Number.isFinite(n)) return UPLOAD_CONCURRENCY_MIN
+  return Math.max(UPLOAD_CONCURRENCY_MIN, Math.min(UPLOAD_CONCURRENCY_MAX, Math.floor(n)))
 }
 
 export const useSettingsStore = defineStore('settings', {
@@ -34,6 +44,7 @@ export const useSettingsStore = defineStore('settings', {
     indelibleOrgName: null as string | null,
     indelibleUserEmail: null as string | null,
     themeMode: 'dark' as ThemeMode,
+    uploadConcurrency: 1,
     loaded: false,
     // Devnet/testnet/direct-key mode (set by manifest or settings form).
     // devnetChainId picks the chain:
@@ -64,6 +75,7 @@ export const useSettingsStore = defineStore('settings', {
         this.indelibleUrl = config.indelible_url
         this.indelibleApiKey = config.indelible_api_key
         this.themeMode = config.theme_mode === 'light' ? 'light' : 'dark'
+        this.uploadConcurrency = clampConcurrency(config.upload_concurrency)
         this.loaded = true
       } catch (e) {
         console.error('Failed to load config:', e)
@@ -81,11 +93,17 @@ export const useSettingsStore = defineStore('settings', {
           indelible_url: this.indelibleUrl,
           indelible_api_key: this.indelibleApiKey,
           theme_mode: this.themeMode,
+          upload_concurrency: this.uploadConcurrency,
         }
         await invoke('save_config', { config })
       } catch (e) {
         console.error('Failed to save config:', e)
       }
+    },
+
+    async setUploadConcurrency(n: number) {
+      this.uploadConcurrency = clampConcurrency(n)
+      await this.saveConfig()
     },
 
     async setStorageDir(path: string) {
@@ -192,3 +210,7 @@ export const useSettingsStore = defineStore('settings', {
     },
   },
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useSettingsStore, import.meta.hot))
+}

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -2,5 +2,3 @@ export const ANVIL_CHAIN_ID = 31337
 export const POLL_INTERVAL = 5000
 export const DETAIL_POLL_INTERVAL = 30_000
 export const PENDING_UPLOAD_TTL_MS = 300_000
-export const MERKLE_THRESHOLD = 64
-export const AVG_CHUNK_SIZE = 262_144


### PR DESCRIPTION
## Summary

- **Dialog is dismissible at every pre-payment stall** — `queued_for_quote`, `quoting`, `awaiting_approval`, `queued_for_upload` — without cancelling the underlying job. Pinia `FileEntry` holds the quote state; the dialog is a thin view bound to `fileIds`. Clicking a pending row in the uploads table reopens the dialog for that entry.
- **New `upload_concurrency` setting** under Settings -> Advanced (default `1`, range `1-8`). Queued rows show "Queued: quoting" or "Queued: uploading" instead of blasting the network in parallel. Approve is gated on every entry being ready; button pluralises to "Approve N Uploads".
- **No more fake cost values**: dropped the `bytes / MiB * 0.05 ANT` heuristic and the size-derived payment-mode fallback. Both dialogs now show an explicit "Not connected to the Autonomi network -- cost estimate unavailable" with a Retry button, checked before any spinner so the user is never left watching one that will never resolve.
- **Connection-aware row status**: "Connecting to network...", "Obtaining quote...", or "Network unavailable" instead of the ambiguous "Preparing upload...". New `StatusBadge` entries so they don't fall back to `?`.
- **Buttons grouped by intent**: `[Close] [Cancel Upload]` on the left, `[Approve Upload]` isolated on the right -- a fat-finger on dismiss can no longer accidentally spend ANT.
- **Pinia HMR**: `files` and `settings` stores now `acceptHMRUpdate` so getter/state changes don't require a full dev-server restart.

## Test plan

- [ ] Pick a file while disconnected -> row reads "Connecting to network..."; once online, flips through "Obtaining quote..." to "Ready to approve".
- [ ] Pick 3 files with concurrency=1 -> first is "Obtaining quote...", others "Queued: quoting"; promotes one at a time as each completes.
- [ ] While some entries are still quoting, Approve is disabled and the readout reads "Ready: X of 3".
- [ ] When all entries reach `awaiting_approval`, Approve enables and reads "Approve 3 Uploads".
- [ ] Close the dialog mid-quote -> dialog dismisses, rows stay pinned, clicking a row reopens the dialog for that entry.
- [ ] Cancel Upload on a queued / quoting / awaiting_approval row -> row disappears.
- [ ] Disconnect mid-quote -> dialog shows "Not connected" error with Retry; row label switches to "Network unavailable".
- [ ] Settings -> Advanced: bump concurrency to 2 -> next pick of 3 runs two in parallel, one queued. Persist across restart.
- [ ] Existing upload history loads as before (no datamap regressions); StatusBadge still shows `?` for any unexpected label.
- [ ] Cross-platform: at minimum Windows + macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)