### PR TITLE
chore: bump GitHub Actions to v5 and dedupe daemon-api type names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     name: frontend (typecheck + test)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: npm
@@ -42,9 +42,9 @@ jobs:
           - check: build
             command: cargo check --manifest-path src-tauri/Cargo.toml
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       ant_tag: ${{ steps.resolve.outputs.ant_tag }}
       ant_version: ${{ steps.resolve.outputs.ant_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: resolve version
         id: resolve
@@ -89,9 +89,9 @@ jobs:
             args: "--target x86_64-apple-darwin"
             slug: macos-x86_64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: npm
@@ -323,9 +323,9 @@ jobs:
       SM_LOG_LEVEL: trace
       SM_LOG_FILE: ${{ github.workspace }}\smctl-signing.log
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: npm

--- a/stores/nodes.ts
+++ b/stores/nodes.ts
@@ -3,7 +3,7 @@ import { useToastStore } from './toasts'
 import { useSettingsStore } from './settings'
 import { invoke } from '@tauri-apps/api/core'
 import { daemonApi, connectSSE, disconnectSSE, type NodeEvent } from '~/utils/daemon-api'
-import type { NodeStatusSummary, NodeStatus as ApiNodeStatus, DaemonStatus } from '~/utils/daemon-api'
+import type { NodeStatusSummary, ApiNodeStatus, DaemonStatus } from '~/utils/daemon-api'
 import { POLL_INTERVAL, DETAIL_POLL_INTERVAL } from '~/utils/constants'
 import type { UnlistenFn } from '@tauri-apps/api/event'
 

--- a/utils/daemon-api.ts
+++ b/utils/daemon-api.ts
@@ -4,7 +4,7 @@ import { useSettingsStore } from '~/stores/settings'
 
 // ── Types matching ant-core/src/node/types.rs ──
 
-export type NodeStatus =
+export type ApiNodeStatus =
   | 'stopped'
   | 'starting'
   | 'running'
@@ -30,10 +30,10 @@ export interface NodeConfig {
   bootstrap_peers: string[]
 }
 
-// NodeInfo: ant-core uses #[serde(flatten)] on config, so all NodeConfig
+// ApiNodeInfo: ant-core uses #[serde(flatten)] on config, so all NodeConfig
 // fields appear at the top level alongside status/pid/uptime_secs.
-export interface NodeInfo extends NodeConfig {
-  status: NodeStatus
+export interface ApiNodeInfo extends NodeConfig {
+  status: ApiNodeStatus
   pid: number | null
   uptime_secs: number | null
 }
@@ -42,7 +42,7 @@ export interface NodeStatusSummary {
   node_id: number
   name: string
   version: string
-  status: NodeStatus
+  status: ApiNodeStatus
   pid?: number
   uptime_secs?: number
   /** Set only when `status === 'upgrade_scheduled'`: the new version that the
@@ -170,7 +170,7 @@ export const daemonApi = {
   nodesStatus: () => request<NodeStatusResult>('GET', '/api/v1/nodes/status'),
 
   /** GET /api/v1/nodes/:id — full config + runtime state */
-  nodeDetail: (id: number) => request<NodeInfo>('GET', `/api/v1/nodes/${id}`),
+  nodeDetail: (id: number) => request<ApiNodeInfo>('GET', `/api/v1/nodes/${id}`),
 
   /** POST /api/v1/nodes */
   addNodes: (opts: AddNodeOpts) => request<AddNodeResult>('POST', '/api/v1/nodes', opts),


### PR DESCRIPTION
## Summary

Two small unrelated cleanups bundled to keep churn low.

- Bump \`actions/checkout@v4\` → \`@v5\` and \`actions/setup-node@v4\` → \`@v5\` in \`ci.yml\` and \`release.yml\` (9 sites). Both v5 majors run on Node.js 24 — required before GitHub forces Node 24 default on **June 2nd, 2026**.
- Rename \`NodeStatus\` / \`NodeInfo\` in \`utils/daemon-api.ts\` to \`ApiNodeStatus\` / \`ApiNodeInfo\` to silence the Nuxt auto-import warning that fires on every typecheck/test run:

  \`\`\`
  [warn] Duplicated imports "NodeStatus", the one from "utils/daemon-api.ts"
  has been ignored and "stores/nodes.ts" is used
  \`\`\`

  \`stores/nodes.ts\` was already aliasing on import (\`NodeStatus as ApiNodeStatus\`), so the new names just match the existing local convention. No behaviour change.

## Test plan

- [x] \`npx nuxi typecheck\` — Duplicated-imports warnings no longer appear; no new TS errors in app code
- [ ] CI green on this PR