### PR TITLE
feat(uploads/downloads): live progress bar driven by ant-core events

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -36,6 +36,7 @@ onMounted(async () => {
   await settingsStore.loadDevnetManifest()
   nodesStore.init()
   filesStore.loadHistory()
+  filesStore.setupProgressListeners()
   updaterStore.checkForUpdate()
   settingsStore.reconnectIndelible()
   // Listen for backend connection-status events so the UI reflects retry state.

--- a/components/ProgressLine.vue
+++ b/components/ProgressLine.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="mt-1 flex flex-col gap-1">
+    <span v-if="detail" class="text-[10px] text-autonomi-muted">{{ detail }}</span>
+    <div class="h-1 w-full overflow-hidden rounded bg-autonomi-surface" role="progressbar" :aria-valuenow="percent ?? undefined" aria-valuemin="0" aria-valuemax="100">
+      <div
+        v-if="percent !== undefined && percent !== null"
+        class="h-full bg-autonomi-blue transition-[width] duration-200 ease-out"
+        :style="{ width: `${clampedPercent}%` }"
+      />
+      <div v-else class="h-full w-1/3 animate-pulse bg-autonomi-blue/60" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  detail: string | null
+  percent: number | null | undefined
+}>()
+
+const clampedPercent = computed(() => {
+  const p = props.percent ?? 0
+  return Math.max(0, Math.min(100, p))
+})
+</script>

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -112,6 +112,7 @@
                 <td class="px-4 py-2.5 text-autonomi-muted">{{ file.size_bytes ? formatBytes(file.size_bytes) : '-' }}</td>
                 <td class="px-4 py-2.5">
                   <StatusBadge :status="statusLabel(file)" />
+                  <ProgressLine v-if="showsProgressBar(file)" :detail="stageDetail(file)" :percent="file.progress" />
                 </td>
                 <td class="px-4 py-2.5 text-autonomi-muted">
                   <template v-if="file.alreadyStored">
@@ -198,6 +199,7 @@
               <td class="px-4 py-2.5 text-autonomi-muted">{{ file.size_bytes ? formatBytes(file.size_bytes) : '-' }}</td>
               <td class="px-4 py-2.5">
                 <StatusBadge :status="statusLabel(file)" />
+                <ProgressLine v-if="showsProgressBar(file)" :detail="stageDetail(file)" :percent="file.progress" />
               </td>
               <td class="px-4 py-2.5 font-mono text-xs text-autonomi-muted">
                 {{ file.dest_path ? basenameOf(file.dest_path) : '-' }}
@@ -401,6 +403,41 @@ function statusLabel(file: FileEntry): string {
   if (file.status === 'awaiting_approval') return 'Ready to approve'
   if (file.status === 'paying') return 'Paying'
   return file.status
+}
+
+/** Sub-stage detail line shown under the status badge while a transfer is
+ *  active. Maps the stage / cumulative counts coming from ant-core's
+ *  UploadEvent / DownloadEvent stream into a tight label that fits a row.
+ *  Shows a per-stage percent (how far through the current step we are);
+ *  the bar above shows global progress. Returns null when there's nothing
+ *  useful to show (no event yet, or the row isn't in an active state). */
+function stageDetail(file: FileEntry): string | null {
+  if (!file.stage) return null
+  const done = file.stageDone ?? 0
+  const total = file.stageTotal
+  const pct = total && total > 0 ? Math.round((done / total) * 100) : null
+  switch (file.stage) {
+    case 'encrypting':
+      // Encryption has no total until it finishes — fall back to a spinner.
+      return 'Encrypting…'
+    case 'quoting':
+      return pct !== null ? `Quoting · ${pct}%` : 'Quoting…'
+    case 'uploading':
+      return pct !== null ? `Storing · ${pct}%` : 'Storing…'
+    case 'resolving':
+      return pct !== null ? `Resolving datamap · ${pct}%` : 'Resolving datamap…'
+    case 'downloading':
+      return pct !== null ? `Downloading · ${pct}%` : 'Downloading…'
+    default:
+      return null
+  }
+}
+
+/** Whether the row should render a progress bar. Bar is shown for any active
+ *  transfer state — even when percent is null (encryption phase) we render
+ *  an indeterminate bar so the user sees motion. */
+function showsProgressBar(file: FileEntry): boolean {
+  return file.status === 'uploading' || file.status === 'downloading'
 }
 
 function isReopenable(file: FileEntry): boolean {

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -1,6 +1,6 @@
 use ant_core::data::{
-    Client, ClientConfig, CustomNetwork, DataMap, EvmNetwork, ExternalPaymentInfo, PaymentMode,
-    PreparedUpload, UploadCostEstimate,
+    Client, ClientConfig, CustomNetwork, DataMap, DownloadEvent, EvmNetwork, ExternalPaymentInfo,
+    PaymentMode, PreparedUpload, UploadCostEstimate, UploadEvent,
 };
 use evmlib::common::{QuoteHash, TxHash};
 use evmlib::wallet::Wallet;
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tauri::{AppHandle, Emitter, Manager};
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, RwLock};
 
 #[derive(Deserialize)]
 struct BootstrapPeersFile {
@@ -173,6 +173,150 @@ pub struct UploadResult {
 pub struct StartUploadRequest {
     pub files: Vec<String>,
     pub upload_id: String,
+}
+
+// ── Progress forwarders ──
+//
+// Spawn a tokio task that drains an mpsc receiver of UploadEvent / DownloadEvent
+// and re-emits them as Tauri events. The frontend listens for `upload-progress`
+// / `download-progress` keyed by `transfer_id` and updates the row in place.
+//
+// Channels are bounded — the receiver task is the only consumer, so back-pressure
+// just slows the upload/download loop. The senders inside ant-core use try_send
+// for high-volume events so we never block the network futures on a busy UI.
+
+/// Wire-shape of the `upload-progress` Tauri event. The `percent` field is
+/// pre-computed so the UI can drive the progress bar without re-deriving it,
+/// and is `None` while the chunk total is still unknown (encryption phase).
+#[derive(Serialize, Clone, Debug)]
+struct UploadProgressPayload {
+    transfer_id: String,
+    stage: &'static str,
+    done: usize,
+    total: Option<usize>,
+    percent: Option<f32>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+struct DownloadProgressPayload {
+    transfer_id: String,
+    stage: &'static str,
+    done: usize,
+    total: Option<usize>,
+    percent: Option<f32>,
+}
+
+/// Map an UploadEvent into the wire payload. Quoting is treated as the first
+/// half of the bar (0..50%) and storage as the second half (50..100%) so the
+/// user sees continuous forward motion across both phases.
+fn map_upload_event(transfer_id: &str, ev: UploadEvent) -> Option<UploadProgressPayload> {
+    let id = transfer_id.to_string();
+    Some(match ev {
+        UploadEvent::Encrypting { chunks_done } => UploadProgressPayload {
+            transfer_id: id,
+            stage: "encrypting",
+            done: chunks_done,
+            total: None,
+            percent: None,
+        },
+        UploadEvent::Encrypted { total_chunks } => UploadProgressPayload {
+            transfer_id: id,
+            stage: "quoting",
+            done: 0,
+            total: Some(total_chunks),
+            percent: Some(0.0),
+        },
+        UploadEvent::QuotingChunks { .. } => return None,
+        UploadEvent::ChunkQuoted { quoted, total } => UploadProgressPayload {
+            transfer_id: id,
+            stage: "quoting",
+            done: quoted,
+            total: Some(total),
+            percent: Some(percent_of(quoted, total) * 0.5),
+        },
+        UploadEvent::ChunkStored { stored, total } => UploadProgressPayload {
+            transfer_id: id,
+            stage: "uploading",
+            done: stored,
+            total: Some(total),
+            percent: Some(50.0 + percent_of(stored, total) * 0.5),
+        },
+        UploadEvent::WaveComplete { .. } => return None,
+    })
+}
+
+fn map_download_event(transfer_id: &str, ev: DownloadEvent) -> DownloadProgressPayload {
+    let id = transfer_id.to_string();
+    match ev {
+        DownloadEvent::ResolvingDataMap { total_map_chunks } => DownloadProgressPayload {
+            transfer_id: id,
+            stage: "resolving",
+            done: 0,
+            total: Some(total_map_chunks),
+            percent: None,
+        },
+        DownloadEvent::MapChunkFetched { fetched } => DownloadProgressPayload {
+            transfer_id: id,
+            stage: "resolving",
+            done: fetched,
+            total: None,
+            percent: None,
+        },
+        DownloadEvent::DataMapResolved { total_chunks } => DownloadProgressPayload {
+            transfer_id: id,
+            stage: "downloading",
+            done: 0,
+            total: Some(total_chunks),
+            percent: Some(0.0),
+        },
+        DownloadEvent::ChunksFetched { fetched, total } => DownloadProgressPayload {
+            transfer_id: id,
+            stage: "downloading",
+            done: fetched,
+            total: Some(total),
+            percent: Some(percent_of(fetched, total)),
+        },
+    }
+}
+
+fn percent_of(done: usize, total: usize) -> f32 {
+    if total == 0 {
+        0.0
+    } else {
+        (done as f32 / total as f32) * 100.0
+    }
+}
+
+/// Spawn a forwarder task that re-emits UploadEvents as `upload-progress`.
+/// Returns the sender end — drop it (or let the upload future drop it) to
+/// shut the forwarder down cleanly.
+fn spawn_upload_progress_forwarder(
+    app: AppHandle,
+    transfer_id: String,
+) -> mpsc::Sender<UploadEvent> {
+    let (tx, mut rx) = mpsc::channel::<UploadEvent>(64);
+    tokio::spawn(async move {
+        while let Some(ev) = rx.recv().await {
+            if let Some(payload) = map_upload_event(&transfer_id, ev) {
+                let _ = app.emit("upload-progress", &payload);
+            }
+        }
+    });
+    tx
+}
+
+fn spawn_download_progress_forwarder(
+    app: AppHandle,
+    transfer_id: String,
+) -> mpsc::Sender<DownloadEvent> {
+    let (tx, mut rx) = mpsc::channel::<DownloadEvent>(64);
+    tokio::spawn(async move {
+        while let Some(ev) = rx.recv().await {
+            let payload = map_download_event(&transfer_id, ev);
+            let _ = app.emit("download-progress", &payload);
+        }
+    });
+    tx
 }
 
 // ── Tauri commands ──
@@ -792,8 +936,10 @@ pub async fn wallet_upload(
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_else(|| "upload".to_string());
 
+    let progress_tx = spawn_upload_progress_forwarder(app.clone(), upload_id.clone());
+
     let result = client
-        .file_upload(&canonical)
+        .file_upload_with_progress(&canonical, PaymentMode::Auto, Some(progress_tx))
         .await
         .map_err(|e| format!("Upload failed: {e}"))?;
 
@@ -828,6 +974,7 @@ pub async fn wallet_upload(
 pub async fn download_file(
     app: AppHandle,
     state: tauri::State<'_, AutonomiState>,
+    transfer_id: String,
     data_map_json: String,
     dest_path: String,
 ) -> Result<u64, String> {
@@ -839,7 +986,7 @@ pub async fn download_file(
     let data_map: DataMap =
         serde_json::from_str(&data_map_json).map_err(|e| format!("Invalid DataMap: {e}"))?;
 
-    download_with_datamap(client, &data_map, &dest_path, &app).await
+    download_with_datamap(client, &data_map, &dest_path, &app, transfer_id).await
 }
 
 /// Fetch a DataMap from the network by its public chunk address, then
@@ -850,6 +997,7 @@ pub async fn download_file(
 pub async fn download_public(
     app: AppHandle,
     state: tauri::State<'_, AutonomiState>,
+    transfer_id: String,
     address: String,
     dest_path: String,
 ) -> Result<u64, String> {
@@ -869,7 +1017,7 @@ pub async fn download_public(
         .await
         .map_err(|e| format!("No data map at that address: {e}"))?;
 
-    download_with_datamap(client, &data_map, &dest_path, &app).await
+    download_with_datamap(client, &data_map, &dest_path, &app, transfer_id).await
 }
 
 async fn download_with_datamap(
@@ -877,6 +1025,7 @@ async fn download_with_datamap(
     data_map: &DataMap,
     dest_path: &str,
     app: &AppHandle,
+    transfer_id: String,
 ) -> Result<u64, String> {
     let dest = expand_tilde(dest_path);
 
@@ -894,8 +1043,10 @@ async fn download_with_datamap(
         }
     }
 
+    let progress_tx = spawn_download_progress_forwarder(app.clone(), transfer_id);
+
     let bytes_written = client
-        .file_download(data_map, &dest)
+        .file_download_with_progress(data_map, &dest, Some(progress_tx))
         .await
         .map_err(|e| format!("Download failed: {e}"))?;
 

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -48,6 +48,24 @@ export type FileStatus =
   | 'downloaded'         // Download complete, waiting for user to open folder
   | 'failed'             // Transfer failed
 
+/** Sub-stage inside an active transfer. Maps 1:1 to ant-core's UploadEvent /
+ *  DownloadEvent variants surfaced by the Rust progress forwarder. Drives the
+ *  detailed label under the status badge ("Encrypting", "Quoting 12/64", ...). */
+export type TransferStage =
+  | 'encrypting'
+  | 'quoting'
+  | 'uploading'
+  | 'resolving'
+  | 'downloading'
+
+interface ProgressEventPayload {
+  transfer_id: string
+  stage: TransferStage
+  done: number
+  total: number | null
+  percent: number | null
+}
+
 export interface FileEntry {
   /** Unique ID for reactive tracking */
   id: number
@@ -77,6 +95,14 @@ export interface FileEntry {
   status: FileStatus
   /** Transfer progress 0-100 */
   progress?: number
+  /** Sub-stage inside the active transfer, populated by upload-progress /
+   *  download-progress events. Ephemeral — cleared when the transfer settles. */
+  stage?: TransferStage
+  /** Cumulative chunks completed in the current stage (paired with stageTotal). */
+  stageDone?: number
+  /** Total chunks for the current stage; absent during encryption (total
+   *  unknown until encryption finishes). */
+  stageTotal?: number
   /** Local destination path (for downloads) */
   dest_path?: string
   /** When the entry was created/uploaded */
@@ -133,6 +159,9 @@ export const useFilesStore = defineStore('files', {
     files: [] as FileEntry[],
     nextId: 1,
     historyLoaded: false,
+    /** True once the Rust progress event listeners have been wired up.
+     *  Idempotent — safe to call setupProgressListeners() multiple times. */
+    _progressListenersStarted: false,
   }),
 
   getters: {
@@ -235,6 +264,33 @@ export const useFilesStore = defineStore('files', {
       } catch (e) {
         console.error('Failed to save upload history:', e)
       }
+    },
+
+    // ── Progress event plumbing ──
+
+    /** Subscribe to upload-progress / download-progress events from the Rust
+     *  backend and route them to the matching FileEntry. The Rust side echoes
+     *  the entry id (as a string) as `transfer_id`, so we just parse it back
+     *  and updateEntry. Idempotent — only wires once per session. */
+    async setupProgressListeners() {
+      if (this._progressListenersStarted) return
+      this._progressListenersStarted = true
+
+      const apply = (payload: ProgressEventPayload) => {
+        const id = Number(payload.transfer_id)
+        if (!Number.isFinite(id)) return
+        // The transfer may have already settled (failed / completed) by the
+        // time a tail-end event arrives; updateEntry no-ops on missing ids.
+        this.updateEntry(id, {
+          stage: payload.stage,
+          stageDone: payload.done,
+          stageTotal: payload.total ?? undefined,
+          progress: payload.percent ?? undefined,
+        })
+      }
+
+      await listen<ProgressEventPayload>('upload-progress', e => apply(e.payload))
+      await listen<ProgressEventPayload>('download-progress', e => apply(e.payload))
     },
 
     // ── Entry management ──
@@ -446,7 +502,8 @@ export const useFilesStore = defineStore('files', {
           this.updateEntry(id, { status: 'failed', error: 'Upload entry has no file path' })
           return
         }
-        const walletUploadId = `wallet-${Date.now()}-${Math.random().toString(36).slice(2)}`
+        // Use the entry id as the transfer_id so Rust-side progress events
+        // (upload-progress) route straight back to this row.
         this.updateEntry(id, { status: 'uploading', progress: 0 })
         try {
           const result = await invoke<{
@@ -455,7 +512,7 @@ export const useFilesStore = defineStore('files', {
             address: string
             chunks_stored: number
             data_map_file: string
-          }>('wallet_upload', { uploadId: walletUploadId, filePath: entry.path })
+          }>('wallet_upload', { uploadId: String(id), filePath: entry.path })
 
           const duration = entry.transferStartedAt
             ? Math.round((Date.now() - entry.transferStartedAt) / 1000)
@@ -468,6 +525,9 @@ export const useFilesStore = defineStore('files', {
             data_map_file: result.data_map_file,
             duration,
             transferStartedAt: undefined,
+            stage: undefined,
+            stageDone: undefined,
+            stageTotal: undefined,
           })
           await this.persistHistory()
           toasts.add(`Upload complete: ${entry.name}`, 'info')
@@ -709,10 +769,12 @@ export const useFilesStore = defineStore('files', {
         // invoke's rejection.
         const request = entry.data_map_json
           ? invoke('download_file', {
+              transferId: String(id),
               dataMapJson: entry.data_map_json,
               destPath: entry.dest_path,
             })
           : invoke('download_public', {
+              transferId: String(id),
               address: entry.address,
               destPath: entry.dest_path,
             })
@@ -726,6 +788,9 @@ export const useFilesStore = defineStore('files', {
           status: 'downloaded',
           progress: 100,
           duration,
+          stage: undefined,
+          stageDone: undefined,
+          stageTotal: undefined,
         })
         toasts.add(`Download complete: ${entry.name}`, 'info')
       } catch (e: any) {


### PR DESCRIPTION
## Summary
- Wires ant-core's `UploadEvent` / `DownloadEvent` channel API (already shipped in `ant-core-v0.2.0`) into the GUI for the direct-key wallet upload path and both download flows.
- Adds a per-stage label (e.g. *Quoting · 47%*, *Storing · 73%*) under the existing status badge, and a global 0–100% progress bar built off `(quoting * 0.5) + (storing * 0.5)` so the bar moves continuously across both phases.
- New `ProgressLine.vue` component handles the determinate / indeterminate cases (encryption has no total until it finishes — falls back to a pulsing bar).

## What changed

**Rust** (`src-tauri/src/autonomi_ops.rs`)
- `spawn_upload_progress_forwarder` / `spawn_download_progress_forwarder` drain a per-call mpsc channel and re-emit each event as a Tauri `upload-progress` / `download-progress` event keyed by `transfer_id`.
- `wallet_upload` now calls `file_upload_with_progress(_, PaymentMode::Auto, Some(tx))`.
- `download_file` / `download_public` / `download_with_datamap` take a `transfer_id` arg and call `file_download_with_progress`.

**Frontend**
- `stores/files.ts`: `TransferStage` type, `stage` / `stageDone` / `stageTotal` on `FileEntry`, `setupProgressListeners()` action routing Tauri events back to the right row by parsing `transfer_id` as the entry id. `wallet_upload` invocation now passes `String(id)` as `uploadId` so events route correctly.
- `app.vue` calls `setupProgressListeners()` on boot.
- `pages/files.vue`: `stageDetail()` returns the per-stage percent label; `showsProgressBar()` gates rendering to active uploads/downloads.

## What's NOT in this PR

- **External-signer (WalletConnect) flow** is intentionally left dark. `Client::file_prepare_upload_with_visibility` and `Client::finalize_upload[_merkle]` don't accept a progress sender today, so threading them needs a small upstream ant-core PR. Tracked separately.
- No ant-core dep bump — the `UploadEvent` / `DownloadEvent` API is already in the pinned `ant-core-v0.2.0`.

## Test plan

- [x] `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` clean.
- [x] `npx vitest run` — 21/21 pass.
- [x] Manual on local Anvil devnet (`cargo run --release --example start-local-devnet --features devnet` from `ant-client`) for 3-, 9-, 10-, and 28-chunk uploads. Quote phase percent climbs 0→100% in the label while bar climbs 0→50%; storage phase mirrors it 50→100%. Download by datamap shows resolving → downloading transitions.
- [ ] Reviewer to verify behaviour against the production network on a personal funded wallet — direct-key path is the same code path, just a different EVM target.

## Notes for reviewers

- During the local-devnet manual test the saorsa-core bootstrap cache leaks mainnet peers from previous sessions (V2-211); wipe `%LOCALAPPDATA%\saorsa\bootstrap\bootstrap_cache.json` before launching the devnet to keep traffic loopback-only.
- This PR's progress wiring re-uses the entry's row id as the `transfer_id` rather than a random UUID, so the listener can update the right row without an extra mapping table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)