### PR TITLE
fix(updater): cancel button + restart watchdog + surfaced errors

### DIFF
--- a/components/UpdateDialog.vue
+++ b/components/UpdateDialog.vue
@@ -61,21 +61,37 @@
         </div>
 
         <!-- Actions -->
-        <div class="mt-5 flex justify-end gap-2">
+        <div class="mt-5 flex items-center justify-between gap-2">
+          <!-- Cancel Download (left) — only shown during install. Disabled
+               once download hits 100% because the install step that follows
+               is uncancellable (would brick the .app on macOS). -->
           <button
-            v-if="!updaterStore.installing"
-            class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
-            @click="close"
+            v-if="updaterStore.installing"
+            class="rounded-md border border-autonomi-error/50 px-3 py-1.5 text-sm text-autonomi-error hover:bg-autonomi-error/10 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
+            :disabled="downloadComplete"
+            :title="downloadComplete ? 'Installing — please wait' : undefined"
+            @click="cancelDownload"
           >
-            Not Now
+            Cancel Download
           </button>
-          <button
-            v-if="!updaterStore.installing"
-            class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
-            @click="confirm"
-          >
-            Update &amp; Restart
-          </button>
+          <span v-else />
+
+          <div class="flex justify-end gap-2">
+            <button
+              v-if="!updaterStore.installing"
+              class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
+              @click="close"
+            >
+              Not Now
+            </button>
+            <button
+              v-if="!updaterStore.installing"
+              class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+              @click="confirm"
+            >
+              Update &amp; Restart
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -88,6 +104,8 @@ import { formatBytes } from '~/utils/formatters'
 
 const updaterStore = useUpdaterStore()
 
