### PR TITLE
docs(build): document sidecar download for source builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,32 @@ The app will open automatically. The node daemon is started on first launch.
 
 ## Building
 
+The Tauri bundle expects an `ant` daemon binary at
+`src-tauri/binaries/ant-<host-triple>` (its [externalBin sidecar][sidecar]).
+Fetch a prebuilt one from the latest [`ant-client`][ant-client] release before
+your first build:
+
+```bash
+# Linux/macOS
+scripts/download-sidecar.sh
+
+# Windows
+.\scripts\download-sidecar.ps1
+```
+
+Pin a specific version with `ANT_TAG=ant-cli-vX.Y.Z` if needed. If you have a
+local `ant-client` checkout next to this repo, `scripts/setup-sidecar.sh` (or
+`.ps1`) will build the binary from source instead.
+
 ```bash
 # Build for production
 npm run tauri build
 ```
 
 Produces platform-specific installers in `src-tauri/target/release/bundle/`.
+
+[sidecar]: https://v2.tauri.app/develop/sidecar/
+[ant-client]: https://github.com/WithAutonomi/ant-client/releases
 
 ## Project Structure
 

--- a/scripts/download-sidecar.ps1
+++ b/scripts/download-sidecar.ps1
@@ -1,0 +1,82 @@
+# Download a prebuilt ant daemon sidecar from the WithAutonomi/ant-client
+# GitHub releases and place it where Tauri expects it. Mirrors the
+# `download ant daemon sidecar` step in .github/workflows/release.yml so
+# that building from source works without cloning ant-client too.
+#
+# Usage:
+#   .\scripts\download-sidecar.ps1                   # latest ant-client release
+#   $env:ANT_TAG = "ant-cli-v0.1.2"; .\scripts\download-sidecar.ps1
+$ErrorActionPreference = "Stop"
+
+$GuiDir = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+
+# Tauri target triple (e.g. x86_64-pc-windows-msvc)
+$CrossTarget = (rustc -vV | Select-String "^host:").ToString().Split(" ")[1]
+if (-not $CrossTarget) {
+    Write-Error "Could not determine host triple from rustc"
+    exit 1
+}
+
+# ant-client publishes musl builds for Linux; map gnu -> musl for the asset name.
+$AntTarget = $CrossTarget -replace "unknown-linux-gnu", "unknown-linux-musl"
+
+# Resolve tag (latest by default)
+$AntTag = $env:ANT_TAG
+if (-not $AntTag) {
+    Write-Host "Resolving latest ant-client release..."
+    $latest = Invoke-RestMethod -Uri "https://api.github.com/repos/WithAutonomi/ant-client/releases/latest"
+    $AntTag = $latest.tag_name
+    if (-not $AntTag) {
+        Write-Error "Could not resolve latest ant-client release"
+        exit 1
+    }
+}
+$AntVersion = $AntTag -replace "^ant-cli-v", ""
+
+# Asset extension differs by OS
+$Ext = if ($AntTarget -like "*windows*") { "zip" } else { "tar.gz" }
+$Asset = "ant-${AntVersion}-${AntTarget}.${Ext}"
+
+$TmpDir = New-Item -ItemType Directory -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())) -Force
+try {
+    $Url = "https://github.com/WithAutonomi/ant-client/releases/download/${AntTag}/${Asset}"
+    Write-Host "Downloading $Asset from $AntTag"
+    $AssetPath = Join-Path $TmpDir $Asset
+    Invoke-WebRequest -Uri $Url -OutFile $AssetPath -UseBasicParsing
+
+    if ($Ext -eq "zip") {
+        Expand-Archive -Path $AssetPath -DestinationPath $TmpDir -Force
+    } else {
+        # tar.exe ships with Windows 10+; same flags as GNU tar for our use.
+        tar -xzf $AssetPath -C $TmpDir
+    }
+
+    $ExtractedDir = Join-Path $TmpDir "ant-${AntVersion}-${AntTarget}"
+    $BinDir = Join-Path $GuiDir "src-tauri\binaries"
+    New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+
+    if ($AntTarget -like "*windows*") {
+        Copy-Item (Join-Path $ExtractedDir "ant.exe") `
+                  (Join-Path $BinDir "ant-${CrossTarget}.exe") -Force
+        Write-Host "Sidecar binary installed: src-tauri\binaries\ant-${CrossTarget}.exe"
+    } else {
+        Copy-Item (Join-Path $ExtractedDir "ant") `
+                  (Join-Path $BinDir "ant-${CrossTarget}") -Force
+        Write-Host "Sidecar binary installed: src-tauri\binaries\ant-${CrossTarget}"
+    }
+
+    # Bundle the bootstrap_peers.toml that ships with this daemon version so the
+    # embedded ant-core client can connect on a fresh install.
+    $PeersSrc = Join-Path $ExtractedDir "bootstrap_peers.toml"
+    if (Test-Path $PeersSrc) {
+        $ResourceDir = Join-Path $GuiDir "src-tauri\resources"
+        New-Item -ItemType Directory -Force -Path $ResourceDir | Out-Null
+        Copy-Item $PeersSrc (Join-Path $ResourceDir "bootstrap_peers.toml") -Force
+        Write-Host "Bootstrap peers refreshed: src-tauri\resources\bootstrap_peers.toml"
+    } else {
+        Write-Warning "bootstrap_peers.toml not found in $Asset — keeping vendored snapshot"
+    }
+}
+finally {
+    Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
+}

