### PR TITLE
feat(updater): pre-release channel opt-in toggle

### DIFF
--- a/components/UpdateDialog.vue
+++ b/components/UpdateDialog.vue
@@ -15,8 +15,14 @@
         <h2 id="update-dialog-title" class="text-lg font-medium">
           Update Available
         </h2>
-        <p class="mt-1 text-sm text-autonomi-muted">
-          v{{ updaterStore.version }} is ready to install
+        <p class="mt-1 flex items-center gap-2 text-sm text-autonomi-muted">
+          <span>v{{ updaterStore.version }} is ready to install</span>
+          <span
+            v-if="updaterStore.isPrerelease"
+            class="rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-400"
+          >
+            Pre-release
+          </span>
         </p>
 
         <!-- Download size (shown during download if available) -->

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -170,12 +170,21 @@
               <p class="mt-1 text-xs text-autonomi-muted">
                 Receive auto-updates for pre-release builds (rc / beta) in addition to stable releases. Off by default.
               </p>
-              <p
+              <div
                 v-if="prereleaseChannelRestartRequired"
-                class="mt-1.5 text-xs font-medium text-amber-400"
+                class="mt-1.5 flex items-center gap-2"
               >
-                Restart the app to apply this change.
-              </p>
+                <p class="text-xs font-medium text-amber-400">
+                  Restart the app to apply this change.
+                </p>
+                <button
+                  type="button"
+                  class="rounded-md border border-amber-400/40 px-2 py-0.5 text-xs font-medium text-amber-400 hover:bg-amber-400/10"
+                  @click="relaunchApp"
+                >
+                  Restart now
+                </button>
+              </div>
             </div>
             <button
               type="button"
@@ -779,6 +788,11 @@ const prereleaseChannelRestartRequired = computed(
 
 async function onPrereleaseToggle() {
   await settingsStore.setPrereleaseChannel(!settingsStore.prereleaseChannel)
+}
+
+async function relaunchApp() {
+  const { relaunch } = await import('@tauri-apps/plugin-process')
+  await relaunch()
 }
 
 async function copyDiagnostics() {

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -162,6 +162,41 @@
           </div>
         </div>
 
+        <!-- Pre-release channel -->
+        <div class="rounded-lg border border-autonomi-border p-4">
+          <div class="flex items-center justify-between gap-3">
+            <div class="min-w-0 flex-1">
+              <h3 class="text-sm font-medium">Pre-release builds</h3>
+              <p class="mt-1 text-xs text-autonomi-muted">
+                Receive auto-updates for pre-release builds (rc / beta) in addition to stable releases. Off by default.
+              </p>
+              <p
+                v-if="prereleaseChannelRestartRequired"
+                class="mt-1.5 text-xs font-medium text-amber-400"
+              >
+                Restart the app to apply this change.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              :aria-checked="settingsStore.prereleaseChannel"
+              :class="[
+                'relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors',
+                settingsStore.prereleaseChannel ? 'bg-autonomi-blue' : 'bg-autonomi-border',
+              ]"
+              @click="onPrereleaseToggle"
+            >
+              <span
+                :class="[
+                  'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+                  settingsStore.prereleaseChannel ? 'translate-x-6' : 'translate-x-1',
+                ]"
+              />
+            </button>
+          </div>
+        </div>
+
         <!-- Indelible Enterprise Connection (only show setup when not connected) -->
         <div v-if="!settingsStore.indelibleConnected" class="rounded-lg border border-autonomi-border p-4">
           <div class="flex items-center justify-between">
