### PR TITLE
fix(linux): disable WebKit DMA-BUF renderer by default

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -708,6 +708,20 @@ fn save_upload_history(entries: Vec<UploadHistoryEntry>) -> Result<(), String> {
 }
 
 pub fn run() {
+    // WebKitGTK's DMA-BUF renderer (default since 2.42) trips over recent Mesa
+    // and proprietary NVIDIA drivers, surfacing as "Could not create default
+    // EGL display: EGL_BAD_PARAMETER" and an immediate WebKitWebProcess SIGABRT
+    // before the window draws (see issue #63). Disabling the DMA-BUF path and
+    // falling back to the GLX/software compositor is the upstream-recommended
+    // workaround. We only set defaults — users can re-enable by exporting the
+    // var to "0" themselves.
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+    }
+
     // Pipe ant-core / ant-node tracing events to stderr so the dev console
     // surfaces upload progress (encrypt → quote → store → finalize). Without
     // a subscriber installed every `tracing::info!()` from those crates is


### PR DESCRIPTION
## Summary
- On Linux, set `WEBKIT_DISABLE_DMABUF_RENDERER=1` at the top of `run()` if the env var isn't already set. Falls back to the GLX/software compositor path; users can opt back in by exporting `WEBKIT_DISABLE_DMABUF_RENDERER=0` before launch.

Background: WebKitGTK's DMA-BUF renderer (default since 2.42) is unstable on recent Mesa and proprietary NVIDIA drivers. On affected systems WebKitWebProcess SIGABRTs before the window draws with `Could not create default EGL display: EGL_BAD_PARAMETER` — reproduced on stock Arch Linux against the v0.6.6 and v0.6.7 AppImages. This is the upstream-recommended workaround (see [tauri-apps/tauri#9394](https://github.com/tauri-apps/tauri/issues/9394), [webkit#261874](https://bugs.webkit.org/show_bug.cgi?id=261874)).

Closes #63

## Test plan
- [x] `cargo check` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` clean.
- [ ] Build the AppImage on the next release and confirm it launches on Arch Linux.
- [ ] Confirm dev mode still launches normally on Linux (`npm run tauri:dev`).
- [ ] Confirm that exporting `WEBKIT_DISABLE_DMABUF_RENDERER=0` before launch re-enables the DMA-BUF path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)