### PR TITLE
ci(release): publish releases at workflow end instead of leaving drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,71 +71,23 @@ jobs:
           echo "ant_version=$VERSION" >> $GITHUB_OUTPUT
           echo "Using ant sidecar: $TAG (version: $VERSION)"
 
-  create-release:
-    name: create draft release
-    runs-on: ubuntu-latest
-    needs: [release-meta]
-    outputs:
-      release_id: ${{ steps.create.outputs.release_id }}
-    steps:
-      - name: create draft release
-        id: create
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          tag="v${{ needs.release-meta.outputs.version }}"
-
-          # `gh release create` (as opposed to raw `gh api`) attaches the pushed
-          # git tag to the release object from creation, so downstream jobs and
-          # the final latest.json see the proper tag name instead of GitHub's
-          # internal `untagged-<id>` placeholder.
-          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" &>/dev/null; then
-            echo "Release $tag already exists (re-run)"
-          else
-            prerelease_flag=""
-            if [ "${{ needs.release-meta.outputs.prerelease }}" = "true" ]; then
-              prerelease_flag="--prerelease"
-            fi
-
-            gh release create "$tag" \
-              --repo "$GITHUB_REPOSITORY" \
-              --draft \
-              --title "Autonomi v${{ needs.release-meta.outputs.version }}" \
-              --generate-notes \
-              $prerelease_flag
-
-            echo "Created draft release $tag"
-          fi
-
-          # Tag-attached assertion: fails fast if GitHub still reports the
-          # release under an `untagged-*` slug. Without this, Windows MSI
-          # upload (which runs earliest) would freeze that slug into the
-          # final latest.json URL.
-          attached_tag=$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json tagName -q .tagName)
-          if [ "$attached_tag" != "$tag" ]; then
-            echo "ERROR: draft release tag is '$attached_tag', expected '$tag'" >&2
-            exit 1
-          fi
-          echo "Tag $tag confirmed attached to draft release"
-
-          release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases" \
-            --jq ".[] | select(.tag_name == \"$tag\") | .id")
-          echo "release_id=$release_id" >> $GITHUB_OUTPUT
-
   build-linux-macos:
     name: build (${{ matrix.args && matrix.args || matrix.platform }})
     runs-on: ${{ matrix.platform }}
-    needs: [release-meta, create-release, resolve-ant-version]
+    needs: [release-meta, resolve-ant-version]
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: ubuntu-22.04
             args: ""
+            slug: linux
           - platform: macos-latest
             args: "--target aarch64-apple-darwin"
+            slug: macos-aarch64
           - platform: macos-latest
             args: "--target x86_64-apple-darwin"
+            slug: macos-x86_64
     steps:
       - uses: actions/checkout@v4
 
@@ -215,16 +167,8 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          releaseId: ${{ needs.create-release.outputs.release_id }}
-          # Pass the concrete tag (not the literal `v__VERSION__` template) so
-          # asset URLs tauri-action stamps into any artifact metadata are
-          # correct. latest.json is composed from scratch in the final job, so
-          # includeUpdaterJson is disabled here to avoid parallel writes.
-          tagName: v${{ needs.release-meta.outputs.version }}
-          releaseName: "Autonomi v${{ needs.release-meta.outputs.version }}"
-          releaseDraft: true
-          prerelease: ${{ needs.release-meta.outputs.prerelease == 'true' }}
-          includeUpdaterJson: false
+          # Build only — no release upload. The publish-release job downloads
+          # the artifacts uploaded below and creates the release at the end.
           args: ${{ matrix.args }}
 
       - name: repair AppImage sidecar (static-pie workaround)
@@ -232,7 +176,6 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -242,8 +185,8 @@ jobs:
           # macOS/Windows bundlers don't touch sidecars, and `.deb`/`.rpm`
           # don't go through linuxdeploy, so only AppImage breaks. Workaround:
           # extract the produced AppImage, overwrite the mangled sidecar
-          # with the pristine binary we already downloaded, repack, re-sign
-          # for the updater, then replace the asset tauri-action uploaded.
+          # with the pristine binary we already downloaded, repack, then
+          # re-sign for the updater so the .sig matches the repaired file.
 
           APPIMAGE=$(realpath "$(ls src-tauri/target/release/bundle/appimage/*.AppImage | head -n 1)")
           PRISTINE=$(realpath src-tauri/binaries/ant-x86_64-unknown-linux-gnu)
@@ -293,14 +236,8 @@ jobs:
           rm -f "$APPIMAGE.sig"
           npx tauri signer sign "$APPIMAGE"
 
