### PR TITLE
chore: bump version to 0.6.8-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.7",
+  "version": "0.6.8-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.7"
+version = "0.6.8-rc.1"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.7"
+version = "0.6.8-rc.1"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.7",
+  "version": "0.6.8-rc.1",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
First internal-tester pre-release of the 0.6.8 cycle.

## What's in this RC vs 0.6.7

**Backend / dependencies**
- `ant-core` bumped 0.2.0 → 0.2.2 (matches today's `ant-cli-v0.2.1` release)
- Transitive: `ant-protocol` 2.0.1 → 2.0.2, `saorsa-core` 0.24.0 → 0.24.1
- `npm ci` lockfile drift fixed; 8 of 10 npm-audit advisories cleared (deferred 2 moderates are upstream-pinned via `@coinbase/cdp-sdk`)

**Uploads / downloads**
- Live per-row progress wired through both upload paths (direct-key wallet + external-signer / WalletConnect) plus the download flow. Bar climbs 0→50% during quoting, 50→100% during storage; per-stage label shows percent ("Storing · 67%").
- Public-visibility uploads enabled — toggle Public in the dialog, get a shareable on-network address surfaced on the row with a Public badge (click to copy).
- Chain auto-switch on the WalletConnect path closes the "current chain id 1 ≠ target chain id 42161" error reported on 0.6.7.
- EIP-1559 fee config corrected on the wallet path — explicit `maxFeePerGas` + `maxPriorityFeePerGas` per writeContract; fixes the masked "User rejected the request" wrapper that was actually a fee-invariant violation on Arbitrum.

**Platform / UX**
- Devnet manifest now read from the shared data directory (`%APPDATA%/ant/`, `~/Library/Application Support/ant/`, etc.) so any consumer (GUI, CLI, TUI) can discover it. Legacy GUI-config path kept for backward compat.
- Windows console-window flash on daemon spawn: hundreds → ~2 (full elimination needs the daemon-side companion to roll into a release).
- **New: pre-release auto-update channel.** Settings → Advanced → "Pre-release builds" toggle. Off by default — stable users keep getting only stable. On — the next launch resolves the latest release including pre-releases via the GitHub API. Restart hint banner appears whenever the live setting differs from the boot snapshot, with an inline "Restart now" button.

## Release process

1. Merge this PR → main has 0.6.8-rc.1 in all 4 files.
2. `git checkout main && git pull && git tag v0.6.8-rc.1 && git push origin v0.6.8-rc.1`
3. `release.yml` builds all platforms (~22 min), creates a **published prerelease** with assets + signed `latest.json`. Stable users won't see it (GitHub `/releases/latest/...` redirect skips prereleases). Internal testers can install from the release page directly.
4. Once installed, testers can toggle the new pre-release channel on, restart, and the next prerelease ships via auto-update.

## Test plan

- [ ] CI green
- [ ] Tag pushed → `release.yml` produces `v0.6.8-rc.1` published prerelease with all 4 platform installers + `latest.json`
- [ ] Manual install of a fresh 0.6.8-rc.1 on Windows / macOS / Linux launches cleanly
- [ ] Pre-release channel toggle round-trips through restart; with toggle on, app picks up subsequent prereleases via auto-update