### PR TITLE
feat(sidebar): teal "PRE-RELEASE" badge for prerelease builds

### DIFF
--- a/components/AppSidebar.vue
+++ b/components/AppSidebar.vue
@@ -8,6 +8,18 @@
 
     <!-- Main navigation -->
     <nav class="flex-1 px-2 py-2">
+      <!-- Pre-release build indicator. Shown whenever the running version
+           contains an -rc./-beta./-alpha. suffix, regardless of whether the
+           pre-release auto-update channel is enabled. Distinct teal palette
+           so it doesn't clash with the amber DEVNET / SEPOLIA TESTNET badge
+           when both apply. -->
+      <div
+        v-if="isPrereleaseBuild"
+        class="mb-2 rounded-md bg-teal-500/10 border border-teal-500/20 px-3 py-1.5 text-center text-xs font-medium text-teal-400"
+      >
+        PRE-RELEASE
+      </div>
+
       <!-- Network mode indicator -->
       <div
         v-if="settingsStore.devnetActive && networkLabel"
@@ -61,6 +73,7 @@
 
 <script setup lang="ts">
 import { arbitrumSepolia } from 'viem/chains'
+import { invoke } from '@tauri-apps/api/core'
 import { useNodesStore } from '~/stores/nodes'
 import { useFilesStore } from '~/stores/files'
 import { useUpdaterStore } from '~/stores/updater'
@@ -71,6 +84,21 @@ const nodesStore = useNodesStore()
 const filesStore = useFilesStore()
 const updaterStore = useUpdaterStore()
 const settingsStore = useSettingsStore()
+
+const currentVersion = ref<string | null>(null)
+onMounted(async () => {
+  try {
+    currentVersion.value = await invoke<string>('get_app_version')
+  } catch {
+    currentVersion.value = null
+  }
+})
+
+// Mirror the `release.yml` and `updater_channel::looks_like_prerelease`
+// detection — anything tagged -rc.N / -beta.N / -alpha.N is a pre-release.
+const isPrereleaseBuild = computed(() =>
+  /-(?:rc|beta|alpha)\./.test(currentVersion.value ?? ''),
+)
 
 const networkLabel = computed<string | null>(() => {
   switch (settingsStore.devnetChainId) {


### PR DESCRIPTION
## Summary

Adds a persistent sidebar badge that surfaces *"this app is a pre-release build"* to anyone running an rc/beta/alpha tag. Sits in the same slot as the existing DEVNET / SEPOLIA TESTNET badge, above the navigation links.

## Why

A tester running v0.6.8-rc.1 against production is identical-looking to a stable v0.6.8 user from the sidebar. When something goes wrong in testing, that ambiguity makes triage slower. A persistent indicator makes the distinction obvious at all times — not just when an update happens to be offered.

## Visual

- Teal palette (`bg-teal-500/10 / border-teal-500/20 / text-teal-400`) — chosen to **not** collide with the amber DEVNET / SEPOLIA TESTNET badge when both apply (e.g. an RC build connected to a Sepolia devnet).
- Same shape, padding, and typographic weight as the network badge for visual consistency.
- Text: `PRE-RELEASE` (uppercase, matches DEVNET conventions).

## Detection

Frontend regex `/-(?:rc|beta|alpha)\./` matches the running version (fetched once on mount via `get_app_version`). Mirrors `release.yml`'s prerelease tag rule and `updater_channel::looks_like_prerelease` in Rust — three call sites, one rule.

## Test plan

- [x] `npx nuxi build` clean
- [ ] CI green
- [ ] Manual: a stable build (e.g. v0.6.7) shows **no** badge.
- [ ] Manual: a pre-release build (e.g. v0.6.8-rc.1) shows the teal `PRE-RELEASE` badge in the top-left.
- [ ] Manual: combined with devnet — both badges stack cleanly, distinct colours.

If you'd rather pink than teal, swap `teal-` → `pink-` in three classnames; one-line tweak.