--- a/scripts/download-sidecar.sh
+++ b/scripts/download-sidecar.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Download a prebuilt ant daemon sidecar from the WithAutonomi/ant-client
+# GitHub releases and place it where Tauri expects it. Mirrors the
+# `download ant daemon sidecar` step in .github/workflows/release.yml so
+# that building from source works without cloning ant-client too.
+#
+# Usage:
+#   scripts/download-sidecar.sh                  # latest ant-client release
+#   ANT_TAG=ant-cli-v0.1.2 scripts/download-sidecar.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GUI_DIR="$(dirname "$SCRIPT_DIR")"
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "error: '$1' is required but not installed" >&2
+        exit 1
+    }
+}
+
+require curl
+require tar
+
+# Tauri target triple (e.g. x86_64-unknown-linux-gnu)
+CROSS_TARGET=$(rustc -vV | awk '/^host:/ {print $2}')
+if [ -z "$CROSS_TARGET" ]; then
+    echo "error: could not determine host triple from rustc" >&2
+    exit 1
+fi
+
+# ant-client publishes musl builds for Linux; map gnu -> musl for the asset name.
+ANT_TARGET="${CROSS_TARGET/unknown-linux-gnu/unknown-linux-musl}"
+
+# Resolve tag (latest by default)
+if [ -z "${ANT_TAG:-}" ]; then
+    echo "Resolving latest ant-client release..."
+    ANT_TAG=$(curl -fsSL https://api.github.com/repos/WithAutonomi/ant-client/releases/latest \
+        | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' \
+        | head -n1 | sed 's/.*"\([^"]*\)"$/\1/')
+    if [ -z "$ANT_TAG" ]; then
+        echo "error: could not resolve latest ant-client release" >&2
+        exit 1
+    fi
+fi
+ANT_VERSION="${ANT_TAG#ant-cli-v}"
+
+# Asset extension differs by OS
+case "$ANT_TARGET" in
+    *windows*) EXT="zip" ;;
+    *)         EXT="tar.gz" ;;
+esac
+ASSET="ant-${ANT_VERSION}-${ANT_TARGET}.${EXT}"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+URL="https://github.com/WithAutonomi/ant-client/releases/download/${ANT_TAG}/${ASSET}"
+echo "Downloading $ASSET from $ANT_TAG"
+curl -fsSL -o "$TMPDIR/$ASSET" "$URL"
+
+if [ "$EXT" = "tar.gz" ]; then
+    tar -xzf "$TMPDIR/$ASSET" -C "$TMPDIR"
+else
+    require unzip
+    unzip -q "$TMPDIR/$ASSET" -d "$TMPDIR"
+fi
+
+EXTRACTED_DIR="$TMPDIR/ant-${ANT_VERSION}-${ANT_TARGET}"
+mkdir -p "$GUI_DIR/src-tauri/binaries"
+case "$ANT_TARGET" in
+    *windows*)
+        cp "$EXTRACTED_DIR/ant.exe" "$GUI_DIR/src-tauri/binaries/ant-${CROSS_TARGET}.exe"
+        echo "Sidecar binary installed: src-tauri/binaries/ant-${CROSS_TARGET}.exe"
+        ;;
+    *)
+        cp "$EXTRACTED_DIR/ant" "$GUI_DIR/src-tauri/binaries/ant-${CROSS_TARGET}"
+        chmod +x "$GUI_DIR/src-tauri/binaries/ant-${CROSS_TARGET}"
+        echo "Sidecar binary installed: src-tauri/binaries/ant-${CROSS_TARGET}"
+        ;;
+esac
+
+# Bundle the bootstrap_peers.toml that ships with this daemon version so the
+# embedded ant-core client can connect on a fresh install.
+PEERS_SRC="$EXTRACTED_DIR/bootstrap_peers.toml"
+if [ -f "$PEERS_SRC" ]; then
+    mkdir -p "$GUI_DIR/src-tauri/resources"
+    cp "$PEERS_SRC" "$GUI_DIR/src-tauri/resources/bootstrap_peers.toml"
+    echo "Bootstrap peers refreshed: src-tauri/resources/bootstrap_peers.toml"
+else
+    echo "Warning: bootstrap_peers.toml not found in $ASSET — keeping vendored snapshot"
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/download-sidecar.{sh,ps1}` that pull the prebuilt `ant` daemon from the latest [`ant-client`](https://github.com/WithAutonomi/ant-client/releases) release (override with `ANT_TAG=ant-cli-vX.Y.Z`). Mirrors the `download ant daemon sidecar` step in `release.yml`.
- Updates the README's "Building" section to call out the sidecar requirement and point at the new helper, with the existing `setup-sidecar.sh` retained as the from-source path for devs with a sibling `ant-client` checkout.

Background: building from a fresh clone fails with `resource path 'binaries/ant-x86_64-unknown-linux-gnu' doesn't exist` because the Tauri `externalBin` sidecar isn't checked in and the only existing helper assumes you've also cloned and built ant-client.

Closes #62

## Test plan
- [x] `bash scripts/download-sidecar.sh` on Linux: downloads `ant-0.2.1-x86_64-unknown-linux-musl.tar.gz`, places `src-tauri/binaries/ant-x86_64-unknown-linux-gnu`, refreshes `bootstrap_peers.toml`. `ant --version` prints `ant 0.2.1`.
- [ ] Same on macOS (host triple resolves to `*-apple-darwin`, asset extension `tar.gz`).
- [ ] `.\scripts\download-sidecar.ps1` on Windows (host triple `*-pc-windows-msvc`, asset extension `zip`).
- [x] CI's existing fmt/clippy/check stub flow is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)