### PR TITLE
chore: bump version to 0.6.7-rc.1

### DIFF
--- a/.ant-version
+++ b/.ant-version
@@ -1,1 +1,1 @@
-latest
+ant-cli-v0.2.0-rc.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.6",
+  "version": "0.6.7-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -811,7 +811,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -822,13 +822,13 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ant-core"
 version = "0.1.1"
-source = "git+https://github.com/WithAutonomi/ant-client?rev=b0c501a163c1a95bdbfc703892b88a8a91f7e482#b0c501a163c1a95bdbfc703892b88a8a91f7e482"
+source = "git+https://github.com/WithAutonomi/ant-client?rev=91af99375bff20c4d0e95d4a956bcfa4deaee0d9#91af99375bff20c4d0e95d4a956bcfa4deaee0d9"
 dependencies = [
  "ant-node",
  "async-stream",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.6"
+version = "0.6.7-rc.1"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",
@@ -906,9 +906,8 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac042e69f7dff2136deee542d66fceb5631474869ea4da9875185a9ad3329cc"
+version = "0.11.0-rc.1"
+source = "git+https://github.com/WithAutonomi/ant-node.git?branch=rc-2026.4.2#2ba556e4af1b606ed2cf52c01674060cb0ab8ce3"
 dependencies = [
  "aes-gcm-siv",
  "blake3",
@@ -2641,7 +2640,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2900,6 +2899,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,7 +2955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4877,7 +4888,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4941,7 +4952,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5972,7 +5983,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5985,7 +5996,7 @@ dependencies = [
  "libc",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6545,7 +6556,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6613,7 +6624,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6689,9 +6700,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d459ba0e4f1a3ac918a1d6b17db392cccde2ee74569545d171d7644fc6463cc7"
+version = "0.24.0-rc.1"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.2#a2813e83526c70048f5a564848b05e8088d786e4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6807,9 +6817,8 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250826f52ac60992947359218d83c21f658aa85407e3980a5dbb258eff4c0cc3"
+version = "0.33.0-rc.1"
+source = "git+https://github.com/saorsa-labs/saorsa-transport.git?branch=rc-2026.4.2#8b44b242fd62023c1a96728382ddd72917a63a4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6821,6 +6830,7 @@ dependencies = [
  "core-foundation 0.9.4",
  "dashmap",
  "dirs 5.0.1",
+ "enum_dispatch",
  "futures-util",
  "hex",
  "igd-next",
@@ -7436,7 +7446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8137,7 +8147,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8653,7 +8663,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9237,7 +9247,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6701,7 +6701,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.2#a2813e83526c70048f5a564848b05e8088d786e4"
+source = "git+https://github.com/Nic-dorman/saorsa-core.git?rev=8a9b8077fc2c69c063a2509ad03b5ec45ef2cc4d#8a9b8077fc2c69c063a2509ad03b5ec45ef2cc4d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.6"
+version = "0.6.7-rc.1"
 edition = "2021"
 
 [lib]
@@ -25,10 +25,10 @@ toml = "0.8"
 tauri-plugin-updater = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-# Pinned to the merge commit of WithAutonomi/ant-client#44, which adds
-# `Client::estimate_upload_cost` (file cost estimation without parking
-# chunks). Repoint to the next `ant-cli-vX.Y.Z` tag once it ships.
-ant-core = { git = "https://github.com/WithAutonomi/ant-client", rev = "b0c501a163c1a95bdbfc703892b88a8a91f7e482" }
+# Pinned to the tip of WithAutonomi/ant-client rc-2026.4.2 (tag
+# `ant-cli-v0.2.0-rc.1`), matching the sidecar bundled via .ant-version.
+# Repoint to the next `ant-cli-vX.Y.Z` tag once the RC promotes to stable.
+ant-core = { git = "https://github.com/WithAutonomi/ant-client", rev = "91af99375bff20c4d0e95d4a956bcfa4deaee0d9" }
 evmlib = "0.8"
 hex = "0.4"
 sha2 = "0.10"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,3 +35,12 @@ sha2 = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+# TEMP — saorsa-labs/saorsa-core#97 fixes an HRTB bound introduced by the
+# parallel-bootstrap-dial change in rc-2026.4.2. Without it, `tokio::spawn`
+# of the connect chain fails to compile in ant-gui. Pinned by SHA so the
+# build stays reproducible; remove once #97 merges and ant-node → ant-client
+# picks up the fixed rev (at which point the ant-core rev above is rebumped
+# and this patch becomes redundant).
+[patch."https://github.com/saorsa-labs/saorsa-core.git"]
+saorsa-core = { git = "https://github.com/Nic-dorman/saorsa-core.git", rev = "8a9b8077fc2c69c063a2509ad03b5ec45ef2cc4d" }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.6",
+  "version": "0.6.7-rc.1",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Bumps ant-gui to `0.6.7-rc.1` in the four version-of-record files (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`).
- Repoints `ant-core` rev to `91af993` — tip of `WithAutonomi/ant-client` `rc-2026.4.2`, released upstream as `ant-cli-v0.2.0-rc.1`.
- Pins `.ant-version` from `latest` to `ant-cli-v0.2.0-rc.1` so the sidecar binary the release pipeline downloads matches the embedded `ant-core` library.

Transitive lockfile churn is the rc-2026.4.2 line of ant-node/saorsa-core/saorsa-transport that the new ant-core pulls in.

This is the RC cut for internal testing of the ant-client rc-2026.4.2 branch ahead of its promotion to stable. Once the branch is stable upstream, we'll bump to `0.6.7` against the final `ant-cli-v0.2.0` tag.

## Test plan

- [ ] CI green (fmt, clippy, build, frontend typecheck + test)
- [ ] After merge: tag `v0.6.7-rc.1` from main, push, confirm `release.yml` composes latest.json and creates a draft pre-release with MSI/deb/rpm/AppImage/dmg assets