### PR TITLE
chore: bump to v0.6.7-rc.5 (ant-core → rc-2026.4.2 HEAD)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.7-rc.4",
+  "version": "0.6.7-rc.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -811,7 +811,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -822,13 +822,13 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "ant-core"
 version = "0.1.1"
-source = "git+https://github.com/WithAutonomi/ant-client?rev=91af99375bff20c4d0e95d4a956bcfa4deaee0d9#91af99375bff20c4d0e95d4a956bcfa4deaee0d9"
+source = "git+https://github.com/WithAutonomi/ant-client?rev=d9ef2c9cf58fda58992bee1bca62246a400b14bf#d9ef2c9cf58fda58992bee1bca62246a400b14bf"
 dependencies = [
  "ant-node",
  "async-stream",
@@ -854,6 +854,7 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
+ "sysinfo",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -906,8 +907,8 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.11.0-rc.1"
-source = "git+https://github.com/WithAutonomi/ant-node.git?branch=rc-2026.4.2#2ba556e4af1b606ed2cf52c01674060cb0ab8ce3"
+version = "0.11.0-rc.2"
+source = "git+https://github.com/WithAutonomi/ant-node.git?branch=rc-2026.4.2#943ca2b3472b8400361bafd8747ca4068e6a95ce"
 dependencies = [
  "aes-gcm-siv",
  "blake3",
@@ -2640,7 +2641,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2955,7 +2956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4883,12 +4884,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4952,7 +4962,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5983,7 +5993,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5996,7 +6006,7 @@ dependencies = [
  "libc",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6556,7 +6566,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6624,7 +6634,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6701,7 +6711,7 @@ dependencies = [
 [[package]]
 name = "saorsa-core"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/Nic-dorman/saorsa-core.git?rev=8a9b8077fc2c69c063a2509ad03b5ec45ef2cc4d#8a9b8077fc2c69c063a2509ad03b5ec45ef2cc4d"
+source = "git+https://github.com/saorsa-labs/saorsa-core.git?branch=rc-2026.4.2#33a3e586db4f88d895e37bfae2f1df2de9ba8752"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7446,7 +7456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7682,6 +7692,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -8147,7 +8170,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8663,7 +8686,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9247,7 +9270,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9269,6 +9292,16 @@ dependencies = [
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
+]
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9301,6 +9334,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9342,6 +9387,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
@@ -9356,6 +9412,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9415,6 +9482,15 @@ dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.7-rc.4"
+version = "0.6.7-rc.5"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.7-rc.4"
+version = "0.6.7-rc.5"
 edition = "2021"
 
 [lib]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,22 +25,16 @@ toml = "0.8"
 tauri-plugin-updater = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-# Pinned to the tip of WithAutonomi/ant-client rc-2026.4.2 (tag
-# `ant-cli-v0.2.0-rc.1`), matching the sidecar bundled via .ant-version.
-# Repoint to the next `ant-cli-vX.Y.Z` tag once the RC promotes to stable.
-ant-core = { git = "https://github.com/WithAutonomi/ant-client", rev = "91af99375bff20c4d0e95d4a956bcfa4deaee0d9" }
+# Pinned to the tip of WithAutonomi/ant-client rc-2026.4.2, which is
+# post-`ant-cli-v0.2.0-rc.2` plus the merged adopt-running-nodes fix (PR #57).
+# Its Cargo.lock resolves saorsa-core to the rc-2026.4.2 HEAD that includes
+# the parallel-bootstrap-dial HRTB fix (PR #97), so no workspace [patch]
+# overrides are needed. Repoint to the next `ant-cli-vX.Y.Z` tag once the
+# RC promotes to stable.
+ant-core = { git = "https://github.com/WithAutonomi/ant-client", rev = "d9ef2c9cf58fda58992bee1bca62246a400b14bf" }
 evmlib = "0.8"
 hex = "0.4"
 sha2 = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-
-# TEMP — saorsa-labs/saorsa-core#97 fixes an HRTB bound introduced by the
-# parallel-bootstrap-dial change in rc-2026.4.2. Without it, `tokio::spawn`
-# of the connect chain fails to compile in ant-gui. Pinned by SHA so the
-# build stays reproducible; remove once #97 merges and ant-node → ant-client
-# picks up the fixed rev (at which point the ant-core rev above is rebumped
-# and this patch becomes redundant).
-[patch."https://github.com/saorsa-labs/saorsa-core.git"]
-saorsa-core = { git = "https://github.com/Nic-dorman/saorsa-core.git", rev = "8a9b8077fc2c69c063a2509ad03b5ec45ef2cc4d" }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.7-rc.4",
+  "version": "0.6.7-rc.5",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Points `ant-core` at `WithAutonomi/ant-client@rc-2026.4.2` HEAD (`d9ef2c9`), which bundles the coordinated rc.2 network release: `ant-cli-v0.2.0-rc.2`, `ant-node 0.11.0-rc.2`, and `saorsa-core 0.24.0-rc.1` (`33a3e58` = saorsa-core PR #97 merge commit, includes the parallel-bootstrap-dial HRTB fix).
- Drops the temp `[patch."saorsa-labs/saorsa-core.git"]` override that pinned a fork — upstream now has the fix on rc-2026.4.2, and ant-core's lockfile already pins to it.
- Bumps version `0.6.7-rc.4` → `0.6.7-rc.5` across `package.json`, `Cargo.toml`, `Cargo.lock`, `tauri.conf.json`.

## Why rc.5

- Validates the `--force-local` Windows tar fix from #52 end-to-end (its tag-triggered release-workflow path didn't get to re-run on the PR).
- Bundles all three recent merges (#51 daemon-restart, #52 installers, this ant-core bump) into a single signed RC for Mac testers.

## Test plan

- [x] `cargo check` clean against rc.2 network code (locally, on combined preview branch with #51 + #52 merged in)
- [x] `npm run tauri dev` builds + launches; saorsa-core's post-HRTB-fix bootstrap dial is exercised at runtime (no `tokio::spawn` Send-bound failure)
- [x] Local sidecar `ant.exe 0.2.0-rc.2` matches the pinned `ant-core` rev
- [ ] CI green on this PR
- [ ] Tag `v0.6.7-rc.5` after merge → release workflow produces signed Mac DMG / Win MSI / Linux AppImage