### PR TITLE
feat(uploads): live progress for external-signer flow + wagmi fixes

### DIFF
--- a/components/BarSegment.vue
+++ b/components/BarSegment.vue
@@ -1,0 +1,15 @@
+<template>
+  <!-- A single bar segment in ProgressLine's quote/store split. flex-1 so the
+       quote and store segments share the row evenly with the dot in between. -->
+  <div class="h-1 flex-1 overflow-hidden rounded bg-autonomi-surface">
+    <div
+      class="h-full bg-autonomi-blue transition-[width] duration-200 ease-out"
+      :style="{ width: `${clamped}%` }"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ percent: number }>()
+const clamped = computed(() => Math.max(0, Math.min(100, props.percent)))
+</script>

--- a/components/PayDot.vue
+++ b/components/PayDot.vue
@@ -1,0 +1,30 @@
+<template>
+  <!-- The payment indicator between the quote and store segments.
+       - empty: outline only, awaiting wallet step
+       - pulse: filled and animated, popup is open
+       - solid: filled, payment confirmed -->
+  <span
+    class="inline-block h-2 w-2 rounded-full transition-colors"
+    :class="classes"
+    :aria-label="label"
+  />
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ state: 'empty' | 'pulse' | 'solid' }>()
+
+const classes = computed(() => {
+  switch (props.state) {
+    case 'pulse': return 'animate-pulse bg-autonomi-blue'
+    case 'solid': return 'bg-autonomi-blue'
+    case 'empty':
+    default: return 'bg-autonomi-surface'
+  }
+})
+
+const label = computed(() => ({
+  empty: 'Payment pending',
+  pulse: 'Awaiting wallet',
+  solid: 'Payment confirmed',
+}[props.state]))
+</script>

--- a/components/ProgressLine.vue
+++ b/components/ProgressLine.vue
@@ -1,25 +1,100 @@
 <template>
-  <div class="mt-1 flex flex-col gap-1">
-    <span v-if="detail" class="text-[10px] text-autonomi-muted">{{ detail }}</span>
-    <div class="h-1 w-full overflow-hidden rounded bg-autonomi-surface" role="progressbar" :aria-valuenow="percent ?? undefined" aria-valuemin="0" aria-valuemax="100">
-      <div
-        v-if="percent !== undefined && percent !== null"
-        class="h-full bg-autonomi-blue transition-[width] duration-200 ease-out"
-        :style="{ width: `${clampedPercent}%` }"
-      />
-      <div v-else class="h-full w-1/3 animate-pulse bg-autonomi-blue/60" />
-    </div>
+  <!-- Segmented bar for uploads: [quote] · [pay] · [store]
+       For downloads: a single bar (no payment phase).
+       Stage detail text is rendered separately by the parent (next to the
+       status badge), not here — this component is purely the bar. -->
+  <div
+    v-if="kind === 'upload'"
+    class="mt-1 flex w-full min-w-[8rem] items-center gap-1.5"
+    role="progressbar"
+    :aria-valuenow="overallPercent"
+    aria-valuemin="0"
+    aria-valuemax="100"
+  >
+    <BarSegment :percent="quoteBarPct" />
+    <PayDot :state="dotState" />
+    <BarSegment :percent="storeBarPct" />
+  </div>
+
+  <div
+    v-else
+    class="mt-1 h-1 w-full min-w-[8rem] overflow-hidden rounded bg-autonomi-surface"
+    role="progressbar"
+    :aria-valuenow="overallPercent"
+    aria-valuemin="0"
+    aria-valuemax="100"
+  >
+    <div
+      v-if="props.percent !== undefined && props.percent !== null"
+      class="h-full bg-autonomi-blue transition-[width] duration-200 ease-out"
+      :style="{ width: `${clamp(props.percent)}%` }"
+    />
+    <div v-else class="h-full w-1/3 animate-pulse bg-autonomi-blue/60" />
   </div>
 </template>
 
 <script setup lang="ts">
+import type { FileEntry, FileStatus, TransferStage } from '~/stores/files'
+
 const props = defineProps<{
-  detail: string | null
+  /** Global percent 0–100; used for the download bar and aria. Optional —
+   *  null means we have no total yet (encryption phase) and the download bar
+   *  falls back to an indeterminate pulse. */
   percent: number | null | undefined
+  /** Upload vs download — determines whether to render the segmented bar or
+   *  the single bar. */
+  kind: FileEntry['kind']
+  /** Outer status — drives the payment dot's state. */
+  status: FileStatus
+  /** Sub-stage and per-stage chunk counts; together drive each segment's fill. */
+  stage: TransferStage | undefined
+  stageDone: number | undefined
+  stageTotal: number | undefined
 }>()
 
