### PR TITLE
chore: bump version to 0.6.8-rc.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.8-rc.3",
+  "version": "0.6.8-rc.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.8-rc.3"
+version = "0.6.8-rc.4"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.8-rc.3"
+version = "0.6.8-rc.4"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.8-rc.3",
+  "version": "0.6.8-rc.4",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Fourth internal-tester pre-release.

## Adds on top of rc.3

- **"Pre-Release" header line on the update banner** (#76) — when the offered update is a pre-release, the teal sidebar banner stacks three lines: `PRE-RELEASE / UPDATE AVAILABLE / v0.6.8-rc.X`. Testers can identify the channel at a glance.

## Test cadence

Cutting rc.4 immediately after rc.3 lets testers on rc.1/rc.2 exercise the V2-237 + #73 install path **twice**:

1. Auto-upgrade rc.1/rc.2 → rc.3 (first verification of the install + restart fix)
2. Auto-upgrade rc.3 → rc.4 (second cycle, with the new "Pre-Release" header label visible in the prompt)

Two upgrades through the prerelease channel in one tester session — confirms the fix is sticky across cycles, not just on a fresh install.

## Release process

Same as previous RC cycles:

1. Merge → main has 0.6.8-rc.4
2. `git tag v0.6.8-rc.4 && git push origin v0.6.8-rc.4` → release.yml builds (~22 min)
3. Edit release notes on github.com
4. `gh workflow run refresh-release-notes.yml -f tag=v0.6.8-rc.4`