@@ -736,6 +771,14 @@ async function onConcurrencyChange(raw: string) {
   const n = Number.parseInt(raw, 10)
   if (!Number.isFinite(n)) return
   await settingsStore.setUploadConcurrency(n)
+}
+
+const prereleaseChannelRestartRequired = computed(
+  () => settingsStore.prereleaseChannel !== settingsStore.prereleaseChannelBootValue,
+)
+
+async function onPrereleaseToggle() {
+  await settingsStore.setPrereleaseChannel(!settingsStore.prereleaseChannel)
 }
 
 async function copyDiagnostics() {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -30,6 +30,11 @@ pub struct AppConfig {
     /// can tune up to 8 via Settings → Advanced.
     #[serde(default = "default_upload_concurrency")]
     pub upload_concurrency: u32,
+    /// Opt-in to pre-release auto-updates (rc / beta builds). Off by default;
+    /// internal-tester convenience. The endpoint URL is resolved once at app
+    /// init from this flag, so toggling requires an app restart to take effect.
+    #[serde(default)]
+    pub prerelease_channel: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -126,6 +131,7 @@ impl Default for AppConfig {
             indelible_api_key: None,
             theme_mode: default_theme_mode(),
             upload_concurrency: default_upload_concurrency(),
+            prerelease_channel: false,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod autonomi_ops;
 mod config;
+mod updater_channel;
 
 use autonomi_ops::AutonomiState;
 use config::{AppConfig, FileMetaResult, UploadHistory, UploadHistoryEntry};
@@ -732,6 +733,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(AutonomiState::new())
         .manage(Arc::new(SseState::new()))
+        .manage(updater_channel::UpdaterChannelState::new())
         .invoke_handler(tauri::generate_handler![
             load_config,
             save_config,
@@ -766,6 +768,8 @@ pub fn run() {
             autonomi_ops::is_autonomi_connected,
             autonomi_ops::retry_autonomi_client,
             autonomi_ops::get_connection_status,
+            updater_channel::check_for_update_custom,
+            updater_channel::install_pending_update,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/updater_channel.rs
+++ b/src-tauri/src/updater_channel.rs
@@ -1,0 +1,231 @@
+//! Custom updater channel selection.
+//!
+//! The bundled `tauri-plugin-updater` reads its endpoint from compile-time
+//! `tauri.conf.json` config, which always points at the GitHub `/releases/
+//! latest/...` redirect. That redirect resolves to the most recent release
+//! marked **non-prerelease** — internal testers running RC builds never get
+//! auto-updates between RCs.
+//!
+//! This module bypasses the plugin's static endpoint by building an
+//! `UpdaterBuilder` ourselves at check time (see [`UpdaterExt::updater_builder`]
+//! and [`UpdaterBuilder::endpoints`] for the API path), pointing it at:
+//!
+//! - the standard stable redirect when `AppConfig.prerelease_channel == false`
+//! - a tag-specific URL resolved via the GitHub releases API when on
+//!
+//! The resolved URL is cached on `UpdaterChannelState` for the rest of the
+//! session — flipping the toggle takes effect on the next check, but the
+//! Settings UI still hints "restart to apply" because the boot-time channel
+//! is what any auto-check after launch uses.
+
+use crate::config::AppConfig;
+use reqwest::Url;
+use serde::Serialize;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_updater::{Update, UpdaterExt};
+use tokio::sync::RwLock;
+
+const STABLE_ENDPOINT: &str =
+    "https://github.com/WithAutonomi/ant-ui/releases/latest/download/latest.json";
+const RELEASES_API: &str = "https://api.github.com/repos/WithAutonomi/ant-ui/releases?per_page=10";
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub struct UpdaterChannelState {
+    /// Cached resolved endpoint URL for the prerelease channel. `None` until
+    /// the first check fires the GitHub API call. Stable channel never sets
+    /// this (the URL is constant).
+    cached_prerelease_endpoint: RwLock<Option<Url>>,
+    /// Update fetched by [`check_for_update_custom`], awaiting install via
+    /// [`install_pending_update`]. We hold it in app state because the JS-side
+    /// `Update` instance from `@tauri-apps/plugin-updater` doesn't apply here
+    /// (we built the `UpdaterBuilder` ourselves with custom endpoints).
+    pending_update: RwLock<Option<Update>>,
+}
+
+impl UpdaterChannelState {
+    pub fn new() -> Self {
+        Self {
+            cached_prerelease_endpoint: RwLock::new(None),
+            pending_update: RwLock::new(None),
+        }
+    }
+}
+
+/// Frontend-facing summary of an available update.
+#[derive(Serialize, Clone)]
+pub struct UpdateMetadata {
+    pub version: String,
+    pub body: Option<String>,
+    /// `true` when the resolved release is marked prerelease on GitHub. Lets
+    /// the UpdateDialog show a "Pre-release" badge so testers can tell at a
+    /// glance which channel they're being offered from.
+    pub is_prerelease: bool,
+}
+
+/// One-shot wire payload for download progress, mirrors the events the JS
+/// plugin emits (`Started` / `Progress` / `Finished`) so the frontend store
+/// can reuse its existing handler shape.
+#[derive(Serialize, Clone)]
+#[serde(tag = "event", content = "data")]
+enum DownloadEvent {
+    #[serde(rename_all = "camelCase")]
+    Started {
+        content_length: Option<u64>,
+    },
+    #[serde(rename_all = "camelCase")]
+    Progress {
+        chunk_length: usize,
+    },
+    Finished,
+}
+
+/// Check for an available update on the channel selected in `AppConfig`.
+/// Returns `None` if the running version is already current.
+#[tauri::command]
+pub async fn check_for_update_custom(app: AppHandle) -> Result<Option<UpdateMetadata>, String> {
+    let endpoint = resolve_updater_endpoint(&app).await?;
+    let updater = app
+        .updater_builder()
+        .endpoints(vec![endpoint])
+        .map_err(|e| format!("Failed to set updater endpoint: {e}"))?
+        .build()
+        .map_err(|e| format!("Failed to build updater: {e}"))?;
+
+    let update = updater
+        .check()
+        .await
+        .map_err(|e| format!("Update check failed: {e}"))?;
+
+    let state = app.state::<UpdaterChannelState>();
+    if let Some(u) = update {
+        let is_prerelease = looks_like_prerelease(&u.version);
+        let meta = UpdateMetadata {
+            version: u.version.clone(),
+            body: u.body.clone(),
+            is_prerelease,
+        };
+        *state.pending_update.write().await = Some(u);
+        Ok(Some(meta))
+    } else {
+        *state.pending_update.write().await = None;
+        Ok(None)
+    }
+}
+
+/// Download and install the update fetched by the most recent
+/// `check_for_update_custom` call. Tauri restarts the app automatically on
+/// completion. Emits `update-download-event` with `Started` / `Progress` /
+/// `Finished` payloads matching the JS plugin's event shape.
+#[tauri::command]
+pub async fn install_pending_update(app: AppHandle) -> Result<(), String> {
+    let state = app.state::<UpdaterChannelState>();
+    let update = state
+        .pending_update
+        .write()
+        .await
+        .take()
+        .ok_or("No pending update — call check_for_update_custom first")?;
+
+    let app_for_chunk = app.clone();
+    let app_for_finish = app.clone();
+    let mut emitted_started = false;
+
+    update
+        .download_and_install(
+            move |chunk_length, content_length| {
+                if !emitted_started {
+                    emitted_started = true;
+                    let _ = app_for_chunk.emit(
+                        "update-download-event",
+                        DownloadEvent::Started { content_length },
+                    );
+                }
+                let _ = app_for_chunk.emit(
+                    "update-download-event",
+                    DownloadEvent::Progress { chunk_length },
+                );
+            },
+            move || {
+                let _ = app_for_finish.emit("update-download-event", DownloadEvent::Finished);
+            },
+        )
+        .await
+        .map_err(|e| format!("Update install failed: {e}"))?;
+
+    Ok(())
+}
+
+/// Decide which endpoint to use for this check based on the persisted
+/// `prerelease_channel` flag. Stable is a constant URL; prerelease is
+/// resolved once via GitHub API and cached for the rest of the session.
+async fn resolve_updater_endpoint(app: &AppHandle) -> Result<Url, String> {
+    let cfg = AppConfig::load().map_err(|e| format!("Failed to load config: {e}"))?;
+
+    if !cfg.prerelease_channel {
+        return Url::parse(STABLE_ENDPOINT).map_err(|e| e.to_string());
+    }
+
+    let state = app.state::<UpdaterChannelState>();
+    if let Some(cached) = state.cached_prerelease_endpoint.read().await.clone() {
+        return Ok(cached);
+    }
+
+    let url = fetch_latest_prerelease_url().await?;
+    *state.cached_prerelease_endpoint.write().await = Some(url.clone());
+    Ok(url)
+}
+
+/// Query the GitHub releases API and pick the newest release by `published_at`,
+/// regardless of its `prerelease` flag (drafts excluded). Constructs the
+/// `latest.json` asset URL on that release.
+async fn fetch_latest_prerelease_url() -> Result<Url, String> {
+    let client = reqwest::Client::builder()
+        .user_agent("ant-gui-updater")
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .map_err(|e| format!("HTTP client init: {e}"))?;
+
+    let resp = client
+        .get(RELEASES_API)
+        .send()
+        .await
+        .map_err(|e| format!("GitHub releases API: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "GitHub releases API returned status {}",
+            resp.status()
+        ));
+    }
+    let releases: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("Parse releases JSON: {e}"))?;
+
+    let arr = releases
+        .as_array()
+        .ok_or("Releases response was not a JSON array")?;
+
+    // Pick newest non-draft release by published_at (lexicographic ordering
+    // works because timestamps are ISO-8601 UTC). Drafts excluded; prereleases
+    // included — that's the whole point of this code path.
+    let latest = arr
+        .iter()
+        .filter(|r| r["draft"].as_bool() != Some(true))
+        .max_by_key(|r| r["published_at"].as_str().unwrap_or("").to_string())
+        .ok_or("No releases found")?;
+
+    let tag = latest["tag_name"]
+        .as_str()
+        .ok_or("Release missing tag_name")?;
+    let url_str =
+        format!("https://github.com/WithAutonomi/ant-ui/releases/download/{tag}/latest.json");
+    Url::parse(&url_str).map_err(|e| format!("Bad asset URL {url_str}: {e}"))
+}
+
+/// Heuristic: a version string with `-rc.` / `-beta.` / `-alpha.` is a
+/// prerelease. Matches the `release.yml` workflow's `prerelease=true`
+/// detection so the badge in the dialog stays accurate.
+fn looks_like_prerelease(version: &str) -> bool {
+    version.contains("-rc.") || version.contains("-beta.") || version.contains("-alpha.")
+}

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -32,6 +32,7 @@ interface AppConfig {
   indelible_api_key: string | null
   theme_mode: string
   upload_concurrency: number
+  prerelease_channel: boolean
 }
 
 /** Allowed range for upload_concurrency (see AppConfig in Rust). */
@@ -57,6 +58,15 @@ export const useSettingsStore = defineStore('settings', {
     indelibleUserEmail: null as string | null,
     themeMode: 'dark' as ThemeMode,
     uploadConcurrency: 1,
+    /** Auto-update channel selector. Off → stable releases only.
+     *  On → next app launch resolves the latest release including pre-releases
+     *  (rc/beta) via the GitHub API. The endpoint is captured at app init, so
+     *  toggling this requires an app restart to take effect — the Settings UI
+     *  shows a hint banner when the live value differs from the boot value. */
+    prereleaseChannel: false,
+    /** Snapshot of `prereleaseChannel` at app boot — drives the "restart to
+     *  apply" hint banner. Set once during loadConfig. */
+    prereleaseChannelBootValue: false,
     loaded: false,
     // Devnet/testnet/direct-key mode (set by manifest or settings form).
     // devnetChainId picks the chain:
@@ -88,6 +98,11 @@ export const useSettingsStore = defineStore('settings', {
         this.indelibleApiKey = config.indelible_api_key
         this.themeMode = config.theme_mode === 'light' ? 'light' : 'dark'
         this.uploadConcurrency = clampConcurrency(config.upload_concurrency)
+        this.prereleaseChannel = config.prerelease_channel ?? false
+        // Capture once on first load — represents the value the Rust side
+        // resolved its updater endpoint URL from. Subsequent toggles diverge
+        // from this until the next app restart.
+        if (!this.loaded) this.prereleaseChannelBootValue = this.prereleaseChannel
         this.loaded = true
       } catch (e) {
         console.error('Failed to load config:', e)
@@ -106,6 +121,7 @@ export const useSettingsStore = defineStore('settings', {
           indelible_api_key: this.indelibleApiKey,
           theme_mode: this.themeMode,
           upload_concurrency: this.uploadConcurrency,
+          prerelease_channel: this.prereleaseChannel,
         }
         await invoke('save_config', { config })
       } catch (e) {
@@ -115,6 +131,11 @@ export const useSettingsStore = defineStore('settings', {
 
     async setUploadConcurrency(n: number) {
       this.uploadConcurrency = clampConcurrency(n)
+      await this.saveConfig()
+    },
+
+    async setPrereleaseChannel(enabled: boolean) {
+      this.prereleaseChannel = enabled
       await this.saveConfig()
     },
 

--- a/stores/updater.ts
+++ b/stores/updater.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
-import { markRaw } from 'vue'
-import { check, type Update } from '@tauri-apps/plugin-updater'
+import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 
 export interface CheckResult {
   ok: boolean
@@ -8,10 +8,22 @@ export interface CheckResult {
   error?: string
 }
 
+interface UpdateMetadata {
+  version: string
+  body: string | null
+  is_prerelease: boolean
+}
+
+type DownloadEvent =
+  | { event: 'Started'; data: { contentLength: number | null } }
+  | { event: 'Progress'; data: { chunkLength: number } }
+  | { event: 'Finished' }
+
+// Inputs that the Rust side surfaces verbatim from tauri-plugin-updater's
+// errors. The plugin's wording is consistent across versions, so the same
+// regex set the JS plugin path used works against the Rust-passthrough
+// strings too.
 function humaniseUpdateError(raw: string): string {
-  // tauri-plugin-updater surfaces `ReleaseNotFound` for any non-success HTTP
-  // response (404, 403, 500, …) with this exact string, so pin to it. The
-  // other phrases catch older plugin versions and direct log messages.
   if (/could not fetch a valid release json|release not found|did not respond with a successful status code|\b404\b|\bnot found\b/i.test(raw)) {
     return 'Cannot find latest version'
   }
@@ -29,13 +41,16 @@ export const useUpdaterStore = defineStore('updater', {
     available: false,
     version: null as string | null,
     body: null as string | null,
+    isPrerelease: false,
     installing: false,
     showDialog: false,
     downloadTotal: null as number | null,
     downloadedBytes: 0,
     checking: false,
     lastCheckedAt: null as number | null,
-    _update: null as Update | null,
+    /** Live listener for download progress while an install is in flight.
+     *  Cleared on Finished or on install failure. */
+    _downloadUnlisten: null as UnlistenFn | null,
   }),
 
   getters: {
@@ -50,21 +65,24 @@ export const useUpdaterStore = defineStore('updater', {
       if (this.checking) return { ok: false, available: false, error: 'Check already in progress' }
       this.checking = true
       try {
-        const update = await check()
+        // Custom Tauri command (see src-tauri/src/updater_channel.rs).
+        // Honours the prerelease_channel flag in AppConfig — stable users go
+        // through the standard /releases/latest/... redirect; pre-release
+        // testers get the latest tag including pre-releases via the GitHub API.
+        const meta = await invoke<UpdateMetadata | null>('check_for_update_custom')
         this.lastCheckedAt = Date.now()
-        if (update) {
+        if (meta) {
           this.available = true
-          this.version = update.version
-          this.body = update.body ?? null
-          // markRaw: Update has private fields that break when wrapped in
-          // Pinia's reactive Proxy — downloadAndInstall() silently no-ops.
-          this._update = markRaw(update)
+          this.version = meta.version
+          this.body = meta.body ?? null
+          this.isPrerelease = meta.is_prerelease
           return { ok: true, available: true }
         }
+        this.available = false
         return { ok: true, available: false }
       } catch (e: any) {
         console.error('Update check failed:', e)
-        const raw = e?.message ?? String(e)
+        const raw = typeof e === 'string' ? e : (e?.message ?? String(e))
         return { ok: false, available: false, error: humaniseUpdateError(raw) }
       } finally {
         this.checking = false
@@ -72,22 +90,32 @@ export const useUpdaterStore = defineStore('updater', {
     },
 
     async installUpdate() {
-      if (!this._update) return
+      if (!this.available) return
       this.installing = true
       this.downloadedBytes = 0
       this.downloadTotal = null
+
+      // Subscribe BEFORE invoking install so we don't lose the Started event
+      // when the download is fast (small installer, warm CDN).
+      this._downloadUnlisten = await listen<DownloadEvent>('update-download-event', (event) => {
+        const payload = event.payload
+        if (payload.event === 'Started') {
+          this.downloadTotal = payload.data.contentLength
+        } else if (payload.event === 'Progress') {
+          this.downloadedBytes += payload.data.chunkLength
+        }
+        // 'Finished' — Tauri will restart the app, no UI action needed.
+      })
+
       try {
-        await this._update.downloadAndInstall((event) => {
-          if (event.event === 'Started') {
-            this.downloadTotal = (event.data as any).contentLength ?? null
-          } else if (event.event === 'Progress') {
-            this.downloadedBytes += (event.data as any).chunkLength ?? 0
-          }
-          // 'Finished' — Tauri will restart the app
-        })
+        await invoke('install_pending_update')
       } catch (e) {
         console.error('Update install failed:', e)
         this.installing = false
+        if (this._downloadUnlisten) {
+          this._downloadUnlisten()
+          this._downloadUnlisten = null
+        }
       }
     },
   },


### PR DESCRIPTION
## Summary

Adds an opt-in "Pre-release builds" toggle to **Settings → Advanced** so internal testers running on RCs get auto-updates between RC builds, not just at stable cuts. Off by default — zero impact on the stable-channel population.

## Why

`tauri-plugin-updater` reads its endpoint from compile-time `tauri.conf.json` config, and we point that at `releases/latest/download/latest.json`. GitHub's `/releases/latest/...` redirect is defined to skip releases marked `prerelease=true`, so RC artefacts are invisible to the in-app updater even though `release.yml` correctly publishes a signed `latest.json` to every prerelease.

Internal testers had to download every RC manually. This PR closes that gap.

## How

The plugin's `Builder` doesn't accept runtime endpoints, so we bypass its frontend `check()`/`Update.downloadAndInstall()` entirely and own the flow ourselves via `app.updater_builder().endpoints(...)` (which the per-call `UpdaterBuilder` *does* support). Plugin stays registered for permissions / target detection.

Three commits, each independently buildable:

1. **`feat(settings): add pre-release channel toggle (UI only)`**
   - `AppConfig.prerelease_channel: bool` (default false), persisted via existing `config.toml` round-trip.
   - Settings → Advanced toggle bound to it.
   - Restart-hint banner that shows whenever the live value differs from the snapshot taken on first `loadConfig`. The snapshot represents the channel the running session resolved its endpoint URL from, so the hint only appears when a restart would actually change behaviour.

2. **`feat(updater): channel-aware check + install commands`**
   - New `src-tauri/src/updater_channel.rs` module with `UpdaterChannelState` (managed) holding a cached resolved endpoint URL and the pending `Update` instance.
   - `check_for_update_custom` reads the channel flag, resolves the endpoint (stable redirect for off; latest tag including pre-releases via the GitHub releases API for on), builds an `UpdaterBuilder` with that endpoint, calls `.check()`, stashes the `Update` for later install. Returns `UpdateMetadata { version, body, is_prerelease }`.
   - `install_pending_update` pulls the `Update` from state, runs `download_and_install`, re-emits Started/Progress/Finished as `update-download-event` with the same payload shape the JS plugin emits today (frontend handler unchanged).

3. **`feat(updater): switch frontend store to channel-aware Tauri commands`**
   - `stores/updater.ts` no longer imports from `@tauri-apps/plugin-updater`. Calls our custom commands instead. Subscribes to `update-download-event` for progress.
   - The `markRaw(Update)` workaround goes away — the `Update` instance now lives in Rust state, not Pinia.
   - `UpdateDialog` shows an amber "Pre-release" badge next to the version when `meta.is_prerelease` is true.

## Notes

- **Restart-required is the documented UX, but the implementation is more lenient.** The check command re-reads the config every call and the prerelease URL is cached for the session. So flipping the toggle and clicking Check Now does pick up the new channel. Restart is still the right hint for users because the auto-check that runs on app boot uses whatever the channel was at boot.
- **Does not change `release.yml`.** The workflow's existing `prerelease=true` detection (`*-rc.*` / `*-beta.*` / `*-alpha.*`) is correct.
- **Plugin remains registered** — needed for permissions and target/exe detection. Its compile-time endpoint config becomes effectively dead but the plugin still expects a valid value, so leaving the existing one is fine.

## Test plan

- [x] `cargo check --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `npx nuxi build` clean (Nuxt + Vite)
- [ ] CI green (Linux)
- [ ] Manual: toggle off → stable check returns expected version, no badge; existing RCs invisible.
- [ ] Manual: toggle on → restart hint appears; after restart, check resolves the latest pre-release tag, dialog shows "Pre-release" amber badge.
- [ ] Manual: install end-to-end on an internal RC build (download progress, restart-on-finish).
- [ ] Manual: toggle on → toggle off → restart → next check reverts to stable.

`vitest` locally hits the same Windows + npm + `@vue/test-utils` ESM flake we've seen on every branch since #59 — pre-existing, CI on Linux is the source of truth.

## Closes

Linear ticket tracking this work (internal).