-const clampedPercent = computed(() => {
-  const p = props.percent ?? 0
+function clamp(p: number) {
   return Math.max(0, Math.min(100, p))
+}
+
+function stagePct(): number {
+  const total = props.stageTotal ?? 0
+  if (!total) return 0
+  return clamp((props.stageDone ?? 0) / total * 100)
+}
+
+/** Quote segment fill — 0..100 of the quote phase only.
+ *
+ *  Stage-driven: `stage` reflects what ant-core is actually doing right now
+ *  (quoting / uploading), regardless of the JS-side outer status which the
+ *  wallet flow pre-flips to 'uploading' before any quoting begins. Status
+ *  is consulted only as a fallback to "we're past quoting":
+ *  - `paying` (external-signer's wallet popup) → segment full
+ *  - `complete` (everything done) → segment full
+ *  Otherwise we fill from the live quote count. */
+const quoteBarPct = computed(() => {
+  if (props.status === 'complete') return 100
+  if (props.stage === 'uploading') return 100
+  if (props.status === 'paying') return 100
+  if (props.stage === 'quoting') return stagePct()
+  return 0
 })
+
+/** Storage segment fill — 0..100 of the storage phase only. */
+const storeBarPct = computed(() => {
+  if (props.status === 'complete') return 100
+  if (props.stage === 'uploading') return stagePct()
+  return 0
+})
+
+/** Payment dot — empty until storage starts, pulses during the external-
+ *  signer wallet popup, goes solid once chunks are being stored. Wallet-flow
+ *  direct-key never enters `paying` (Rust drives payment internally), so
+ *  the dot just flips empty → solid when stage transitions to 'uploading'. */
+const dotState = computed<'empty' | 'pulse' | 'solid'>(() => {
+  if (props.status === 'paying') return 'pulse'
+  if (props.stage === 'uploading' || props.status === 'complete') return 'solid'
+  return 'empty'
+})
+
+const overallPercent = computed(() => clamp(props.percent ?? 0))
 </script>

--- a/components/StatusBadge.vue
+++ b/components/StatusBadge.vue
@@ -1,7 +1,9 @@
 <template>
-  <span class="inline-flex items-center gap-1 text-xs font-medium" :class="colorClass" role="status">
-    <span aria-hidden="true">{{ dot }}</span>
-    <span>{{ label }}</span>
+  <!-- max-w-xs + truncate keeps long failure messages from blowing the table
+       width out; the full text remains readable via the title tooltip. -->
+  <span class="inline-flex max-w-xs items-center gap-1 align-middle text-xs font-medium" :class="colorClass" role="status" :title="label">
+    <span aria-hidden="true" class="shrink-0">{{ dot }}</span>
+    <span class="truncate">{{ label }}</span>
   </span>
 </template>
 

--- a/components/StatusBadge.vue
+++ b/components/StatusBadge.vue
@@ -1,9 +1,16 @@
 <template>
-  <!-- max-w-xs + truncate keeps long failure messages from blowing the table
-       width out; the full text remains readable via the title tooltip. -->
-  <span class="inline-flex max-w-xs items-center gap-1 align-middle text-xs font-medium" :class="colorClass" role="status" :title="label">
+  <!-- Non-error labels render at their natural width (whitespace-nowrap so
+       they never break to two lines). Error labels — which can be a wall of
+       viem stacktrace — keep `max-w-xs truncate` so they don't blow out the
+       table. The full error text is always available via the title tooltip. -->
+  <span
+    class="inline-flex items-center gap-1 align-middle text-xs font-medium"
+    :class="[colorClass, isError ? 'max-w-xs' : 'whitespace-nowrap']"
+    role="status"
+    :title="label"
+  >
     <span aria-hidden="true" class="shrink-0">{{ dot }}</span>
-    <span class="truncate">{{ label }}</span>
+    <span :class="isError ? 'truncate' : ''">{{ label }}</span>
   </span>
 </template>
 
@@ -22,6 +29,8 @@ const statusMap: Record<string, { dot: string; label: string; color: string }> =
   // File transfer statuses
   Pending: { dot: '○', label: 'Pending', color: 'text-autonomi-muted' },
   Quoting: { dot: '◐', label: 'Quoting', color: 'text-autonomi-warning' },
+  'Encrypting…': { dot: '◐', label: 'Encrypting…', color: 'text-autonomi-warning' },
+  'Resolving datamap': { dot: '◐', label: 'Resolving datamap', color: 'text-autonomi-warning' },
   'Queued: quoting': { dot: '○', label: 'Queued: quoting', color: 'text-autonomi-muted' },
   'Queued: uploading': { dot: '○', label: 'Queued: uploading', color: 'text-autonomi-muted' },
   'Connecting to network…': { dot: '◐', label: 'Connecting to network…', color: 'text-autonomi-warning' },
@@ -40,18 +49,21 @@ const statusMap: Record<string, { dot: string; label: string; color: string }> =
 const entry = computed(() => {
   // Handle percentage statuses like "Uploading 45%" or "Downloading 80%"
   if (props.status.includes('%')) {
-    return { dot: '◐', label: props.status, color: 'text-autonomi-blue' }
+    return { dot: '◐', label: props.status, color: 'text-autonomi-blue', error: false }
   }
   if (props.status.startsWith('Failed') || props.status.startsWith('ERR')) {
-    return { dot: '✖', label: props.status, color: 'text-autonomi-error' }
+    return { dot: '✖', label: props.status, color: 'text-autonomi-error', error: true }
   }
   if (props.status.startsWith('Quote:')) {
-    return { dot: '●', label: props.status, color: 'text-autonomi-blue' }
+    return { dot: '●', label: props.status, color: 'text-autonomi-blue', error: false }
   }
-  return statusMap[props.status] ?? { dot: '?', label: props.status, color: 'text-autonomi-muted' }
+  const mapped = statusMap[props.status]
+  if (mapped) return { ...mapped, error: false }
+  return { dot: '?', label: props.status, color: 'text-autonomi-muted', error: false }
 })
 
 const dot = computed(() => entry.value.dot)
 const label = computed(() => entry.value.label)
 const colorClass = computed(() => entry.value.color)
+const isError = computed(() => entry.value.error)
 </script>

--- a/components/StatusBadge.vue
+++ b/components/StatusBadge.vue
@@ -38,7 +38,7 @@ const statusMap: Record<string, { dot: string; label: string; color: string }> =
   'Saving datamap…': { dot: '◐', label: 'Saving datamap…', color: 'text-autonomi-warning' },
   'Network unavailable': { dot: '✖', label: 'Network unavailable', color: 'text-autonomi-error' },
   'Ready to approve': { dot: '●', label: 'Ready to approve', color: 'text-autonomi-blue' },
-  Paying: { dot: '◐', label: 'Paying', color: 'text-autonomi-warning' },
+  'Awaiting approval': { dot: '◐', label: 'Awaiting approval', color: 'text-autonomi-warning' },
   Uploading: { dot: '●', label: 'Uploading', color: 'text-autonomi-blue' },
   Downloading: { dot: '●', label: 'Downloading', color: 'text-autonomi-blue' },
   Complete: { dot: '●', label: 'Done', color: 'text-autonomi-success' },

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -87,10 +87,10 @@
                 <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('name')">
                   Name {{ uploadSortIndicator('name') }}
                 </th>
+                <th class="px-4 py-2.5">Status</th>
                 <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('size_bytes')">
                   Size {{ uploadSortIndicator('size_bytes') }}
                 </th>
-                <th class="px-4 py-2.5">Status</th>
                 <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('cost')">
                   Cost {{ uploadSortIndicator('cost') }}
                 </th>
@@ -108,12 +108,25 @@
                 :class="rowClass(file)"
                 @click="onRowClick(file)"
               >
-                <td class="px-4 py-2.5">{{ file.name }}</td>
-                <td class="px-4 py-2.5 text-autonomi-muted">{{ file.size_bytes ? formatBytes(file.size_bytes) : '-' }}</td>
                 <td class="px-4 py-2.5">
-                  <StatusBadge :status="statusLabel(file)" />
-                  <ProgressLine v-if="showsProgressBar(file)" :detail="stageDetail(file)" :percent="file.progress" />
+                  <div>{{ file.name }}</div>
+                  <ProgressLine
+                    v-if="showsProgressBar(file)"
+                    :percent="file.progress"
+                    :kind="file.kind"
+                    :status="file.status"
+                    :stage="file.stage"
+                    :stage-done="file.stageDone"
+                    :stage-total="file.stageTotal"
+                  />
                 </td>
+                <td class="px-4 py-2.5 align-top">
+                  <div><StatusBadge :status="statusLabel(file)" /></div>
+                  <div v-if="showsProgressBar(file) && stageDetail(file)" class="mt-1 text-[10px] leading-tight text-autonomi-muted">
+                    {{ stageDetail(file) }}
+                  </div>
+                </td>
+                <td class="px-4 py-2.5 text-autonomi-muted">{{ file.size_bytes ? formatBytes(file.size_bytes) : '-' }}</td>
                 <td class="px-4 py-2.5 text-autonomi-muted">
                   <template v-if="file.alreadyStored">
                     <span class="text-green-400">Free — already stored</span>
@@ -177,10 +190,10 @@
               <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleDownloadSort('name')">
                 Name {{ downloadSortIndicator('name') }}
               </th>
+              <th class="px-4 py-2.5">Status</th>
               <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleDownloadSort('size_bytes')">
                 Size {{ downloadSortIndicator('size_bytes') }}
               </th>
-              <th class="px-4 py-2.5">Status</th>
               <th class="px-4 py-2.5">Saved to</th>
               <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleDownloadSort('date')">
                 Date {{ downloadSortIndicator('date') }}
@@ -195,12 +208,25 @@
               :class="rowClass(file)"
               @click="onRowClick(file)"
             >
-              <td class="px-4 py-2.5">{{ file.name }}</td>
-              <td class="px-4 py-2.5 text-autonomi-muted">{{ file.size_bytes ? formatBytes(file.size_bytes) : '-' }}</td>
               <td class="px-4 py-2.5">
-                <StatusBadge :status="statusLabel(file)" />
-                <ProgressLine v-if="showsProgressBar(file)" :detail="stageDetail(file)" :percent="file.progress" />
+                <div>{{ file.name }}</div>
+                <ProgressLine
+                  v-if="showsProgressBar(file)"
+                  :percent="file.progress"
+                  :kind="file.kind"
+                  :status="file.status"
+                  :stage="file.stage"
+                  :stage-done="file.stageDone"
+                  :stage-total="file.stageTotal"
+                />
               </td>
+              <td class="px-4 py-2.5 align-top">
+                <div><StatusBadge :status="statusLabel(file)" /></div>
+                <div v-if="showsProgressBar(file) && stageDetail(file)" class="mt-1 text-[10px] leading-tight text-autonomi-muted">
+                  {{ stageDetail(file) }}
+                </div>
+              </td>
+              <td class="px-4 py-2.5 text-autonomi-muted">{{ file.size_bytes ? formatBytes(file.size_bytes) : '-' }}</td>
               <td class="px-4 py-2.5 font-mono text-xs text-autonomi-muted">
                 {{ file.dest_path ? basenameOf(file.dest_path) : '-' }}
               </td>
@@ -388,8 +414,22 @@ function statusLabel(file: FileEntry): string {
     return 'Saving datamap…'
   }
 
-  if (file.status === 'uploading') return 'Uploading'
-  if (file.status === 'downloading') return 'Downloading'
+  if (file.status === 'uploading') {
+    // Wallet-flow direct-key uploads pre-set status='uploading' before the
+    // Rust side has gone through encrypt/quote, so the badge would say
+    // "Uploading" while the sub-text counts up "Quoting 0..100%". Defer
+    // to the actual stage when it disagrees with the outer status.
+    if (file.stage === 'encrypting') return 'Encrypting…'
+    if (file.stage === 'quoting') return 'Quoting'
+    return 'Uploading'
+  }
+  if (file.status === 'downloading') {
+    // Same logic for downloads — datamap resolution can run a few seconds
+    // before chunk fetching starts, and the user shouldn't see "Downloading"
+    // while we're still pulling the datamap apart.
+    if (file.stage === 'resolving') return 'Resolving datamap'
+    return 'Downloading'
+  }
   if (file.status === 'downloaded') return 'Downloaded'
   if (file.status === 'failed') return file.error ? `Failed: ${file.error}` : 'Failed'
   if (file.status === 'complete') return 'Complete'

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -37,13 +37,10 @@
     <section class="mb-6">
       <div class="mb-2 flex items-center justify-between">
         <h2 class="text-sm font-medium text-autonomi-text">Uploads</h2>
-        <button
-          v-if="hasSettledUploads"
-          class="text-xs text-autonomi-muted hover:text-autonomi-text"
-          @click="filesStore.clearUploadHistory()"
-        >
-          Clear History
-        </button>
+        <!-- Bulk "Clear history" lives in Settings → Storage now (V2-232).
+             Per-row × on hover handles the common case of trimming a single
+             failed/complete entry; bulk wipe is gated behind a confirmation
+             dialog over there to prevent accidental data loss. -->
       </div>
 
       <div class="relative">
@@ -98,13 +95,14 @@
                 <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('date')">
                   Date {{ uploadSortIndicator('date') }}
                 </th>
+                <th class="w-px px-2 py-2.5"><span class="sr-only">Actions</span></th>
               </tr>
             </thead>
             <tbody class="divide-y divide-autonomi-border">
               <tr
                 v-for="file in sortedUploads"
                 :key="file.id"
-                class="transition-colors"
+                class="group transition-colors"
                 :class="rowClass(file)"
                 @click="onRowClick(file)"
               >
@@ -155,6 +153,25 @@
                   <span v-else class="text-autonomi-muted">-</span>
                 </td>
                 <td class="px-4 py-2.5 text-autonomi-muted">{{ formatDate(file.date) }}</td>
+                <td class="px-2 py-2.5 text-right whitespace-nowrap">
+                  <span v-if="isSettled(file)" class="inline-flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                    <button
+                      v-if="canRetry(file)"
+                      class="rounded px-1.5 py-0.5 text-[11px] text-autonomi-muted hover:bg-autonomi-surface hover:text-autonomi-blue"
+                      title="Retry upload"
+                      @click.stop="onRetry(file)"
+                    >
+                      ↻ Retry
+                    </button>
+                    <button
+                      class="rounded px-1.5 py-0.5 text-[11px] text-autonomi-muted hover:bg-autonomi-surface hover:text-autonomi-error"
+                      title="Remove from list"
+                      @click.stop="onRemove(file)"
+                    >
+                      ✕
+                    </button>
+                  </span>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -198,13 +215,14 @@
               <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleDownloadSort('date')">
                 Date {{ downloadSortIndicator('date') }}
               </th>
+              <th class="w-px px-2 py-2.5"><span class="sr-only">Actions</span></th>
             </tr>
           </thead>
           <tbody class="divide-y divide-autonomi-border">
             <tr
               v-for="file in sortedDownloads"
               :key="file.id"
-              class="transition-colors"
+              class="group transition-colors"
               :class="rowClass(file)"
               @click="onRowClick(file)"
             >
@@ -231,6 +249,17 @@
                 {{ file.dest_path ? basenameOf(file.dest_path) : '-' }}
               </td>
               <td class="px-4 py-2.5 text-autonomi-muted">{{ formatDate(file.date) }}</td>
+              <td class="px-2 py-2.5 text-right whitespace-nowrap">
+                <span v-if="isSettled(file)" class="inline-flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                  <button
+                    class="rounded px-1.5 py-0.5 text-[11px] text-autonomi-muted hover:bg-autonomi-surface hover:text-autonomi-error"
+                    title="Remove from list"
+                    @click.stop="onRemove(file)"
+                  >
+                    ✕
+                  </button>
+                </span>
+              </td>
             </tr>
           </tbody>
         </table>
@@ -388,10 +417,6 @@ const sortedDownloads = computed(() => {
   return [...pinned, ...settled]
 })
 
-const hasSettledUploads = computed(() =>
-  filesStore.settledUploads.some(f => f.status === 'complete' || f.status === 'failed'),
-)
-
 const hasSettledDownloads = computed(() =>
   filesStore.settledDownloads.some(f => f.status !== 'downloading'),
 )
@@ -441,7 +466,10 @@ function statusLabel(file: FileEntry): string {
     return 'Obtaining quote…'
   }
   if (file.status === 'awaiting_approval') return 'Ready to approve'
-  if (file.status === 'paying') return 'Paying'
+  // `paying` is only reachable from the external-signer flow (wallet-flow
+  // direct-key never enters this state — Rust drives payment internally),
+  // so we can label it for that context unconditionally.
+  if (file.status === 'paying') return 'Awaiting approval'
   return file.status
 }
 
@@ -490,6 +518,27 @@ function showsProgressBar(file: FileEntry): boolean {
     || file.status === 'uploading'
     || file.status === 'downloading'
   )
+}
+
+/** Settled = not currently transferring or queued. Per-row Remove and (for
+ *  failed uploads) Retry are gated on this — we don't want a row to vanish
+ *  mid-store. */
+function isSettled(file: FileEntry): boolean {
+  return file.status === 'failed' || file.status === 'complete' || file.status === 'downloaded'
+}
+
+/** Retry only applies to failed uploads — failed downloads need a different
+ *  re-fetch path that's not in scope for this iteration. */
+function canRetry(file: FileEntry): boolean {
+  return file.kind === 'upload' && file.status === 'failed' && !!file.path
+}
+
+function onRetry(file: FileEntry) {
+  filesStore.retryUpload(file.id)
+}
+
+function onRemove(file: FileEntry) {
+  filesStore.removeEntry(file.id)
 }
 
 function isReopenable(file: FileEntry): boolean {

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -433,11 +433,23 @@ function stageDetail(file: FileEntry): string | null {
   }
 }
 
