### PR TITLE
chore: bump version to 0.6.8-rc.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.8-rc.2",
+  "version": "0.6.8-rc.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.8-rc.2"
+version = "0.6.8-rc.3"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.8-rc.2"
+version = "0.6.8-rc.3"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.8-rc.2",
+  "version": "0.6.8-rc.3",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Third internal-tester pre-release.

## Adds on top of rc.2

- **Linux/macOS auto-restart after install** (#73) — closes the "stuck at 100%" bug. `tauri-plugin-updater` only `process::exit(0)`s on Windows; Linux/macOS need an explicit `app.restart()` after `download_and_install` returns. Verified rc.1 → rc.2 upgrade on Ubuntu 25.10 in #73.
- **Teal banner + dialog badge for prerelease updates** (#74) — visual consistency with the sidebar PRE-RELEASE indicator.

## Headline test for rc.3

Anyone on installed v0.6.8-rc.1 or rc.2 (Linux/macOS) with Pre-release builds toggled on should:
- Auto-detect rc.3 with the new teal update banner in the sidebar
- Click → dialog with teal Pre-release badge
- Click Update & Restart → download, install, **app actually restarts cleanly into rc.3** (Linux/macOS — was broken on rc.1, fixed in #73)
- Sidebar shows the teal PRE-RELEASE badge once running on rc.3

## Release process

1. Merge → main has 0.6.8-rc.3 across 4 files
2. `git tag v0.6.8-rc.3 && git push origin v0.6.8-rc.3` → release.yml builds (~22 min) → publishes prerelease
3. Edit auto-gen release notes on github.com
4. `gh workflow run refresh-release-notes.yml -f tag=v0.6.8-rc.3` → polished notes propagate into latest.json for the in-app dialog