### PR TITLE
chore(deps): bump ant-core 0.2.0 -> 0.2.2

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -804,8 +804,8 @@ dependencies = [
 
 [[package]]
 name = "ant-core"
-version = "0.2.0"
-source = "git+https://github.com/WithAutonomi/ant-client?tag=ant-core-v0.2.0#0d789c899888f009913751831b7ab127a57ee640"
+version = "0.2.2"
+source = "git+https://github.com/WithAutonomi/ant-client?tag=ant-core-v0.2.2#8b2c9c606a1223f105fed9aa2b56310b6a6763da"
 dependencies = [
  "ant-protocol",
  "async-stream",
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe630f23f4adae05beba7e2c0861ab9c1a6d2cc88c98898e3742bed3a5a4ce35"
+checksum = "4602614e5dc5af433bf2b12678016eb955b4981b04c0667e61d1ee85b19aacc8"
 dependencies = [
  "blake3",
  "bytes",
@@ -6574,9 +6574,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed544b4fb88a5615649893ee2d1394e0f48633f63dc72700e51f6b133fdfc1c"
+checksum = "9966410bc0996de6a2e8adbc4d0919a0f18f8e5c3655aaf00cc1bed28720d82f"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ toml = "0.8"
 tauri-plugin-updater = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-ant-core = { git = "https://github.com/WithAutonomi/ant-client", tag = "ant-core-v0.2.0" }
+ant-core = { git = "https://github.com/WithAutonomi/ant-client", tag = "ant-core-v0.2.2" }
 evmlib = "0.8"
 hex = "0.4"
 sha2 = "0.10"


### PR DESCRIPTION
## Summary

Bumps the `ant-core` library crate pin to `ant-core-v0.2.2` — the tag at the same SHA as today's `ant-cli-v0.2.1` release. Two-line change in `Cargo.toml`/`Cargo.lock`.

## What's now reachable

This bump unblocks downstream work in this repo:

| Upstream PR | What it adds | Downstream consumer |
|---|---|---|
| WithAutonomi/ant-client#68 | external-signer progress events through prepare/finalize | ant-ui #66 (currently draft, pinned to a temporary branch) |
| WithAutonomi/ant-client#39 | `Visibility` arg on `file_prepare_upload`, `data_map_address` on `FileUploadResult` | ant-ui #32 (currently draft) |
| WithAutonomi/ant-client#31 | shared devnet-manifest write-side | already merged as ant-ui #9 (read-side companion) |
| (internal) | new `ant_core::datamap_file` module — msgpack canonical + JSON legacy auto-detect, the canonical helper for datamap I/O | available for future datamap rework |

## Transitive bumps

Picked up automatically via the lockfile:
- `ant-protocol` 2.0.1 → 2.0.2
- `saorsa-core` 0.24.0 → 0.24.1

## Test plan

- [x] `cargo check --all-targets` — clean, 36s
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `npx vitest run` — 21/21 pass
- [ ] Reviewer to spot-check that the Cargo.lock churn matches the table above (no surprise transitives)

## Notes

- No `ant-gui` version bump in this PR — that's a separate release-prep concern.
- After this lands, ant-ui #66 should be rebased to drop its temporary branch pin and exit draft, and #32 should be rebased + smoked against the new symbols (`Visibility`, `file_prepare_upload_with_visibility`, `FileUploadResult.data_map_address`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)