+const downloadComplete = computed(() => updaterStore.downloadProgress === 100)
+
 function close() {
   if (updaterStore.installing) return
   updaterStore.showDialog = false
@@ -95,6 +113,10 @@ function close() {
 
 function confirm() {
   updaterStore.installUpdate()
+}
+
+function cancelDownload() {
+  updaterStore.cancelInstall()
 }
 
 function renderMarkdown(text: string): string {

--- a/components/UpdateDialog.vue
+++ b/components/UpdateDialog.vue
@@ -43,8 +43,8 @@
         <!-- Download progress -->
         <div v-if="updaterStore.installing" class="mt-4">
           <div class="flex items-center justify-between text-xs text-autonomi-muted">
-            <span>Downloading...</span>
-            <span v-if="updaterStore.downloadProgress !== null">{{ updaterStore.downloadProgress }}%</span>
+            <span>{{ downloadComplete ? 'Download succeeded, the app will restart shortly' : 'Downloading...' }}</span>
+            <span v-if="!downloadComplete && updaterStore.downloadProgress !== null">{{ updaterStore.downloadProgress }}%</span>
           </div>
           <div class="mt-1.5 h-2 overflow-hidden rounded-full bg-autonomi-surface">
             <div
@@ -52,10 +52,10 @@
               :style="{ width: (updaterStore.downloadProgress ?? 0) + '%' }"
             />
           </div>
-          <p v-if="updaterStore.downloadTotal" class="mt-1 text-right text-[10px] text-autonomi-muted">
+          <p v-if="!downloadComplete && updaterStore.downloadTotal" class="mt-1 text-right text-[10px] text-autonomi-muted">
             {{ formatBytes(updaterStore.downloadedBytes) }} / {{ formatBytes(updaterStore.downloadTotal) }}
           </p>
-          <p class="mt-2 text-xs text-autonomi-muted">
+          <p v-if="!downloadComplete" class="mt-2 text-xs text-autonomi-muted">
             The app will restart automatically when complete.
           </p>
         </div>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -770,6 +770,7 @@ pub fn run() {
             autonomi_ops::get_connection_status,
             updater_channel::check_for_update_custom,
             updater_channel::install_pending_update,
+            updater_channel::cancel_pending_install,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/updater_channel.rs
+++ b/src-tauri/src/updater_channel.rs
@@ -21,10 +21,11 @@
 use crate::config::AppConfig;
 use reqwest::Url;
 use serde::Serialize;
+use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_updater::{Update, UpdaterExt};
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
 
 const STABLE_ENDPOINT: &str =
     "https://github.com/WithAutonomi/ant-ui/releases/latest/download/latest.json";
@@ -41,6 +42,12 @@ pub struct UpdaterChannelState {
     /// `Update` instance from `@tauri-apps/plugin-updater` doesn't apply here
     /// (we built the `UpdaterBuilder` ourselves with custom endpoints).
     pending_update: RwLock<Option<Update>>,
+    /// Set while a download is in flight. [`cancel_pending_install`] notifies
+    /// waiters to break the `tokio::select!` in `install_pending_update`. Only
+    /// honoured during download — once `install` starts, cancel becomes a
+    /// no-op because aborting mid-install would leave the user's `.app` in a
+    /// tempdir on macOS and brick their install.
+    cancel_notify: RwLock<Option<Arc<Notify>>>,
 }
 
 impl UpdaterChannelState {
@@ -48,6 +55,7 @@ impl UpdaterChannelState {
         Self {
             cached_prerelease_endpoint: RwLock::new(None),
             pending_update: RwLock::new(None),
+            cancel_notify: RwLock::new(None),
         }
     }
 }
@@ -79,6 +87,16 @@ enum DownloadEvent {
     },
     Finished,
 }
+
+#[derive(Serialize, Clone)]
+struct RestartFailedEvent {
+    version: String,
+}
+
+/// How long to wait after `app.restart()` before assuming the restart silently
+/// failed. A successful restart terminates the process within ~1-2s, so 10s is
+/// a comfortable buffer that won't false-positive on a slow main loop.
+const RESTART_WATCHDOG_DELAY: Duration = Duration::from_secs(10);
 
 /// Check for an available update on the channel selected in `AppConfig`.
 /// Returns `None` if the running version is already current.
@@ -118,10 +136,23 @@ pub async fn check_for_update_custom(app: AppHandle) -> Result<Option<UpdateMeta
 /// `Started` / `Progress` / `Finished` payloads matching the JS plugin's
 /// event shape, then restarts the app so the new binary is picked up.
 ///
-/// `download_and_install` only restarts on Windows (the NSIS/MSI installer
-/// exits the running process as part of its own flow). On Linux (AppImage)
-/// and macOS the new binary is written to disk but the running process keeps
-/// going — we have to call `app.restart()` ourselves or the UI hangs at 100%.
+/// We deliberately split `download` from `install` (rather than calling the
+/// combined `download_and_install`) so [`cancel_pending_install`] can drop
+/// the in-flight download future via `tokio::select!`. Once `install` starts
+/// we're past the cancel window — on macOS `install_inner` moves the running
+/// `.app` to a temp backup before extracting the new bundle into place, and
+/// aborting between those steps would leave the user with no app.
+///
+/// The plugin only triggers a process restart on Windows (its NSIS/MSI path
+/// calls `process::exit(0)` directly). Linux (AppImage) and macOS write the
+/// new binary to disk and return, so we call `app.restart()` ourselves.
+///
+/// `app.restart()` can silently fail on macOS: when invoked from a non-main
+/// thread (Tauri commands run on the tokio runtime), it asks the main loop
+/// to exit and sleeps forever. If the main loop doesn't honour the exit, the
+/// task hangs and the frontend never hears back. The watchdog spawned just
+/// before the restart catches that case and emits `update-restart-failed` so
+/// the UI can prompt the user to quit and reopen manually.
 #[tauri::command]
 pub async fn install_pending_update(app: AppHandle) -> Result<(), String> {
     let state = app.state::<UpdaterChannelState>();
@@ -132,33 +163,81 @@ pub async fn install_pending_update(app: AppHandle) -> Result<(), String> {
         .take()
         .ok_or("No pending update — call check_for_update_custom first")?;
 
+    let cancel_notify = Arc::new(Notify::new());
+    *state.cancel_notify.write().await = Some(cancel_notify.clone());
+
     let app_for_chunk = app.clone();
     let app_for_finish = app.clone();
     let mut emitted_started = false;
+    let update_version = update.version.clone();
 
-    update
-        .download_and_install(
-            move |chunk_length, content_length| {
-                if !emitted_started {
-                    emitted_started = true;
-                    let _ = app_for_chunk.emit(
-                        "update-download-event",
-                        DownloadEvent::Started { content_length },
-                    );
-                }
+    let download_fut = update.download(
+        move |chunk_length, content_length| {
+            if !emitted_started {
+                emitted_started = true;
                 let _ = app_for_chunk.emit(
                     "update-download-event",
-                    DownloadEvent::Progress { chunk_length },
+                    DownloadEvent::Started { content_length },
                 );
-            },
-            move || {
-                let _ = app_for_finish.emit("update-download-event", DownloadEvent::Finished);
-            },
-        )
-        .await
+            }
+            let _ = app_for_chunk.emit(
+                "update-download-event",
+                DownloadEvent::Progress { chunk_length },
+            );
+        },
+        move || {
+            let _ = app_for_finish.emit("update-download-event", DownloadEvent::Finished);
+        },
+    );
+
+    let bytes = tokio::select! {
+        res = download_fut => {
+            // Clear cancel handle as soon as download resolves — install is
+            // past the cancel window.
+            *state.cancel_notify.write().await = None;
+            res.map_err(|e| format!("Update download failed: {e}"))?
+        }
+        _ = cancel_notify.notified() => {
+            *state.cancel_notify.write().await = None;
+            return Err("CANCELLED".to_string());
+        }
+    };
+
+    update
+        .install(bytes)
         .map_err(|e| format!("Update install failed: {e}"))?;
 
+    // Watchdog: if `app.restart()` actually terminates the process, this
+    // thread dies with it before the sleep ends. If we're still alive after
+    // the delay, restart silently failed — surface to the UI.
+    let app_for_watchdog = app.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(RESTART_WATCHDOG_DELAY);
+        let _ = app_for_watchdog.emit(
+            "update-restart-failed",
+            RestartFailedEvent {
+                version: update_version,
+            },
+        );
+    });
+
     app.restart()
+}
+
+/// Cancel an in-flight download started by [`install_pending_update`]. No-op
+/// if no download is in flight. Returns `Err` if the install has already
+/// crossed into the uncancellable `install` step.
+#[tauri::command]
+pub async fn cancel_pending_install(app: AppHandle) -> Result<(), String> {
+    let state = app.state::<UpdaterChannelState>();
+    let notify = state
+        .cancel_notify
+        .read()
+        .await
+        .clone()
+        .ok_or("No cancellable install in progress")?;
+    notify.notify_waiters();
+    Ok(())
 }
 
 /// Decide which endpoint to use for this check based on the persisted

--- a/src-tauri/src/updater_channel.rs
+++ b/src-tauri/src/updater_channel.rs
@@ -190,16 +190,32 @@ pub async fn install_pending_update(app: AppHandle) -> Result<(), String> {
         },
     );
 
-    let bytes = tokio::select! {
+    let download_outcome = tokio::select! {
         res = download_fut => {
             // Clear cancel handle as soon as download resolves — install is
             // past the cancel window.
             *state.cancel_notify.write().await = None;
-            res.map_err(|e| format!("Update download failed: {e}"))?
+            res.map(Some).map_err(|e| format!("Update download failed: {e}"))
         }
         _ = cancel_notify.notified() => {
             *state.cancel_notify.write().await = None;
+            Ok(None)
+        }
+    };
+
+    // Restore the Update on cancel or download error so the user can retry
+    // from the same Update Available state without round-tripping through
+    // check_for_update_custom (which would otherwise hit "No pending update"
+    // because we take()'d it at the top of this function).
+    let bytes = match download_outcome {
+        Ok(Some(b)) => b,
+        Ok(None) => {
+            *state.pending_update.write().await = Some(update);
             return Err("CANCELLED".to_string());
+        }
+        Err(e) => {
+            *state.pending_update.write().await = Some(update);
+            return Err(e);
         }
     };
 

--- a/stores/updater.ts
+++ b/stores/updater.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { invoke } from '@tauri-apps/api/core'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { useToastStore } from './toasts'
 
 export interface CheckResult {
   ok: boolean
@@ -18,6 +19,10 @@ type DownloadEvent =
   | { event: 'Started'; data: { contentLength: number | null } }
   | { event: 'Progress'; data: { chunkLength: number } }
   | { event: 'Finished' }
+
+interface RestartFailedEvent {
+  version: string
+}
 
 // Inputs that the Rust side surfaces verbatim from tauri-plugin-updater's
 // errors. The plugin's wording is consistent across versions, so the same
@@ -51,6 +56,9 @@ export const useUpdaterStore = defineStore('updater', {
     /** Live listener for download progress while an install is in flight.
      *  Cleared on Finished or on install failure. */
     _downloadUnlisten: null as UnlistenFn | null,
+    /** Live listener for the Rust-side restart watchdog. Fires only on macOS/
+     *  Linux when `app.restart()` silently fails to terminate the process. */
+    _restartFailedUnlisten: null as UnlistenFn | null,
   }),
 
   getters: {
@@ -95,6 +103,8 @@ export const useUpdaterStore = defineStore('updater', {
       this.downloadedBytes = 0
       this.downloadTotal = null
 
+      const toasts = useToastStore()
+
       // Subscribe BEFORE invoking install so we don't lose the Started event
       // when the download is fast (small installer, warm CDN).
       this._downloadUnlisten = await listen<DownloadEvent>('update-download-event', (event) => {
@@ -107,15 +117,55 @@ export const useUpdaterStore = defineStore('updater', {
         // 'Finished' — Tauri will restart the app, no UI action needed.
       })
 
+      this._restartFailedUnlisten = await listen<RestartFailedEvent>('update-restart-failed', (event) => {
+        const v = event.payload.version
+        toasts.add(
+          `Update to v${v} installed but the app didn't restart. Quit and reopen Autonomi to finish updating.`,
+          'error',
+        )
+        this.installing = false
+        this._cleanupInstallListeners()
+      })
+
       try {
         await invoke('install_pending_update')
       } catch (e) {
-        console.error('Update install failed:', e)
-        this.installing = false
-        if (this._downloadUnlisten) {
-          this._downloadUnlisten()
-          this._downloadUnlisten = null
+        const raw = typeof e === 'string' ? e : ((e as any)?.message ?? String(e))
+        // The Rust side returns the literal string "CANCELLED" when the user
+        // hit Cancel Download — that's a normal exit, not an error to surface.
+        if (raw === 'CANCELLED') {
+          this.installing = false
+          this._cleanupInstallListeners()
+          return
         }
+        console.error('Update install failed:', e)
+        toasts.add(`Update install failed: ${raw}`, 'error')
+        this.installing = false
+        this._cleanupInstallListeners()
+      }
+    },
+
+    async cancelInstall() {
+      if (!this.installing) return
+      try {
+        await invoke('cancel_pending_install')
+      } catch (e) {
+        // No-op cases (already past the cancel window, no install in flight)
+        // surface as Err here. The user has already been waiting on the
+        // install screen — fall through; install_pending_update's own return
+        // path will resolve the dialog state.
+        console.warn('Cancel install failed (likely past cancel window):', e)
+      }
+    },
+
+    _cleanupInstallListeners() {
+      if (this._downloadUnlisten) {
+        this._downloadUnlisten()
+        this._downloadUnlisten = null
+      }
+      if (this._restartFailedUnlisten) {
+        this._restartFailedUnlisten()
+        this._restartFailedUnlisten = null
       }
     },
   },


### PR DESCRIPTION
## Summary

Three related fixes prompted by a macOS report where the Update Dialog reverts to "Update Available" after download with no indication anything went wrong:

- **Surface install errors as toasts.** Previously `console.error`'d only — testers had no signal. Now the actual error string lands in a toast so we can see what's failing.
- **Watchdog for silent restart failures on macOS.** `app.restart()` from a non-main thread (we're inside a tokio task) calls `request_exit` and sleeps forever waiting for the main loop. If the main loop doesn't honour the exit, the install task hangs and the frontend never hears back. A watchdog thread spawned just before `app.restart()` emits `update-restart-failed` 10s later if we're still alive — successful restarts kill the thread with the process. Toast: *"Update to vX.Y.Z installed but the app didn't restart. Quit and reopen Autonomi to finish updating."*
- **Cancel Download button.** Split `download_and_install` into separate `download` + `install` calls so the in-flight download can be cancelled via `tokio::select!` + `Notify`. New `cancel_pending_install` Tauri command. Dialog gets a destructive-outline button bottom-left during install; disabled at 100% because `install_inner` on macOS moves the running .app to a temp backup before extracting, and aborting between those steps would brick the install.

The watchdog and surfaced errors apply to all platforms; the cancel button is a UX win everywhere but matters most on macOS where the install path can sit waiting on an admin-privileges prompt.

## Test plan

- [ ] Linux: build locally, set version to `0.6.8-rc.3`, click Update & Restart against published rc.4, verify cancel mid-download dismisses the download cleanly and dialog returns to original state
- [ ] Linux: let download complete, verify install + restart still works (regression check)
- [ ] macOS: same flow — primary target. Watchdog should NOT fire on a healthy run; toast should appear if `app.restart()` silently fails
- [ ] Windows: regression — install path uses `process::exit(0)` inside `download_and_install` so neither cancel nor watchdog should fire under normal flow
- [ ] Provoke an install error (e.g. simulated permission denied on Linux) → verify install-failed toast shows the actual error string

🤖 Generated with [Claude Code](https://claude.com/claude-code)