### PR TITLE
chore: bump version to 0.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.6.8-rc.5",
+  "version": "0.6.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.6.8-rc.5"
+version = "0.6.8"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.6.8-rc.5"
+version = "0.6.8"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.6.8-rc.5",
+  "version": "0.6.8",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Stable promote of 0.6.8-rc.5 — Mac dev confirmed the cancel-download / restart-watchdog / surfaced-error fixes from #78 work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)