### PR TITLE
chore: bump version to 0.6.8-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.8-rc.1",
+  "version": "0.6.8-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.8-rc.1"
+version = "0.6.8-rc.2"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.8-rc.1"
+version = "0.6.8-rc.2"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.8-rc.1",
+  "version": "0.6.8-rc.2",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Second internal-tester pre-release of the 0.6.8 cycle.

## Adds on top of v0.6.8-rc.1

- **Sidebar PRE-RELEASE indicator** (#70) — teal badge that surfaces when running an `-rc./-beta./-alpha.` build. Distinct palette from the amber DEVNET / SEPOLIA TESTNET badge so both can stack cleanly. Detection mirrors `release.yml`'s prerelease tag rule.
- **refresh-release-notes workflow** (#71) — ~30s manual `workflow_dispatch` to push the polished GitHub release body into `latest.json.notes`, so the in-app UpdateDialog renders proper release notes (not the empty string `release.yml` writes by default).

## Why rc.2

To exercise the V2-237 auto-update path end-to-end. Internal testers running installed v0.6.8-rc.1 with Settings → Advanced → Pre-release builds toggled on should auto-detect rc.2 and offer the install via the existing UpdateDialog flow — without any manual download.

## Release process

1. Merge this PR → main has 0.6.8-rc.2 in all 4 files.
2. `git tag v0.6.8-rc.2 && git push origin v0.6.8-rc.2`
3. `release.yml` builds all platforms (~22 min), publishes prerelease.
4. Edit auto-gen release notes on github.com to be tester-readable.
5. Run `gh workflow run refresh-release-notes.yml -f tag=v0.6.8-rc.2` (~30s) so the in-app dialog gets the polished notes.

## Test plan

- [ ] CI green
- [ ] Tag pushed → release.yml succeeds → v0.6.8-rc.2 published prerelease
- [ ] Installed v0.6.8-rc.1 with toggle on → auto-update prompt offers v0.6.8-rc.2 with the amber Pre-release dialog badge
- [ ] After running `refresh-release-notes`: re-check on installed rc.1 → dialog shows the edited release notes (not "No release notes available")
- [ ] Sidebar of rc.2 shows the new teal PRE-RELEASE badge