### PR TITLE
feat(updater): teal banner + dialog badge for prerelease updates

### DIFF
--- a/components/AppSidebar.vue
+++ b/components/AppSidebar.vue
@@ -31,7 +31,10 @@
       <!-- Update banner -->
       <button
         v-if="updaterStore.available"
-        class="mb-2 flex w-full items-center gap-2 rounded-lg bg-amber-400 px-3 py-2.5 text-left text-sm font-semibold text-gray-900 shadow-md shadow-amber-400/25 transition-all hover:bg-amber-300 active:scale-[0.98]"
+        class="mb-2 flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-left text-sm font-semibold text-gray-900 shadow-md transition-all active:scale-[0.98]"
+        :class="updaterStore.isPrerelease
+          ? 'bg-teal-400 shadow-teal-400/25 hover:bg-teal-300'
+          : 'bg-amber-400 shadow-amber-400/25 hover:bg-amber-300'"
         @click="onUpdateClick"
       >
         <div class="min-w-0 flex-1">

--- a/components/UpdateDialog.vue
+++ b/components/UpdateDialog.vue
@@ -19,7 +19,7 @@
           <span>v{{ updaterStore.version }} is ready to install</span>
           <span
             v-if="updaterStore.isPrerelease"
-            class="rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-400"
+            class="rounded bg-teal-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-teal-400"
           >
             Pre-release
           </span>


### PR DESCRIPTION
## Summary

Extends the teal prerelease accent established in #70 (the static "PRE-RELEASE" sidebar badge) to the updater UI, so an update offered to a tester on the prerelease channel is visually consistent with the rest of the prerelease styling — instead of sharing the amber palette used by stable updates and the network badges.

- **Sidebar "Update Available" banner** (`components/AppSidebar.vue`): teal-400 when `updaterStore.isPrerelease`, amber-400 (existing colour) for stable. Same shape, same dark text, same shadow/hover behaviour.
- **UpdateDialog "Pre-release" badge** (`components/UpdateDialog.vue`): teal-500/10 background + teal-400 text, matching the sidebar badge from #70 directly.

## Test plan

Verified locally on Ubuntu 25.10 with a patched 0.6.8-rc.1 build:

- [x] Pre-release channel on, update available → sidebar banner is teal, dialog badge is teal
- [x] Same component renders amber when `isPrerelease` is false (verified by walking through `updaterStore.isPrerelease` logic; can't actually trigger a stable→stable update from rc.1 since the repo's `latest` stable is 0.6.7, older than the running 0.6.8-rc.1)
- [ ] Reviewer to spot-check colour contrast / dark-mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)