-          # Replace the asset tauri-action already uploaded to the draft release.
-          tag="v${{ needs.release-meta.outputs.version }}"
-          gh release upload "$tag" "$APPIMAGE" "$APPIMAGE.sig" --clobber
-
       - name: build portable Linux tar.gz
         if: startsWith(matrix.platform, 'ubuntu')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -321,13 +258,48 @@ jobs:
           out="$GITHUB_WORKSPACE/Autonomi_x64_linux.tar.gz"
           tar -C "$work" -czf "$out" autonomi
 
-          tag="v${{ needs.release-meta.outputs.version }}"
-          gh release upload "$tag" "$out" --clobber
+      - name: stage release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Collect all assets for this matrix entry into a single staging
+          # directory so the artifact upload step has a stable path. The
+          # publish-release job flattens artifacts from every build job and
+          # uploads them to the GitHub release in one go.
+          stage="$GITHUB_WORKSPACE/release-assets"
+          mkdir -p "$stage"
+
+          if [ "${{ matrix.platform }}" = "ubuntu-22.04" ]; then
+            cp src-tauri/target/release/bundle/appimage/*.AppImage     "$stage/"
+            cp src-tauri/target/release/bundle/appimage/*.AppImage.sig "$stage/"
+            cp src-tauri/target/release/bundle/deb/*.deb               "$stage/"
+            cp src-tauri/target/release/bundle/deb/*.deb.sig           "$stage/"
+            cp src-tauri/target/release/bundle/rpm/*.rpm               "$stage/"
+            cp src-tauri/target/release/bundle/rpm/*.rpm.sig           "$stage/"
+            cp "$GITHUB_WORKSPACE/Autonomi_x64_linux.tar.gz"           "$stage/"
+          else
+            # macOS: tauri-action emits .app.tar.gz under target/<triple>/release/bundle/macos/
+            target=$(echo "${{ matrix.args }}" | sed -n 's/.*--target \([^ ]*\).*/\1/p')
+            cp src-tauri/target/"$target"/release/bundle/macos/*.app.tar.gz     "$stage/"
+            cp src-tauri/target/"$target"/release/bundle/macos/*.app.tar.gz.sig "$stage/"
+          fi
+
+          echo "Staged assets:"
+          ls -l "$stage"
+
+      - name: upload release assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-${{ matrix.slug }}
+          path: release-assets/
+          if-no-files-found: error
+          retention-days: 7
 
   build-windows:
     name: build windows MSI (signed)
     runs-on: windows-latest
-    needs: [release-meta, create-release, resolve-ant-version]
+    needs: [release-meta, resolve-ant-version]
     env:
       SM_HOST: ${{ secrets.SM_HOST }}
       SM_API_KEY: ${{ secrets.SM_API_KEY }}
@@ -484,23 +456,7 @@ jobs:
             exit 1
           }
 
-      - name: upload MSI to release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          tag="${GITHUB_REF#refs/tags/}"
-
-          # Upload MSI installer and updater signature
-          # In Tauri v2, the .msi is the updater artifact directly (no .msi.zip)
-          gh release upload "$tag" \
-            src-tauri/target/release/bundle/msi/*.msi \
-            src-tauri/target/release/bundle/msi/*.msi.sig \
-            --clobber
-
       - name: build portable Windows tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
@@ -523,8 +479,28 @@ jobs:
           # otherwise treats as an rsh-style host:path spec and tries to dial.
           tar --force-local -C "$work" -czf "$out" autonomi
 
-          tag="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag" "$out" --clobber
+      - name: stage release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          stage="$GITHUB_WORKSPACE/release-assets"
+          mkdir -p "$stage"
+
+          cp src-tauri/target/release/bundle/msi/*.msi      "$stage/"
+          cp src-tauri/target/release/bundle/msi/*.msi.sig  "$stage/"
+          cp "$GITHUB_WORKSPACE/Autonomi_x64_windows.tar.gz" "$stage/"
+
+          echo "Staged assets:"
+          ls -l "$stage"
+
+      - name: upload release assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-windows
+          path: release-assets/
+          if-no-files-found: error
+          retention-days: 7
 
       - name: upload signing logs on failure
         if: failure()
@@ -534,33 +510,70 @@ jobs:
           path: ${{ github.workspace }}\smctl-signing.log
           if-no-files-found: ignore
 
-  compose-latest-json:
-    name: compose and upload latest.json
+  publish-release:
+    name: publish release
     runs-on: ubuntu-latest
     needs: [release-meta, build-linux-macos, build-windows]
     steps:
-      - name: download all signature files
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # Download every artifact uploaded by the build jobs
+          # (release-assets-linux, release-assets-macos-aarch64,
+          # release-assets-macos-x86_64, release-assets-windows) and flatten
+          # them into a single directory so subsequent steps see one path.
+          path: assets
+          pattern: release-assets-*
+          merge-multiple: true
+
+      - name: list downloaded assets
         run: |
+          echo "Downloaded assets:"
+          ls -l assets
+
+      - name: create published release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
           tag="v${{ needs.release-meta.outputs.version }}"
-          mkdir -p sigs
-          gh release download "$tag" --pattern "*.sig" --dir sigs --clobber --repo "$GITHUB_REPOSITORY"
-          echo "Downloaded signatures:"
-          ls -l sigs
+
+          prerelease_flag=""
+          if [ "${{ needs.release-meta.outputs.prerelease }}" = "true" ]; then
+            prerelease_flag="--prerelease"
+          fi
+
+          # No --draft: this creates a published (or published pre-release)
+          # GitHub release. `gh release create` always attaches the pushed
+          # tag to the release object from creation, so latest.json URLs
+          # composed below resolve correctly.
+          gh release create "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Autonomi v${{ needs.release-meta.outputs.version }}" \
+            --generate-notes \
+            $prerelease_flag
+
+      - name: upload built assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="v${{ needs.release-meta.outputs.version }}"
+          gh release upload "$tag" assets/* --clobber --repo "$GITHUB_REPOSITORY"
 
       - name: compose latest.json from scratch
         env:
           VERSION: ${{ needs.release-meta.outputs.version }}
         run: |
+          set -euo pipefail
           tag="v${VERSION}"
           base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}"
 
           read_sig() {
-            local path="sigs/$1"
+            local path="assets/$1"
             if [ ! -s "$path" ]; then
               echo "ERROR: signature file missing or empty: $path" >&2
-              ls -l sigs >&2
+              ls -l assets >&2
               exit 1
             fi
             cat "$path"
@@ -612,9 +625,9 @@ jobs:
 
       - name: assert latest.json integrity
         run: |
-          # Fails if any URL still contains GitHub's `untagged-*` draft slug or
-          # tauri-action's unsubstituted `__VERSION__` template. Also guards
-          # against empty/null signatures.
+          # Defends against unsubstituted `__VERSION__` templates and
+          # GitHub's `untagged-*` placeholder slug, plus empty/null
+          # signatures and platform-key drift.
           if jq -e '.platforms | to_entries[] | select(.value.url | test("__VERSION__|/releases/download/untagged-"))' latest.json > /dev/null; then
             echo "ERROR: latest.json contains broken URLs (__VERSION__ or untagged-*)" >&2
             jq '.platforms' latest.json >&2
@@ -637,7 +650,7 @@ jobs:
 
       - name: upload latest.json to release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="v${{ needs.release-meta.outputs.version }}"
           gh release upload "$tag" latest.json --clobber --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary

- Drops the upfront `create-release` job. Build jobs (`build-linux-macos`, `build-windows`) now upload their bundled outputs as GitHub Actions artifacts (`release-assets-linux`, `release-assets-macos-aarch64`, `release-assets-macos-x86_64`, `release-assets-windows`) instead of pushing assets straight into a draft release.
- Adds a final `publish-release` job that downloads every artifact, runs `gh release create` **without** `--draft` (with `--prerelease` for tags whose version contains `-rc.` / `-beta.` / `-alpha.`, reusing the existing `release-meta.outputs.prerelease` output), uploads all assets to the release, then composes and uploads `latest.json` from the now-local `.sig` files.
- Net effect: releases are published the moment the workflow finishes — no manual promotion step. Pre-release tags become published pre-releases. Final tags become published "Latest" releases.

The Windows MSI signing job is still slow (~19 min, dominated by a 15m 46s `build and bundle MSI` step that lumps cargo compile + Tauri bundle + DigiCert HSM signing). Time attribution requires splitting that step, so optimisation is deferred to a follow-up PR.

## Test plan
- [ ] Push a `vX.Y.Z-rc.N` tag once this is merged and confirm a single **published pre-release** is produced (not a draft) with all `.AppImage` / `.deb` / `.rpm` / `.app.tar.gz` / `.msi` plus their `.sig` files, the two portable `.tar.gz` archives, and `latest.json`.
- [ ] Fetch `https://github.com/WithAutonomi/ant-ui/releases/latest/download/latest.json` and confirm it resolves; verify signatures and URLs are non-empty.
- [ ] Push a `vX.Y.Z` tag and confirm the resulting release is marked **Latest**, not Pre-release, not Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)