### PR TITLE
feat(wallet): direct-PK uploads via Rust evmlib (rc.6 → rc.9)

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -43,23 +43,27 @@ onMounted(async () => {
 
   // Initialize autonomi client — when manifest present, pass custom config
   if (settingsStore.devnetActive) {
+    // When the manifest supplied a private key, hand it to the Rust client
+    // too — that flips uploads onto evmlib's wallet flow (`wallet_upload`),
+    // bypassing the JS-side wagmi external-signer dance. evmlib auto-approves
+    // the vault on first use, so no separate approval call is needed for the
+    // wallet path. The JS-side wallet still gets initialised below for the
+    // balance display in the header.
+    const { getDevnetWalletKey } = await import('~/stores/settings')
     invoke('init_autonomi_client', {
       bootstrapPeers: settingsStore.devnetBootstrapPeers,
       evmRpcUrl: settingsStore.devnetRpcUrl,
       evmTokenAddress: settingsStore.devnetTokenAddress,
       evmVaultAddress: settingsStore.devnetVaultAddress,
+      walletPrivateKey: getDevnetWalletKey(),
     }).catch((e) => {
       console.warn('Autonomi client init failed:', e)
     })
 
-    // Auto-activate the direct-key wallet whenever the manifest supplied a
-    // `wallet_private_key` (loadDevnetManifest stashes it and flips
-    // _devnetWalletKeySet). Previously gated on ANVIL_CHAIN_ID only, so a
-    // Sepolia manifest with a pre-funded key silently left the wallet
-    // disconnected — the key sat in storage and every upload hit the
-    // no-wallet path. Manifests *without* a key still fall through to
-    // WalletConnect, and no-manifest (production) is unaffected since this
-    // entire block is gated on `devnetActive`.
+    // Init the JS-side direct wallet for balance display + WalletConnect
+    // fallback. The Rust-side wallet (above) is what actually pays for
+    // uploads in direct-key mode now, but the wagmi config still drives the
+    // header balance widget and any user-initiated WalletConnect interaction.
     if (settingsStore._devnetWalletKeySet) {
       const { initDevnetWallet } = await import('~/composables/useDevnetWallet')
       initDevnetWallet()

--- a/app.vue
+++ b/app.vue
@@ -52,10 +52,15 @@ onMounted(async () => {
       console.warn('Autonomi client init failed:', e)
     })
 
-    // Only bypass WalletConnect for local Anvil devnet. Sepolia / mainnet
-    // manifests expect the user to connect their own wallet via WalletConnect.
-    const { ANVIL_CHAIN_ID } = await import('~/utils/constants')
-    if (settingsStore.devnetChainId === ANVIL_CHAIN_ID) {
+    // Auto-activate the direct-key wallet whenever the manifest supplied a
+    // `wallet_private_key` (loadDevnetManifest stashes it and flips
+    // _devnetWalletKeySet). Previously gated on ANVIL_CHAIN_ID only, so a
+    // Sepolia manifest with a pre-funded key silently left the wallet
+    // disconnected — the key sat in storage and every upload hit the
+    // no-wallet path. Manifests *without* a key still fall through to
+    // WalletConnect, and no-manifest (production) is unaffected since this
+    // entire block is gated on `devnetActive`.
+    if (settingsStore._devnetWalletKeySet) {
       const { initDevnetWallet } = await import('~/composables/useDevnetWallet')
       initDevnetWallet()
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.7-rc.5",
+  "version": "0.6.7-rc.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.7-rc.6",
+  "version": "0.6.7-rc.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.7-rc.8",
+  "version": "0.6.7-rc.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.7-rc.7",
+  "version": "0.6.7-rc.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -553,6 +553,25 @@ async function connectDirectWallet() {
       return
     }
 
+    // Hot-attach the wallet on the Rust client so direct-PK uploads take the
+    // evmlib path (wallet_upload). Without this, uploads triggered via the
+    // settings-UI key-entry flow hit the Rust side with no wallet attached
+    // and error out — the JS state flips _devnetWalletKeySet=true while the
+    // Rust client was initialised wallet-less at app startup.
+    try {
+      await invoke('attach_wallet', {
+        walletPrivateKey: key,
+        evmRpcUrl: settingsStore.devnetRpcUrl,
+        evmTokenAddress: settingsStore.devnetTokenAddress,
+        evmVaultAddress: settingsStore.devnetVaultAddress,
+      })
+    } catch (e: any) {
+      console.warn('attach_wallet failed:', e)
+      // Non-fatal — uploads will fall back to the JS wagmi path. Surface
+      // through the toast so the user sees something didn't go right.
+      toasts.add(`Wallet attach (Rust side) failed: ${e?.message ?? e}`, 'error')
+    }
+
     directWalletActive.value = true
     editingDirectWallet.value = false
     directWalletKeyInput.value = ''

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.7-rc.5"
+version = "0.6.7-rc.6"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.7-rc.6"
+version = "0.6.7-rc.7"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.7-rc.8"
+version = "0.6.7-rc.9"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.7-rc.7"
+version = "0.6.7-rc.8"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.7-rc.8"
+version = "0.6.7-rc.9"
 edition = "2021"
 
 [lib]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.7-rc.6"
+version = "0.6.7-rc.7"
 edition = "2021"
 
 [lib]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.7-rc.7"
+version = "0.6.7-rc.8"
 edition = "2021"
 
 [lib]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.7-rc.5"
+version = "0.6.7-rc.6"
 edition = "2021"
 
 [lib]

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -3,6 +3,7 @@ use ant_core::data::{
     PreparedUpload, UploadCostEstimate,
 };
 use evmlib::common::{QuoteHash, TxHash};
+use evmlib::wallet::Wallet;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -81,6 +82,10 @@ pub struct InitArgs {
     pub evm_rpc_url: Option<String>,
     pub evm_token_address: Option<String>,
     pub evm_vault_address: Option<String>,
+    /// Optional hex-encoded private key. When present (devnet manifest path
+    /// only — never WalletConnect), the Rust client gets a wallet attached
+    /// via `Client::with_wallet`, unlocking the wallet-flow upload path.
+    pub wallet_private_key: Option<String>,
 }
 
 /// Pending uploads older than this are garbage-collected.
@@ -266,7 +271,35 @@ async fn run_connection_loop(app: AppHandle, args: InitArgs) {
     match Client::connect(&peers, client_config).await {
         Ok(client) => {
             let peer_count = client.network().connected_peers().await.len();
-            let client = client.with_evm_network(evm_network);
+            // When the manifest supplies a wallet key, attach a wallet so the
+            // Rust client can drive payments end-to-end via evmlib (the same
+            // path ant-cli uses). This bypasses the JS-side wagmi flow for
+            // direct-key mode — useful when devops manifests and on-chain
+            // contracts can drift, since one Rust path is easier to keep
+            // aligned than two parallel client implementations. Skip the
+            // wallet when no key is provided (WalletConnect / production):
+            // those flows still go through the external-signer path.
+            let client = if let Some(key) = args.wallet_private_key.as_deref() {
+                let key = if let Some(rest) = key.strip_prefix("0x") {
+                    rest
+                } else {
+                    key
+                };
+                match Wallet::new_from_private_key(evm_network.clone(), key) {
+                    Ok(wallet) => {
+                        eprintln!("Wallet attached to Client (address {})", wallet.address());
+                        client.with_wallet(wallet)
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Wallet from manifest key rejected, falling back to external-signer mode: {e}"
+                        );
+                        client.with_evm_network(evm_network)
+                    }
+                }
+            } else {
+                client.with_evm_network(evm_network)
+            };
             *app.state::<AutonomiState>().client.write().await = Some(client);
             eprintln!("Autonomi connect succeeded ({peer_count} peers)");
             set_connection_status(&app, ConnectionStatus::Connected).await;
@@ -294,6 +327,7 @@ pub async fn init_autonomi_client(
     evm_rpc_url: Option<String>,
     evm_token_address: Option<String>,
     evm_vault_address: Option<String>,
+    wallet_private_key: Option<String>,
 ) -> Result<bool, String> {
     if state.client.read().await.is_some() {
         return Ok(true);
@@ -311,6 +345,7 @@ pub async fn init_autonomi_client(
         evm_rpc_url,
         evm_token_address,
         evm_vault_address,
+        wallet_private_key,
     };
     *state.last_init_args.write().await = Some(args.clone());
 
@@ -638,6 +673,129 @@ pub async fn confirm_upload_merkle(
         .finalize_upload_merkle(prepared, hash_bytes)
         .await
         .map_err(|e| format!("Merkle upload failed: {e}"))?;
+
+    let data_map_json = serde_json::to_string(&result.data_map)
+        .map_err(|e| format!("Failed to serialize DataMap: {e}"))?;
+    let address = format!("0x{:x}", Sha256::digest(data_map_json.as_bytes()));
+    let data_map_file = crate::config::write_datamap_for(&file_name, &data_map_json)?
+        .to_string_lossy()
+        .into_owned();
+
+    app.emit(
+        "upload-progress",
+        serde_json::json!({
+            "upload_id": upload_id,
+            "status": "complete",
+            "chunks_stored": result.chunks_stored,
+        }),
+    )
+    .ok();
+
+    Ok(UploadResult {
+        upload_id,
+        data_map_json,
+        address,
+        chunks_stored: result.chunks_stored,
+        data_map_file,
+    })
+}
+
+/// Hot-attach a wallet to the running Client.
+///
+/// Used by the runtime direct-key path (Settings → Connect with private key)
+/// where the user supplies a key after the app already booted and called
+/// `init_autonomi_client` without one. Without this, uploads in that path
+/// hit `wallet_upload` against a wallet-less client and get an error.
+///
+/// Builds the EVM network the same way `init_autonomi_client` does: when an
+/// `evm_rpc_url` is supplied, all three custom fields are required and a
+/// `Custom` network is built; otherwise the `ArbitrumOne` preset is used so
+/// the wallet sits on the same chain as the bootstrap peers (mainnet by
+/// default when no manifest is present).
+///
+/// `Client::with_wallet` consumes the client by value, so we take it out of
+/// the `RwLock<Option<Client>>`, transform it, and put it back. The network
+/// connection (saorsa-transport peers) is preserved — no re-bootstrap.
+#[tauri::command]
+pub async fn attach_wallet(
+    state: tauri::State<'_, AutonomiState>,
+    wallet_private_key: String,
+    evm_rpc_url: Option<String>,
+    evm_token_address: Option<String>,
+    evm_vault_address: Option<String>,
+) -> Result<(), String> {
+    let evm_network = if let Some(rpc_url) = &evm_rpc_url {
+        let token = evm_token_address
+            .as_deref()
+            .ok_or("evm_token_address required when evm_rpc_url is provided")?;
+        let vault = evm_vault_address
+            .as_deref()
+            .ok_or("evm_vault_address required when evm_rpc_url is provided")?;
+        EvmNetwork::Custom(CustomNetwork::new(rpc_url, token, vault))
+    } else {
+        EvmNetwork::ArbitrumOne
+    };
+
+    let key = wallet_private_key
+        .strip_prefix("0x")
+        .unwrap_or(&wallet_private_key);
+    let wallet = Wallet::new_from_private_key(evm_network, key)
+        .map_err(|e| format!("Failed to build wallet from private key: {e}"))?;
+    let address = wallet.address();
+
+    let mut client_lock = state.client.write().await;
+    let client = client_lock
+        .take()
+        .ok_or("Autonomi client not initialized — wait for connection before attaching a wallet")?;
+    *client_lock = Some(client.with_wallet(wallet));
+
+    eprintln!("Wallet attached to Client (address {address})");
+    Ok(())
+}
+
+/// One-shot wallet-flow upload for direct-key mode.
+///
+/// Uses ant-core's `Client::file_upload` (the wallet flow that ant-cli runs)
+/// instead of the two-phase external-signer dance (`start_upload` → frontend
+/// payForQuotes → `confirm_upload`). The Rust client must have been
+/// initialised with `wallet_private_key` so it has an attached wallet.
+///
+/// `upload_id` is the frontend-supplied tracking id, included in the result
+/// so the upload row can be reconciled on receive.
+#[tauri::command]
+pub async fn wallet_upload(
+    app: AppHandle,
+    state: tauri::State<'_, AutonomiState>,
+    upload_id: String,
+    file_path: String,
+) -> Result<UploadResult, String> {
+    let client_lock = state.client.read().await;
+    let client = client_lock
+        .as_ref()
+        .ok_or("Autonomi client not initialized")?;
+    if client.wallet().is_none() {
+        return Err(
+            "Autonomi client has no wallet — wallet_upload requires direct-key (manifest) mode"
+                .into(),
+        );
+    }
+
+    let path = PathBuf::from(&file_path);
+    let canonical = tokio::fs::canonicalize(&path)
+        .await
+        .map_err(|e| format!("Invalid file path: {e}"))?;
+    if !canonical.is_file() {
+        return Err("Path is not a regular file".into());
+    }
+    let file_name = canonical
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "upload".to_string());
+
+    let result = client
+        .file_upload(&canonical)
+        .await
+        .map_err(|e| format!("Upload failed: {e}"))?;
 
     let data_map_json = serde_json::to_string(&result.data_map)
         .map_err(|e| format!("Failed to serialize DataMap: {e}"))?;

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -246,12 +246,15 @@ async fn run_connection_loop(app: AppHandle, args: InitArgs) {
         EvmNetwork::ArbitrumOne
     };
 
-    // Devnet (custom EVM RPC) runs on loopback — opt the saorsa-transport
-    // `local` flag in for that case only. Production peers reject the
-    // loopback handshake variant, so the default of `false` is correct
-    // for mainnet uploads. Matches the `--allow-loopback` semantics in
-    // ant-cli (see WithAutonomi/ant-client#40).
-    let allow_loopback = args.evm_rpc_url.is_some();
+    // `allow_loopback` changes the saorsa-transport QUIC handshake variant;
+    // enabling it on a client that dials remote peers makes those peers
+    // reject the connection (`found 0 peers` despite a successful dial).
+    // Enable only when the bootstrap peers themselves are on loopback —
+    // i.e. a genuine local Anvil + local ant-node setup. Remote devnets
+    // (a Sepolia manifest with public DigitalOcean peers) must not flip
+    // this on just because a custom EVM RPC is configured. Matches the
+    // `--allow-loopback` semantics in ant-cli, which is explicit-opt-in.
+    let allow_loopback = peers.iter().any(|p| p.ip().is_loopback());
 
     set_connection_status(&app, ConnectionStatus::Connecting).await;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -734,6 +734,8 @@ pub fn run() {
             autonomi_ops::estimate_file_cost,
             autonomi_ops::confirm_upload,
             autonomi_ops::confirm_upload_merkle,
+            autonomi_ops::wallet_upload,
+            autonomi_ops::attach_wallet,
             autonomi_ops::download_file,
             autonomi_ops::download_public,
             autonomi_ops::read_datamap_file,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.7-rc.8",
+  "version": "0.6.7-rc.9",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.7-rc.7",
+  "version": "0.6.7-rc.8",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.7-rc.5",
+  "version": "0.6.7-rc.6",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.7-rc.6",
+  "version": "0.6.7-rc.7",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -435,6 +435,49 @@ export const useFilesStore = defineStore('files', {
       const entry = this.findById(id)
       if (!entry) return
 
+      // Direct-key (manifest) mode: skip the entire JS quote+pay+confirm
+      // dance and call the Rust-side wallet_upload, which drives evmlib's
+      // wallet flow — same code path ant-cli uses. Avoids JS BigInt
+      // round-trips, devops vault-config drift, and double-implementation
+      // bugs. WalletConnect users still take the external-signer path below.
+      const settings = useSettingsStore()
+      if (settings.devnetActive && settings._devnetWalletKeySet) {
+        if (!entry.path) {
+          this.updateEntry(id, { status: 'failed', error: 'Upload entry has no file path' })
+          return
+        }
+        const walletUploadId = `wallet-${Date.now()}-${Math.random().toString(36).slice(2)}`
+        this.updateEntry(id, { status: 'uploading', progress: 0 })
+        try {
+          const result = await invoke<{
+            upload_id: string
+            data_map_json: string
+            address: string
+            chunks_stored: number
+            data_map_file: string
+          }>('wallet_upload', { uploadId: walletUploadId, filePath: entry.path })
+
+          const duration = entry.transferStartedAt
+            ? Math.round((Date.now() - entry.transferStartedAt) / 1000)
+            : 0
+          this.updateEntry(id, {
+            status: 'complete',
+            progress: 100,
+            address: result.address,
+            data_map_json: result.data_map_json,
+            data_map_file: result.data_map_file,
+            duration,
+            transferStartedAt: undefined,
+          })
+          await this.persistHistory()
+          toasts.add(`Upload complete: ${entry.name}`, 'info')
+        } catch (e: any) {
+          this.updateEntry(id, { status: 'failed', error: e.message ?? String(e) })
+          toasts.add(`Upload failed: ${entry.name} — ${e.message ?? e}`, 'error')
+        }
+        return
+      }
+
       try {
         let uploadId: string
         let quote: UploadQuote

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -5,7 +5,19 @@ import { ANVIL_CHAIN_ID } from '~/utils/constants'
 
 // Private key stored outside reactive state — not visible in Vue DevTools.
 let _walletKey: string | null = null
-export function setDevnetWalletKey(key: string | null) { _walletKey = key }
+export function setDevnetWalletKey(key: string | null) {
+  // viem's `privateKeyToAccount` requires a `0x`-prefixed hex string.
+  // The manual settings.vue entry path normalises prefix explicitly, but
+  // devnet manifests from devops ship the key without `0x` — store it
+  // normalised here so both entry paths converge. Missing this caused
+  // the manifest-driven wallet to silently fail to init: viem would
+  // derive a junk address (or throw) from the unprefixed bytes.
+  if (key && !key.startsWith('0x')) {
+    _walletKey = `0x${key}`
+  } else {
+    _walletKey = key
+  }
+}
 export function getDevnetWalletKey(): string | null { return _walletKey }
 
 export type ThemeMode = 'dark' | 'light'


### PR DESCRIPTION
## Summary

Four stacked fixes/features needed to make a devops Sepolia manifest produce a working out-of-the-box app, ending in a consolidation of the direct-private-key upload path onto the same Rust evmlib flow that `ant-cli` uses. Bumps `0.6.7-rc.5 → 0.6.7-rc.9` along the way.

In commit order:

### rc.6 — `fix(client)`: auto-detect `allow_loopback` from bootstrap peers (`86c0163`)

Previous logic flipped saorsa-transport's `local` flag whenever an EVM RPC URL was set:

```rust
let allow_loopback = args.evm_rpc_url.is_some();
```

This was originally to support local Anvil devnets, but it silently broke every remote testnet/devnet manifest. `allow_loopback` selects the QUIC handshake variant — when `true`, remote peers reject the connection. Symptom: `Client::connect` succeeds, badge lights up, then quotes fail with `insufficient peers: Found 0 peers, need 7`. Reproduced cleanly at the ant-cli layer with/without `--allow-loopback`.

Fix: enable only when at least one bootstrap peer is on loopback (`127.0.0.1` / `::1`) — matches ant-cli's explicit-opt-in semantics. Production path unchanged: bundled `bootstrap_peers.toml` is all public IPs.

### rc.7 — `fix(wallet)`: auto-init direct-key wallet whenever manifest supplies a key (`721f47e`)

`loadDevnetManifest` stashes any manifest `wallet_private_key` and flips `_devnetWalletKeySet`. The auto-restore in `app.vue::onMounted` was gated on `devnetChainId === ANVIL_CHAIN_ID`, so Sepolia/mainnet manifests with a pre-funded test key silently left the wallet disconnected. Switched the gate to `_devnetWalletKeySet`.

### rc.8 — `fix(wallet)`: normalise `0x` prefix on devnet-manifest private key (`313cada`)

Devnet manifests ship `wallet_private_key` as raw 64-hex (no `0x`); viem's `privateKeyToAccount` requires the prefix. Manual entry in `pages/settings.vue` already prepended it; the manifest path stored verbatim and silently derived a junk address. Normalised in `setDevnetWalletKey` so both entry paths converge.

### rc.9 — `feat(wallet)`: direct-PK uploads via Rust evmlib (headline change) (`73e9f83`)

Previously direct-PK upload went through the JS-side wagmi external-signer flow: backend prepared chunks, frontend signed `payForQuotes` with viem, backend finalised with the returned tx hashes. Two parallel payment codepaths (JS for direct-PK + WalletConnect, Rust for nothing) made debugging the chunk-payment verification failures harder than it needed to be — diagnosing across both surfaces hid the real cause (a stale `payment_vault_address` in the devops devnet manifest).

Direct-PK now routes through ant-core's wallet flow, the same end-to-end path as `ant-cli`:

- `init_autonomi_client` accepts `wallet_private_key`; when present (manifest path), backend builds an `evmlib::Wallet` from the matching custom EVM network and calls `Client::with_wallet(wallet)` so the Rust client carries an attached signer.
- New `wallet_upload(upload_id, file_path)` Tauri command drives `client.file_upload(&path)` directly — encrypt, quote, pay, store all inside Rust. Returns the existing `UploadResult` shape.
- `stores/files.ts::startRealUpload` branches at the top: when `devnetActive && _devnetWalletKeySet`, it invokes `wallet_upload` and skips the JS quote/pay/confirm dance. WalletConnect users (no manifest, no key) keep the existing JS path.
- `attach_wallet(...)` Tauri command hot-attaches a wallet to the running Client for the runtime direct-PK path (Settings → Connect with private key) — needed when `init_autonomi_client` already ran wallet-less.
- `pages/settings.vue::connectDirectWallet` calls `attach_wallet` after the wagmi config is initialised so both sides see the same wallet on the same network.
- `app.vue` no longer calls `ensureAntApproval` — `evmlib::Wallet::pay_for_quotes` auto-approves to MAX when allowance is insufficient, and the JS path's `ensureAllowance` did the same on its side. The previously parked rc.9 commit's `composables/useWallet.ts::ensureAntApproval` helper is dropped — it was solving a problem that didn't actually exist; the real bug was the wrong vault address in the manifest.

## Why the four together

Each fix is required for a fresh-install + devops Sepolia manifest to work:

| | Without it |
|---|---|
| rc.6 | 0 connected peers despite reachable bootstrap |
| rc.7 | wallet stays disconnected on non-Anvil manifests |
| rc.8 | viem derives a junk address from unprefixed key |
| rc.9 | two parallel payment codepaths to diagnose |

Version bumps applied across the four version-of-record files (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`) at each step.

## Test plan

- [x] rc.6: ant-cli reproducer with/without `--allow-loopback` against 7 DigitalOcean peers — confirmed handshake-variant theory
- [x] rc.6: end-to-end against Sepolia manifest — pre-fix 0 peers, post-fix 7 peers + 14 quotes for a 3-chunk file
- [x] rc.7: Sepolia manifest with key → wallet auto-inits; without key → falls through to WalletConnect
- [x] rc.8: manifest-loaded key now produces matching `paymentAddress`
- [x] rc.9: manifest-path upload completes via `wallet_upload` (Rust-only payment flow)
- [ ] CI green
- [ ] Manual end-to-end on a signed rc.9 build with a fresh Sepolia manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)