### PR TITLE
fix(files): surface real download errors and validate save-as filenames

### DIFF
--- a/components/files/DatamapSaveAsDialog.vue
+++ b/components/files/DatamapSaveAsDialog.vue
@@ -15,10 +15,14 @@
             v-model="filename"
             type="text"
             placeholder="myfile.dat"
-            class="w-full rounded-md border border-autonomi-border bg-autonomi-surface px-3 py-2 text-sm text-autonomi-text focus:border-autonomi-blue focus:outline-none"
+            :class="[
+              'w-full rounded-md border bg-autonomi-surface px-3 py-2 text-sm text-autonomi-text focus:outline-none',
+              filenameError ? 'border-red-500 focus:border-red-500' : 'border-autonomi-border focus:border-autonomi-blue',
+            ]"
             @keyup.enter="confirm"
             @keyup.escape="$emit('close')"
           />
+          <p v-if="filenameError" class="mt-1 text-xs text-red-400">{{ filenameError }}</p>
         </div>
 
         <div class="flex justify-end gap-2">
@@ -52,10 +56,16 @@ const emit = defineEmits<{
   confirm: [filename: string]
 }>()
 
+import { filenameError as checkFilename } from '~/utils/validators'
+
 const inputEl = ref<HTMLInputElement | null>(null)
 const filename = ref('')
 
