### PR TITLE
feat(updater): "Pre-Release" label above the update banner

### DIFF
--- a/components/AppSidebar.vue
+++ b/components/AppSidebar.vue
@@ -38,6 +38,12 @@
         @click="onUpdateClick"
       >
         <div class="min-w-0 flex-1">
+          <div
+            v-if="updaterStore.isPrerelease"
+            class="text-[10px] font-bold uppercase tracking-wider opacity-70"
+          >
+            Pre-Release
+          </div>
           <div class="text-xs font-bold uppercase tracking-wide">Update Available</div>
           <div class="truncate text-xs font-medium opacity-80">v{{ updaterStore.version }}</div>
         </div>


### PR DESCRIPTION
## Summary

Adds a small "Pre-Release" header line above the existing teal "Update Available" banner so testers can see the channel of the offered update at a glance, not just from the version string.

## Visual

When the offered update is a pre-release (`isPrerelease === true`), the sidebar banner stacks three lines:

```
PRE-RELEASE        ← new (text-[10px], uppercase, bold, opacity-70)
UPDATE AVAILABLE   ← existing (text-xs, uppercase, bold)
v0.6.8-rc.X        ← existing (text-xs, opacity-80)
```

Stable update banners are unchanged — no extra label, amber palette as before.

## Pairs with

- #74 (teal banner / dialog badge for pre-release updates)
- The existing sidebar PRE-RELEASE indicator (#70) — same wording so the two surfaces are consistent.

## Test plan

- [x] `npx nuxi build` clean
- [x] Manual on Windows dev with faked v0.6.6 + pre-release toggle on → banner shows the three-line stack with "Pre-Release / Update Available / v0.6.8-rc.2".
- [ ] CI green
- [ ] Reviewer: confirm spacing / weight reads cleanly. The new line uses `text-[10px]` and `opacity-70` to give the existing "Update Available" headline visual primacy — easy to bump up if the hierarchy feels wrong.