### PR TITLE
fix(updater): restart on Linux/macOS after install

### DIFF
--- a/src-tauri/src/updater_channel.rs
+++ b/src-tauri/src/updater_channel.rs
@@ -114,9 +114,14 @@ pub async fn check_for_update_custom(app: AppHandle) -> Result<Option<UpdateMeta
 }
 
 /// Download and install the update fetched by the most recent
-/// `check_for_update_custom` call. Tauri restarts the app automatically on
-/// completion. Emits `update-download-event` with `Started` / `Progress` /
-/// `Finished` payloads matching the JS plugin's event shape.
+/// `check_for_update_custom` call. Emits `update-download-event` with
+/// `Started` / `Progress` / `Finished` payloads matching the JS plugin's
+/// event shape, then restarts the app so the new binary is picked up.
+///
+/// `download_and_install` only restarts on Windows (the NSIS/MSI installer
+/// exits the running process as part of its own flow). On Linux (AppImage)
+/// and macOS the new binary is written to disk but the running process keeps
+/// going — we have to call `app.restart()` ourselves or the UI hangs at 100%.
 #[tauri::command]
 pub async fn install_pending_update(app: AppHandle) -> Result<(), String> {
     let state = app.state::<UpdaterChannelState>();
@@ -153,7 +158,7 @@ pub async fn install_pending_update(app: AppHandle) -> Result<(), String> {
         .await
         .map_err(|e| format!("Update install failed: {e}"))?;
 
-    Ok(())
+    app.restart()
 }
 
 /// Decide which endpoint to use for this check based on the persisted


### PR DESCRIPTION
## Summary

`tauri-plugin-updater::download_and_install` only calls `std::process::exit(0)` on **Windows** (see `tauri-plugin-updater-2.10.1/src/updater.rs:288`, where the comment explicitly says "exit the app through `std::process::exit(0)` on Windows"). On Linux and macOS it just writes the new binary to disk and returns — the caller has to restart the app explicitly.

Without that restart, on Linux/macOS:
- the download bar fills to 100%
- the `Finished` event fires
- `install_pending_update` returns `Ok(())`
- …and nothing else happens — the running process keeps the **old** binary loaded, and the UI is stuck in `installing: true` forever

Windows is unaffected because the NSIS installer's `process::exit` path inside `download_and_install` already tears the running process down, and the installer relaunches the new binary itself.

The fix is one line: call `app.restart()` after `download_and_install` returns. `AppHandle::restart()` returns `!`, so it replaces the trailing `Ok(())`. On Windows it's harmless — the installer is already exiting the process by the time control would reach it.

## Scope

Affects **both stable and pre-release** channels — the install path is shared. Technically the same bug existed pre-rc.1 (the JS plugin's `Update.downloadAndInstall()` also doesn't auto-restart on Linux/macOS — same comment in `stores/updater.ts` claimed it did) but stable users on Linux/Mac generally don't update via the in-app flow, so it went unnoticed. The new pre-release opt-in toggle (#68) is what made testers actually hit it.

## Test plan

Verified locally on Ubuntu 25.10 (kernel 6.17, x86_64):

- [x] Built a patched `0.6.8-rc.1` AppImage with the fix, opted in to pre-release, triggered update against published rc.2 → download completes, app exits, relaunches as rc.2
- [x] Verified the misleading "Tauri will restart the app" comment in `stores/updater.ts:86` is now accurate (Rust side actually does restart)
- [ ] Suggest verifying on macOS — same code path, same bug, same fix expected to apply
- [ ] Windows regression check: install completes and relaunches as today (no behaviour change expected — the installer's exit happens before `restart()` would run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)