### PR TITLE
fix(windows): add CREATE_NO_WINDOW to daemon spawn flags

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -501,8 +501,12 @@ async fn ensure_daemon_running() -> Result<String, String> {
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        // CREATE_NEW_PROCESS_GROUP — detaches from parent console
-        cmd.creation_flags(0x00000200);
+        // CREATE_NEW_PROCESS_GROUP (0x00000200) — detaches the daemon from
+        // our process group so signals don't propagate.
+        // CREATE_NO_WINDOW       (0x08000000) — prevents Windows from
+        // allocating a console window for the console-subsystem daemon
+        // binary, which would otherwise flash on every spawn.
+        cmd.creation_flags(0x08000200);
     }
     #[cfg(unix)]
     {


### PR DESCRIPTION
## Summary

The daemon sidecar `ant.exe` is a console-subsystem binary; spawning it from ant-gui (which has no console) caused Windows to allocate a fresh console window for the child, briefly visible as a ghost-window flash on every spawn.

The previous flag value `0x00000200` is `CREATE_NEW_PROCESS_GROUP`, not `CREATE_NO_WINDOW` (the comment was correct about the flag's effect of detaching from the parent's console, but that flag alone doesn't suppress new console allocation). Combine with `CREATE_NO_WINDOW` (`0x08000000`) to keep the process-group detach AND prevent the visible flash.

## Pairs with

WithAutonomi/ant-client#66 — silences the higher-volume cause of the flash storm reported in #61: the daemon's per-node version-probe subprocesses + post-sleep `tokio::time::interval` burst-catchup. Either PR alone reduces the visible problem; together they're correct.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` clean
- [x] Manual UAT (Windows): app launch → no flash on white→live transition (was: 1 flash). Confirmed against a patched daemon binary with the ant-client companion fix applied.
- [ ] Re-run a full sleep-cycle test once both PRs land in a release.

Refs #61