-/** Whether the row should render a progress bar. Bar is shown for any active
- *  transfer state — even when percent is null (encryption phase) we render
- *  an indeterminate bar so the user sees motion. */
+/** Whether the row should render a progress bar. Shown for every active
+ *  transfer state where progress events are flowing or could flow:
+ *
+ *  - `quoting`     — start_upload emits Encrypting/Encrypted/ChunkQuoted (0..50%)
+ *  - `paying`      — bar freezes at 50% while the wallet popup is open
+ *  - `uploading`   — confirm_upload emits ChunkStored (50..100%)
+ *  - `downloading` — file_download emits ChunksFetched (0..100%)
+ *
+ *  Even when `percent` is null (encryption, before total chunks are known)
+ *  we render an indeterminate bar so the user sees motion. */
 function showsProgressBar(file: FileEntry): boolean {
-  return file.status === 'uploading' || file.status === 'downloading'
+  return (
+    file.status === 'quoting'
+    || file.status === 'paying'
+    || file.status === 'uploading'
+    || file.status === 'downloading'
+  )
 }
 
 function isReopenable(file: FileEntry): boolean {

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -378,6 +378,27 @@
       </div>
     </div>
 
+    <!-- Upload history (V2-232) — bulk clear lives here so it's not a
+         single click away on the Files page. Per-row × on hover handles
+         the common single-row case. -->
+    <div class="flex items-center justify-between rounded-lg border border-autonomi-border p-4">
+      <div class="min-w-0 flex-1">
+        <h3 class="text-sm font-medium">Upload history</h3>
+        <p class="mt-0.5 text-xs text-autonomi-muted">
+          {{ settledUploadCount }} settled
+          {{ settledUploadCount === 1 ? 'entry' : 'entries' }} in
+          <span class="font-mono">upload_history.json</span>. DataMaps on disk and chunks on the network are untouched.
+        </p>
+      </div>
+      <button
+        :disabled="settledUploadCount === 0"
+        class="shrink-0 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted hover:text-autonomi-error disabled:opacity-50 disabled:hover:text-autonomi-muted"
+        @click="confirmClearUploadHistory"
+      >
+        Clear history
+      </button>
+    </div>
+
     <!-- Software -->
     <div class="rounded-lg border border-autonomi-border p-4">
       <div class="flex items-start justify-between gap-3">
@@ -433,6 +454,7 @@ import { isValidEthAddress } from '~/utils/validators'
 import { useToastStore } from '~/stores/toasts'
 import { useErrorLogStore } from '~/stores/errorlog'
 import { useUpdaterStore } from '~/stores/updater'
+import { useFilesStore } from '~/stores/files'
 
 const settingsStore = useSettingsStore()
 const walletStore = useWalletStore()
@@ -440,9 +462,30 @@ const nodesStore = useNodesStore()
 const toasts = useToastStore()
 const errorLogStore = useErrorLogStore()
 const updaterStore = useUpdaterStore()
+const filesStore = useFilesStore()
 const showAdvanced = ref(false)
 const showLog = ref(false)
 const appVersion = ref('0.1.0')
+
+/** Number of settled (complete/failed) upload rows we'd wipe if Clear is
+ *  pressed. Mid-transfer rows survive — clearUploadHistory's filter only
+ *  drops complete + failed entries. */
+const settledUploadCount = computed(() =>
+  filesStore.settledUploads.filter(f => f.status === 'complete' || f.status === 'failed').length,
+)
+
+async function confirmClearUploadHistory() {
+  if (settledUploadCount.value === 0) return
+  // Native window.confirm is enough here — the sheet is already a settings
+  // page surface and the action is reversible only via OS-level file
+  // restoration on `upload_history.json`.
+  const ok = window.confirm(
+    `Clear ${settledUploadCount.value} upload ${settledUploadCount.value === 1 ? 'entry' : 'entries'} from history?\n\nThis removes the local row + persisted record. The DataMaps on disk and the chunks on the network are unaffected.`,
+  )
+  if (!ok) return
+  filesStore.clearUploadHistory()
+  toasts.add('Upload history cleared', 'info')
+}
 
 // Re-compute "Last checked X ago" every 30s so the label stays fresh while
 // the settings page is visible, without paying for a global ticker.

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -571,8 +571,7 @@ pub async fn start_upload(
     // Phase 1: Encrypt file and prepare chunks (gets quotes from network).
     // The forwarder turns ant-core's UploadEvent stream (Encrypting / Encrypted /
     // ChunkQuoted) into Tauri `upload-progress` events keyed by the row id.
-    let progress_tx =
-        spawn_upload_progress_forwarder(app.clone(), request.upload_id.clone());
+    let progress_tx = spawn_upload_progress_forwarder(app.clone(), request.upload_id.clone());
     let prepared = client
         .file_prepare_upload_with_progress(
             &path,

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -568,9 +568,17 @@ pub async fn start_upload(
     }
     let path = canonical;
 
-    // Phase 1: Encrypt file and prepare chunks (gets quotes from network)
+    // Phase 1: Encrypt file and prepare chunks (gets quotes from network).
+    // The forwarder turns ant-core's UploadEvent stream (Encrypting / Encrypted /
+    // ChunkQuoted) into Tauri `upload-progress` events keyed by the row id.
+    let progress_tx =
+        spawn_upload_progress_forwarder(app.clone(), request.upload_id.clone());
     let prepared = client
-        .file_prepare_upload(&path)
+        .file_prepare_upload_with_progress(
+            &path,
+            ant_core::data::Visibility::Private,
+            Some(progress_tx),
+        )
         .await
         .map_err(|e| format!("Failed to prepare upload: {e}"))?;
 
@@ -751,9 +759,12 @@ pub async fn confirm_upload(
         ));
     }
 
-    // Phase 2: Finalize upload with tx hashes and store chunks
+    // Phase 2: Finalize upload with tx hashes and store chunks.
+    // The forwarder emits ChunkStored events as each chunk is stored on the
+    // network so the row's bar climbs from 50% to 100%.
+    let progress_tx = spawn_upload_progress_forwarder(app.clone(), upload_id.clone());
     let result = client
-        .finalize_upload(prepared, &tx_hash_map)
+        .finalize_upload_with_progress(prepared, &tx_hash_map, Some(progress_tx))
         .await
         .map_err(|e| format!("Upload failed: {e}"))?;
 
@@ -813,8 +824,9 @@ pub async fn confirm_upload_merkle(
         .try_into()
         .map_err(|_| "Winner pool hash must be exactly 32 bytes".to_string())?;
 
+    let progress_tx = spawn_upload_progress_forwarder(app.clone(), upload_id.clone());
     let result = client
-        .finalize_upload_merkle(prepared, hash_bytes)
+        .finalize_upload_merkle_with_progress(prepared, hash_bytes, Some(progress_tx))
         .await
         .map_err(|e| format!("Merkle upload failed: {e}"))?;
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -56,6 +56,11 @@ pub struct UploadHistoryEntry {
     /// persistence existed.
     #[serde(default)]
     pub data_map_file: Option<String>,
+    /// Pre-formatted ETH gas cost for the upload's payment tx(s). `None` for
+    /// legacy entries written before gas was tracked, or for already-stored
+    /// uploads where no payment tx ran.
+    #[serde(default)]
+    pub gas_cost: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -327,6 +327,33 @@ export const useFilesStore = defineStore('files', {
       if (wasUpload) this.persistHistory()
     },
 
+    /** Reset a failed upload row so the scheduler picks it up for another go.
+     *  Reuses `entry.path` so the user doesn't need to re-pick the file from
+     *  disk, and clears stale per-attempt fields (error, progress, stage,
+     *  address/datamap, costs). Status flips to `queued_for_upload` so the
+     *  page scheduler re-runs `startRealUpload` and gets a fresh quote. */
+    retryUpload(id: number) {
+      const entry = this.files.find(f => f.id === id)
+      if (!entry || entry.kind !== 'upload' || entry.status !== 'failed') return
+      if (!entry.path) return
+      this.updateEntry(id, {
+        status: 'queued_for_upload',
+        error: undefined,
+        progress: undefined,
+        stage: undefined,
+        stageDone: undefined,
+        stageTotal: undefined,
+        address: undefined,
+        data_map_json: undefined,
+        data_map_file: undefined,
+        cost: undefined,
+        gas_cost: undefined,
+        alreadyStored: undefined,
+        duration: undefined,
+        transferStartedAt: Date.now(),
+      })
+    },
+
     /** Remove every upload row in a settled state. Persists. */
     clearUploadHistory() {
       this.files = this.files.filter(f =>

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -152,6 +152,10 @@ export interface UploadHistoryEntry {
   /** Absolute path to the persisted DataMap file; `null`/absent for legacy
    *  entries written before datamap persistence was added. */
   data_map_file?: string | null
+  /** ETH gas cost (formatted string). `null`/absent for legacy entries
+   *  written before gas was tracked, or for already-stored uploads where
+   *  no payment tx ran. */
+  gas_cost?: string | null
 }
 
 export const useFilesStore = defineStore('files', {
@@ -238,6 +242,7 @@ export const useFilesStore = defineStore('files', {
             size_bytes: e.size_bytes,
             address: e.address,
             cost: e.cost ?? undefined,
+            gas_cost: e.gas_cost ?? undefined,
             data_map_file: e.data_map_file ?? undefined,
             status: 'complete',
             date: e.uploaded_at,
@@ -262,6 +267,7 @@ export const useFilesStore = defineStore('files', {
           cost: f.cost ?? null,
           uploaded_at: f.date,
           data_map_file: f.data_map_file ?? null,
+          gas_cost: f.gas_cost ?? null,
         }))
 
       try {

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -162,6 +162,11 @@ export const useFilesStore = defineStore('files', {
     /** True once the Rust progress event listeners have been wired up.
      *  Idempotent — safe to call setupProgressListeners() multiple times. */
     _progressListenersStarted: false,
+    /** Maps a Rust-side transfer_id (string) to its FileEntry row id (number).
+     *  The wallet/download paths use `String(id)` so the listener falls through
+     *  to a numeric parse; the external-signer path uses an opaque `quote-…`
+     *  id assigned by `getUploadQuote`, which we register here. */
+    _transferIdToRowId: {} as Record<string, number>,
   }),
 
   getters: {
@@ -277,7 +282,11 @@ export const useFilesStore = defineStore('files', {
       this._progressListenersStarted = true
 
       const apply = (payload: ProgressEventPayload) => {
-        const id = Number(payload.transfer_id)
+        // External-signer flow registers a string→row mapping; wallet/download
+        // flows just stringify the row id. Try the map first, fall back to a
+        // numeric parse.
+        const mapped = this._transferIdToRowId[payload.transfer_id]
+        const id = mapped ?? Number(payload.transfer_id)
         if (!Number.isFinite(id)) return
         // The transfer may have already settled (failed / completed) by the
         // time a tail-end event arrives; updateEntry no-ops on missing ids.
@@ -429,8 +438,17 @@ export const useFilesStore = defineStore('files', {
      *  daemon. Used internally by `startRealUpload` after the user clicks
      *  Confirm — not for display. For pre-upload cost display, use
      *  `estimateFileCost` instead. */
-    async getUploadQuote(path: string): Promise<UploadQuote | null> {
+    async getUploadQuote(path: string, transferRowId?: number): Promise<UploadQuote | null> {
       const uploadId = `quote-${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+      // If the caller has a row to drive a progress bar on, register the
+      // transfer_id → row mapping NOW (before invoke). The Rust side starts
+      // emitting upload-progress events as soon as encryption begins; if we
+      // registered after `start_upload` returns we'd lose the entire quote
+      // phase (0–50%).
+      if (transferRowId !== undefined) {
+        this._transferIdToRowId[uploadId] = transferRowId
+      }
 
       // Deferred so the listener can resolve independently of where the
       // Promise is awaited.
@@ -552,11 +570,18 @@ export const useFilesStore = defineStore('files', {
           // there is a single implementation of the listen+invoke dance.
           if (!entry.path) throw new Error('Upload entry has no file path')
           this.updateEntry(id, { status: 'quoting' })
-          const fresh = await this.getUploadQuote(entry.path)
+          const fresh = await this.getUploadQuote(entry.path, id)
           if (!fresh) throw new Error('Failed to get quote from network')
           uploadId = fresh.upload_id
           quote = fresh
           this.updateEntry(id, { cost: quote.total_cost_display })
+        }
+
+        // For the dialog flow (preQuote already in hand) the mapping wasn't
+        // registered during the dialog's getUploadQuote call. Register it
+        // here so confirm_upload's storage events route to the right row.
+        if (preQuote) {
+          this._transferIdToRowId[uploadId] = id
         }
 
         this.updateEntry(id, { status: 'paying' })

--- a/utils/payment.ts
+++ b/utils/payment.ts
@@ -1,4 +1,4 @@
-import { readContract, writeContract, waitForTransactionReceipt, getAccount } from '@wagmi/core'
+import { readContract, writeContract, waitForTransactionReceipt, getAccount, switchChain } from '@wagmi/core'
 import { getTokenAddress, getVaultAddress, getActiveChainId } from '~/utils/wallet-config'
 import paymentVaultAbi from '~/assets/abi/IPaymentVault.json'
 import paymentTokenAbi from '~/assets/abi/PaymentToken.json'
@@ -57,6 +57,21 @@ function getSignerAccount(wagmiConfig: any): `0x${string}` {
 }
 
 /**
+ * Make sure the connected wallet is on the chain we're about to write to.
+ * If not, request a switch — wagmi turns this into a `wallet_switchEthereumChain`
+ * request which prompts the user in the wallet (extension popup or
+ * WalletConnect mobile push). For the direct-key (devnet wallet import)
+ * path we skip — that wallet always sits on the manifest's chain.
+ */
+async function ensureActiveChain(wagmiConfig: any): Promise<void> {
+  if (getDevnetAccount?.()) return
+  const target = getActiveChainId()
+  const account = getAccount(wagmiConfig)
+  if (account.chainId === target) return
+  await switchChain(wagmiConfig, { chainId: target })
+}
+
+/**
  * Build the account option for writeContract.
  */
 function accountOpt(): { account: any } | {} {
@@ -75,6 +90,8 @@ export async function payForQuotes(
   if (payments.length === 0) {
     return { txHashMap: {}, totalPaid: 0n, gasSpent: 0n }
   }
+
+  await ensureActiveChain(wagmiConfig)
 
   const totalAmount = payments.reduce(
     (sum, [, , amount]) => sum + BigInt(amount),
@@ -99,6 +116,14 @@ export async function payForQuotes(
       functionName: 'payForQuotes',
       args: [input],
       chainId: getActiveChainId(),
+      // V2-231: override both EIP-1559 fees explicitly. viem only
+      // auto-estimates the side that's missing, so passing only one
+      // produces an invalid pair (maxFee=baseFee < maxPriority).
+      // Arbitrum base fees are ~0.02 gwei; 1 gwei cap = ~50× headroom;
+      // 0.1 gwei tip is performative (Arbitrum sequencer doesn't
+      // tip-prioritize). Ceiling cost: ~1 gwei × ~150k gas ≈ 0.00015 ETH.
+      maxFeePerGas: 1_000_000_000n,
+      maxPriorityFeePerGas: 100_000_000n,
       ...accountOpt(),
     })
 
@@ -127,6 +152,8 @@ export async function payForMerkleTree(
   poolCommitments: SerializedPoolCommitment[],
   merkleTimestamp: bigint,
 ): Promise<MerklePaymentResult> {
+  await ensureActiveChain(wagmiConfig)
+
   const commitments = poolCommitments.map(pc => ({
     poolHash: pc.pool_hash as `0x${string}`,
     candidates: pc.candidates.map(c => ({
@@ -148,6 +175,9 @@ export async function payForMerkleTree(
     functionName: 'payForMerkleTree',
     args: [depth, commitments, merkleTimestamp],
     chainId: getActiveChainId(),
+    // V2-231: override BOTH fees so EIP-1559's maxFee >= maxPriority holds.
+    maxFeePerGas: 1_000_000_000n,
+    maxPriorityFeePerGas: 100_000_000n,
     ...accountOpt(),
   })
 
@@ -205,6 +235,9 @@ async function ensureAllowance(wagmiConfig: any, needed: bigint): Promise<bigint
     functionName: 'approve',
     args: [getVaultAddress(), needed],
     chainId: getActiveChainId(),
+    // V2-231: override BOTH fees so EIP-1559's maxFee >= maxPriority holds.
+    maxFeePerGas: 1_000_000_000n,
+    maxPriorityFeePerGas: 100_000_000n,
     ...accountOpt(),
   })
 


### PR DESCRIPTION
## Summary

- Wires the WalletConnect / external-signer flow into the same `upload-progress` Tauri-event pipeline #65 introduced for the wallet-flow + downloads. `start_upload` / `confirm_upload` / `confirm_upload_merkle` all spawn `spawn_upload_progress_forwarder` and pass it into ant-core's `_with_progress` methods (now in `ant-core-v0.2.2`).
- Closes the listener-routing gap for opaque `quote-...` transfer ids by introducing a `_transferIdToRowId` map in the files store, populated *before* `start_upload` is invoked so quote-phase events route from the very first event.
- Picks up two wallet bugs that surfaced during Sepolia testing: chain auto-switch and a corrected EIP-1559 fee config.
- A few UX polish items (`showsProgressBar` widening, per-stage percent in label, status badge truncation).

## What changed

**Rust** (`src-tauri/src/autonomi_ops.rs`)

```
start_upload          → file_prepare_upload_with_progress(path, Visibility::Private, Some(tx))
confirm_upload        → finalize_upload_with_progress(prepared, &tx_hash_map, Some(tx))
confirm_upload_merkle → finalize_upload_merkle_with_progress(prepared, hash, Some(tx))
```

All three spawn `spawn_upload_progress_forwarder(app, upload_id)` (already on main from #65) so events route via the same Tauri `upload-progress` channel.

**Frontend**

- `stores/files.ts` — `_transferIdToRowId: Record<string, number>` populated by `getUploadQuote(path, transferRowId?)` *before* `invoke('start_upload')`. Listener falls back to `Number(transfer_id)` so the wallet/download paths (which stringify the row id) keep working unchanged.
- `pages/files.vue` — `showsProgressBar()` now returns true for `quoting` / `paying` too. `stageDetail()` returns a per-stage percent ("Storing · 67%") instead of a fraction.
- `components/StatusBadge.vue` — `max-w-xs truncate` + `title` so long error messages don't widen the table.

**utils/payment.ts**

- `ensureActiveChain(wagmiConfig)` calls `switchChain` before each `writeContract` if the wallet's current `chainId` doesn't match `getActiveChainId()`. This is the same chain-mismatch issue reported against the 0.6.7 release ("current chain id 1 does not match target chain id 42161 - Arbitrum One") — surfaces whenever MetaMask is sitting on a different chain than the manifest expects.
- All three `writeContract` sites now pass **both** `maxFeePerGas: 1_000_000_000n` and `maxPriorityFeePerGas: 100_000_000n`. An earlier fix that set only the priority fee tripped EIP-1559's `maxFee >= maxPriority` invariant on Arbitrum's tiny base fees and surfaced as a generic "User rejected the request" wrapper.

## Test plan

- [x] `cargo check --all-targets` clean against `ant-core-v0.2.2` (just-merged via #67)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] End-to-end Sepolia upload (devnet-sepolia rig + MetaMask Mobile via WalletConnect, funded test wallet). 9-chunk file completes cleanly; bar climbs 0→50% during quoting, then 50→100% during storage; row settles to Complete.
- [ ] Reviewer: confirm the bar UX feels right under your network conditions