### PR TITLE
chore(scripts): add reset-state for a clean test setup

### DIFF
--- a/scripts/reset-state.ps1
+++ b/scripts/reset-state.ps1
@@ -1,0 +1,185 @@
+# Wipe all Autonomi GUI and ant daemon/node state so the next run starts
+# from a clean setup. Windows counterpart of scripts/reset-state.sh.
+#
+# This uninstalls the Autonomi MSI (so it no longer appears in Add/Remove
+# Programs) and deletes: GUI settings, upload history, datamaps, the node
+# registry, node data and logs, the cached ant-node binaries, and the
+# saorsa-core bootstrap-peer cache (the P2P stack auto-creates one in
+# %LOCALAPPDATA%\saorsa\bootstrap\, so old testnet peers persist there
+# otherwise). Wallet keys are NOT persisted on disk (they come from the
+# SECRET_KEY env var), so nothing secret is at risk.
+
+[CmdletBinding()]
+param(
+    [switch]$Yes
+)
+
+$ErrorActionPreference = "Stop"
+
+# PowerShell 6+ defines $IsWindows; Windows PowerShell 5.1 does not but only runs on Windows.
+if ((Test-Path variable:IsWindows) -and -not $IsWindows) {
+    Write-Error "reset-state.ps1 is Windows-only. Use scripts/reset-state.sh on Linux or macOS."
+    exit 1
+}
+
+$AppData = $env:APPDATA
+if (-not $AppData) {
+    $AppData = Join-Path $env:USERPROFILE "AppData\Roaming"
+}
+$LocalAppData = $env:LOCALAPPDATA
+if (-not $LocalAppData) {
+    $LocalAppData = Join-Path $env:USERPROFILE "AppData\Local"
+}
+
+$GuiState     = Join-Path $AppData "autonomi\ant-gui"
+$AntData      = Join-Path $AppData "ant"
+$SaorsaCache  = Join-Path $LocalAppData "saorsa"
+
+# Find MSI-installed Autonomi entries in the Windows uninstall registry.
+# Tauri's WiX bundle registers under one of these three hives depending on
+# per-user vs per-machine install and 32- vs 64-bit view.
+function Get-AutonomiInstalls {
+    $roots = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall'
+    )
+    $results = @()
+    foreach ($root in $roots) {
+        if (-not (Test-Path $root)) { continue }
+        Get-ChildItem -LiteralPath $root -ErrorAction SilentlyContinue | ForEach-Object {
+            $entry = Get-ItemProperty -LiteralPath $_.PSPath -ErrorAction SilentlyContinue
+            if ($entry -and $entry.DisplayName -like 'Autonomi*') {
+                $results += [pscustomobject]@{
+                    DisplayName  = $entry.DisplayName
+                    ProductCode  = $_.PSChildName
+                    RegistryRoot = $root
+                }
+            }
+        }
+    }
+    return $results
+}
+
+$Installs = Get-AutonomiInstalls
+
+# Collect custom node paths referenced by the registry before we wipe it,
+# so nodes created with --data-dir-path / --log-dir-path outside the
+# default ant tree are also removed.
+$CustomPaths = @()
+$Registry = Join-Path $AntData "node_registry.json"
+if (Test-Path $Registry) {
+    try {
+        $reg = Get-Content -Raw -Path $Registry | ConvertFrom-Json
+        if ($reg.nodes) {
+            foreach ($prop in $reg.nodes.PSObject.Properties) {
+                $node = $prop.Value
+                foreach ($field in @('data_dir','log_dir')) {
+                    $p = $node.$field
+                    if ($p -and ("$p" -notlike "$AntData*")) {
+                        $CustomPaths += "$p"
+                    }
+                }
+            }
+        }
+    } catch {
+        Write-Warning "Could not parse $Registry - custom node paths (if any) will not be wiped: $_"
+    }
+}
+
+$Targets = @($GuiState, $AntData, $SaorsaCache) + $CustomPaths
+
+Write-Host "The following actions will run:"
+if ($Installs.Count -gt 0) {
+    foreach ($i in $Installs) {
+        Write-Host "  - uninstall MSI: $($i.DisplayName) $($i.ProductCode)"
+    }
+} else {
+    Write-Host "  - uninstall MSI: (no Autonomi install found in Add/Remove Programs)"
+}
+foreach ($t in $Targets) {
+    if (Test-Path -LiteralPath $t) {
+        Write-Host "  - delete: $t"
+    } else {
+        Write-Host "  - delete: $t  (not present)"
+    }
+}
+
+if (-not $Yes) {
+    $reply = Read-Host "Continue? [y/N]"
+    if ($reply -notmatch '^(y|yes)$') {
+        Write-Host "Aborted."
+        exit 1
+    }
+}
+
+# Warn if a per-machine install is present but we're not elevated. msiexec
+# will fail with 1625/1620 under those conditions; better to surface it up front.
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltInRole]::Administrator
+)
+$perMachine = $Installs | Where-Object { $_.RegistryRoot -like 'HKLM:*' }
+if ($perMachine -and -not $isAdmin) {
+    Write-Warning "A per-machine Autonomi install was found but this shell is not elevated."
+    Write-Warning "msiexec will likely fail; re-run this script from an Administrator PowerShell."
+}
+
+Write-Host ""
+Write-Host "Stopping Autonomi GUI and ant processes..."
+foreach ($name in @('Autonomi','ant-gui','ant','ant-node')) {
+    Get-Process -Name $name -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+}
+
+# Extra daemon cleanup via PID file, in case a detached daemon is still up.
+$PidFile = Join-Path $AntData "daemon.pid"
+if (Test-Path -LiteralPath $PidFile) {
+    $raw = (Get-Content -Raw -Path $PidFile).Trim()
+    $daemonPid = 0
+    if ([int]::TryParse($raw, [ref]$daemonPid) -and $daemonPid -gt 0) {
+        Get-Process -Id $daemonPid -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Uninstall each matching MSI entry.
+$UninstallFailed = $false
+foreach ($i in $Installs) {
+    Write-Host ""
+    Write-Host "Uninstalling $($i.DisplayName) ($($i.ProductCode))..."
+    if ($i.ProductCode -notmatch '^\{[0-9A-Fa-f-]+\}$') {
+        Write-Warning "  skipping: not an MSI ProductCode (entry key: $($i.ProductCode))"
+        $UninstallFailed = $true
+        continue
+    }
+    $proc = Start-Process -FilePath 'msiexec.exe' `
+        -ArgumentList '/x', $i.ProductCode, '/qn', '/norestart' `
+        -Wait -PassThru -NoNewWindow
+    if ($proc.ExitCode -eq 0 -or $proc.ExitCode -eq 3010) {
+        # 3010 = success but reboot required; still a successful uninstall.
+        Write-Host "  msiexec exit code: $($proc.ExitCode)"
+    } else {
+        Write-Warning "  msiexec exit code: $($proc.ExitCode) (uninstall may have failed)"
+        $UninstallFailed = $true
+    }
+}
+
+Write-Host ""
+Write-Host "Deleting directories..."
+$DeleteFailed = $false
+foreach ($t in $Targets) {
+    if (Test-Path -LiteralPath $t) {
+        try {
+            Remove-Item -LiteralPath $t -Recurse -Force -ErrorAction Stop
+            Write-Host "  removed: $t"
+        } catch {
+            Write-Host "  FAILED:  $t ($($_.Exception.Message))"
+            $DeleteFailed = $true
+        }
+    }
+}
+
+Write-Host ""
+if ($UninstallFailed -or $DeleteFailed) {
+    Write-Host "Reset finished with errors - see messages above."
+    exit 1
+}
+Write-Host "Reset complete."

--- a/scripts/reset-state.sh
+++ b/scripts/reset-state.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# Wipe all Autonomi GUI and ant daemon/node state so the next run starts
+# from a clean setup. Covers both Linux and macOS; Windows has a separate
+# scripts/reset-state.ps1.
+#
+# This deletes: GUI settings, upload history, datamaps, the node registry,
+# node data and logs, the cached ant-node binaries, and the saorsa-core
+# bootstrap-peer cache (the P2P stack auto-creates one in the OS cache dir
+# under saorsa/bootstrap/, so old testnet peers persist there otherwise).
+# On macOS it also removes the DMG-installed Autonomi.app bundle from
+# /Applications. Wallet keys are NOT persisted on disk (they come from the
+# SECRET_KEY env var), so nothing secret is at risk.
+set -e
+
+YES=0
+for arg in "$@"; do
+    case "$arg" in
+        -y|--yes) YES=1 ;;
+        -h|--help)
+            cat <<EOF
+Usage: $0 [--yes]
+
+Stops the Autonomi GUI and ant daemon, then removes all GUI and ant
+state directories. Prompts before deleting unless --yes is given.
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
+
+case "$(uname -s)" in
+    Linux)
+        GUI_STATE="${XDG_CONFIG_HOME:-$HOME/.config}/autonomi/ant-gui"
+        ANT_DATA="${XDG_DATA_HOME:-$HOME/.local/share}/ant"
+        ANT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/ant"
+        ANT_LOGS=""
+        SAORSA_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/saorsa"
+        ;;
+    Darwin)
+        GUI_STATE="$HOME/Library/Application Support/autonomi/ant-gui"
+        ANT_DATA="$HOME/Library/Application Support/ant"
+        ANT_CONFIG=""
+        ANT_LOGS="$HOME/Library/Logs/ant"
+        SAORSA_CACHE="$HOME/Library/Caches/saorsa"
+        APP_BUNDLES=("/Applications/Autonomi.app" "$HOME/Applications/Autonomi.app")
+        ;;
+    *)
+        echo "Unsupported OS: $(uname -s). Use scripts/reset-state.ps1 on Windows." >&2
+        exit 1
+        ;;
+esac
+
+# Collect custom node paths referenced by the registry before we wipe it,
+# so nodes created with --data-dir-path / --log-dir-path outside the
+# default ant tree are also removed.
+CUSTOM_PATHS=()
+REGISTRY="$ANT_DATA/node_registry.json"
+if [ -f "$REGISTRY" ]; then
+    if command -v jq >/dev/null 2>&1; then
+        while IFS= read -r path; do
+            if [ -z "$path" ] || [ "$path" = "null" ]; then
+                continue
+            fi
+            case "$path" in
+                "$ANT_DATA"/*|"$ANT_LOGS"/*) ;;
+                *) CUSTOM_PATHS+=("$path") ;;
+            esac
+        done < <(jq -r '.nodes // {} | to_entries[].value | (.data_dir // empty), (.log_dir // empty)' "$REGISTRY" 2>/dev/null)
+    else
+        echo "warning: jq not installed — nodes created with a custom --data-dir-path"
+        echo "         will not be discovered; only default paths will be wiped."
+    fi
+fi
+
+TARGETS=("$GUI_STATE" "$ANT_DATA")
+[ -n "$ANT_CONFIG" ] && TARGETS+=("$ANT_CONFIG")
+[ -n "$ANT_LOGS" ] && TARGETS+=("$ANT_LOGS")
+[ -n "$SAORSA_CACHE" ] && TARGETS+=("$SAORSA_CACHE")
+if [ "${#CUSTOM_PATHS[@]}" -gt 0 ]; then
+    TARGETS+=("${CUSTOM_PATHS[@]}")
+fi
+# On macOS, also remove the DMG-installed .app bundle(s).
+if [ "${#APP_BUNDLES[@]}" -gt 0 ]; then
+    TARGETS+=("${APP_BUNDLES[@]}")
+fi
+
+echo "The following paths will be deleted:"
+for t in "${TARGETS[@]}"; do
+    if [ -e "$t" ]; then
+        echo "  - $t"
+    else
+        echo "  - $t  (not present)"
+    fi
+done
+
+if [ "$YES" -ne 1 ]; then
+    printf "Continue? [y/N] "
+    read -r REPLY
+    case "$REPLY" in
+        y|Y|yes|YES) ;;
+        *) echo "Aborted."; exit 1 ;;
+    esac
+fi
+
+echo ""
+echo "Stopping Autonomi GUI and ant processes..."
+PROC_NAMES=(Autonomi ant-gui ant ant-node)
+for name in "${PROC_NAMES[@]}"; do
+    pkill -TERM -x "$name" 2>/dev/null || true
+done
+sleep 1
+for name in "${PROC_NAMES[@]}"; do
+    pkill -KILL -x "$name" 2>/dev/null || true
+done
+
+# Extra daemon cleanup via PID file, in case a detached daemon is still up.
+PID_FILE="$ANT_DATA/daemon.pid"
+if [ -f "$PID_FILE" ]; then
+    DAEMON_PID="$(tr -d '[:space:]' < "$PID_FILE" 2>/dev/null || true)"
+    if [ -n "$DAEMON_PID" ] && [ "$DAEMON_PID" -eq "$DAEMON_PID" ] 2>/dev/null; then
+        if kill -0 "$DAEMON_PID" 2>/dev/null; then
+            kill -TERM "$DAEMON_PID" 2>/dev/null || true
+            sleep 1
+            kill -KILL "$DAEMON_PID" 2>/dev/null || true
+        fi
+    fi
+fi
+
+echo ""
+echo "Deleting directories..."
+FAILED=0
+for t in "${TARGETS[@]}"; do
+    if [ -e "$t" ]; then
+        if rm -rf -- "$t" 2>/dev/null; then
+            echo "  removed: $t"
+        else
+            echo "  FAILED:  $t (permission denied — re-run with sudo)"
+            FAILED=1
+        fi
+    fi
+done
+
+echo ""
+if [ "$FAILED" -ne 0 ]; then
+    echo "Reset finished with errors — some paths could not be removed."
+    exit 1
+fi
+echo "Reset complete."
+


### PR DESCRIPTION
## Summary

Adds a one-shot "factory reset" pair of scripts for manual testing:

- `scripts/reset-state.sh` — Linux + macOS (single script, `uname -s` detection)
- `scripts/reset-state.ps1` — Windows

Each script kills the Autonomi GUI and `ant`/`ant-node` processes, stops the daemon via `daemon.pid`, then wipes:

- GUI state under `autonomi/ant-gui/` (config, upload history, datamaps)
- The full `ant/` tree (registry, daemon files, `nodes/`, `bin/` binary cache, logs)
- The saorsa-core bootstrap-peer cache (see below)
- Custom node data dirs referenced by `node_registry.json` (caught via `jq` / `ConvertFrom-Json`) for nodes created with `--data-dir-path`
- Platform-specific extras: the MSI install on Windows (`msiexec /x` against the ProductCode found in the uninstall registry, so it disappears from Add/Remove Programs), `/Applications/Autonomi.app` on macOS

No wallet handling: `ant` never persists secret keys to disk — they come from the `SECRET_KEY` env var at runtime — so nothing secret is at risk.

## The saorsa peer cache (non-obvious)

`saorsa-core 0.23.1`'s `P2PNode::new` always auto-creates a `BootstrapManager` from `BootstrapConfig::default()` when no override is supplied (`src/network.rs:833-842`). Default cache path is `dirs::cache_dir()/saorsa/bootstrap/` (`src/bootstrap/manager.rs:288-296`). Neither `ant-node`'s daemon side nor `ant-core::data::Network::new` (used by `Client::connect`, which `src-tauri/src/autonomi_ops.rs:263` calls) sets `core_config.bootstrap_cache_config`. So peers from previous testnets persist in the OS cache dir across runs:

- Linux: `${XDG_CACHE_HOME:-~/.cache}/saorsa/`
- macOS: `~/Library/Caches/saorsa/`
- Windows: `%LOCALAPPDATA%\saorsa\`

The scripts wipe the whole `saorsa/` namespace, since the entire P2P stack is saorsa-based and any cache under it is stale testnet state.

## Test plan

- [x] Bash syntax check (`bash -n`) passes
- [x] PowerShell parse check (`[Parser]::ParseFile`) passes
- [x] Linux dry-run with fake `\$HOME` lists all four expected paths and exits 0
- [x] PowerShell guard on non-Windows OSes exits 1 with a clear message
- [x] End-to-end on Linux: launch GUI → start node → upload file → run script → confirm `~/.config/autonomi/`, `~/.local/share/ant/`, `~/.cache/saorsa/` all gone; no `ant` processes remain; GUI relaunches as a fresh install
- [x] End-to-end on macOS: same as above + verify `/Applications/Autonomi.app` removed
- [x] End-to-end on Windows: same as above + verify Autonomi no longer in Add/Remove Programs

🤖 Generated with [Claude Code](https://claude.com/claude-code)