-const valid = computed(() => filename.value.trim().length > 0)
+const filenameError = computed(() => checkFilename(filename.value))
+
+const valid = computed(
+  () => filename.value.trim().length > 0 && filenameError.value === null,
+)
 
 watch(() => props.open, (val) => {
   if (val) {

--- a/components/files/DownloadDialog.vue
+++ b/components/files/DownloadDialog.vue
@@ -27,9 +27,13 @@
             v-model="filename"
             type="text"
             placeholder="myfile.dat"
-            class="w-full rounded-md border border-autonomi-border bg-autonomi-surface px-3 py-2 text-sm text-autonomi-text focus:border-autonomi-blue focus:outline-none"
+            :class="[
+              'w-full rounded-md border bg-autonomi-surface px-3 py-2 text-sm text-autonomi-text focus:outline-none',
+              filenameError ? 'border-red-500 focus:border-red-500' : 'border-autonomi-border focus:border-autonomi-blue',
+            ]"
             @keyup.enter="confirm"
           />
+          <p v-if="filenameError" class="mt-1 text-xs text-red-400">{{ filenameError }}</p>
         </div>
 
         <div class="flex justify-end gap-2">
@@ -59,14 +63,18 @@ const emit = defineEmits<{
   download: [address: string, filename: string]
 }>()
 
+import { filenameError as checkFilename } from '~/utils/validators'
+
 const inputEl = ref<HTMLInputElement | null>(null)
 const address = ref('')
 const filename = ref('')
 
+const filenameError = computed(() => checkFilename(filename.value))
+
 const valid = computed(() => {
   const addr = address.value.trim()
   const isHex = /^(0x)?[0-9a-fA-F]{8,}$/.test(addr)
-  return isHex && filename.value.trim().length > 0
+  return isHex && filename.value.trim().length > 0 && filenameError.value === null
 })
 
 watch(() => props.open, (val) => {

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -1119,8 +1119,9 @@ fn expand_tilde(path: &str) -> PathBuf {
 ///
 /// Used by the "Download by datamap" flow: the user picks a `.datamap` file
 /// via the OS file dialog, and the frontend forwards the returned JSON to
-/// `download_file`. The path is trusted (chosen by the user through the
-/// native picker); we only validate that the file parses as UTF-8.
+/// `download_file`. Delegates format detection to `ant_core::data::read_datamap`
+/// (msgpack canonical, JSON legacy — sniffed by first byte), then re-encodes as
+/// JSON so the JS side keeps a single `data_map_json` contract.
 #[tauri::command]
 pub fn read_datamap_file(path: String) -> Result<String, String> {
     let canonical =
@@ -1128,7 +1129,10 @@ pub fn read_datamap_file(path: String) -> Result<String, String> {
     if !canonical.is_file() {
         return Err(format!("Not a regular file: {path}"));
     }
-    std::fs::read_to_string(&canonical).map_err(|e| format!("Failed to read {path}: {e}"))
+    let data_map = ant_core::data::read_datamap(&canonical)
+        .map_err(|e| format!("Failed to read datamap at {path}: {e}"))?;
+    serde_json::to_string(&data_map)
+        .map_err(|e| format!("Failed to encode datamap at {path}: {e}"))
 }
 
 /// Check if the data client is currently connected.

--- a/src-tauri/src/autonomi_ops.rs
+++ b/src-tauri/src/autonomi_ops.rs
@@ -1131,8 +1131,7 @@ pub fn read_datamap_file(path: String) -> Result<String, String> {
     }
     let data_map = ant_core::data::read_datamap(&canonical)
         .map_err(|e| format!("Failed to read datamap at {path}: {e}"))?;
-    serde_json::to_string(&data_map)
-        .map_err(|e| format!("Failed to encode datamap at {path}: {e}"))
+    serde_json::to_string(&data_map).map_err(|e| format!("Failed to encode datamap at {path}: {e}"))
 }
 
 /// Check if the data client is currently connected.

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -740,7 +740,7 @@ export const useFilesStore = defineStore('files', {
         toasts.add(`Upload complete: ${entry.name}`, 'info')
       } catch (e: any) {
         this.updateEntry(id, { status: 'failed', error: e.message ?? String(e) })
-        toasts.add(`Upload failed: ${entry.name} — ${e.message}`, 'error')
+        toasts.add(`Upload failed: ${entry.name} — ${e.message ?? e}`, 'error')
       }
     },
 
@@ -778,7 +778,7 @@ export const useFilesStore = defineStore('files', {
         toasts.add(`Upload complete: ${entry.name}`, 'info')
       } catch (e: any) {
         this.updateEntry(id, { status: 'failed', error: e.message ?? String(e) })
-        toasts.add(`Upload failed: ${entry.name} — ${e.message}`, 'error')
+        toasts.add(`Upload failed: ${entry.name} — ${e.message ?? e}`, 'error')
       }
     },
 
@@ -882,7 +882,7 @@ export const useFilesStore = defineStore('files', {
         toasts.add(`Download complete: ${entry.name}`, 'info')
       } catch (e: any) {
         this.updateEntry(id, { status: 'failed', error: e.message ?? String(e) })
-        toasts.add(`Download failed: ${entry.name} — ${e.message}`, 'error')
+        toasts.add(`Download failed: ${entry.name} — ${e.message ?? e}`, 'error')
       }
     },
 

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -1,3 +1,25 @@
 export function isValidEthAddress(addr: string): boolean {
   return /^0x[0-9a-fA-F]{40}$/.test(addr)
 }
+
+// Windows-reserved set is the strict superset across platforms — rejecting it
+// everywhere keeps the same filename portable to any host. Forward/backslash
+// would also be path-traversal; null + control chars are never valid.
+const RESERVED_FILENAME_CHARS = /[<>:"/\\|?*\x00-\x1f]/
+const RESERVED_FILENAME_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|$)/i
+
+/**
+ * Validate a user-typed "Save as" filename against the cross-platform reserved
+ * set. Returns an error message for the UI, or null when the name is safe to
+ * pass to the OS. An empty/whitespace-only string returns null so the caller
+ * can decide whether emptiness is itself an error (most callers gate the
+ * submit button on `name.trim().length > 0` separately).
+ */
+export function filenameError(name: string): string | null {
+  const trimmed = name.trim()
+  if (trimmed.length === 0) return null
+  if (RESERVED_FILENAME_CHARS.test(trimmed)) return 'Filename cannot contain special characters'
+  if (/[. ]$/.test(trimmed)) return 'Filename cannot end with a dot or space'
+  if (RESERVED_FILENAME_NAMES.test(trimmed)) return `${trimmed} is a reserved name on Windows`
+  return null
+}


### PR DESCRIPTION
## Summary

- Replace `\${e.message}` (which renders "undefined" for plain-string Tauri rejections) with `\${e.message ?? e}` on upload + download error toasts in `stores/files.ts`
- Add a shared `filenameError` validator in `utils/validators.ts` and wire it into `DownloadDialog.vue` + `DatamapSaveAsDialog.vue` so reserved chars, trailing dot/space, and Windows reserved names are rejected at the input with an inline message
- Switch `read_datamap_file` to delegate to `ant_core::data::read_datamap` so ant-cli-produced msgpack datamaps load (previously rejected as non-UTF-8); re-encode to JSON to keep the existing `data_map_json` JS contract

Closes #81.

## Test plan

- [x] Reserved-char filename (`my:file.dat`) blocks the Download button with an inline error
- [x] Kanji filename passes validation and downloads end-to-end on Windows
- [x] An ant-cli-produced msgpack `.datamap` file loads via the picker without "stream did not contain valid UTF-8"
- [x] Download error toasts now show the real Rust error string instead of "undefined"
- [x] `cargo check --no-default-features` passes