### PR TITLE
fix(wallet): direct-wallet RPC override + clean disconnect

### DIFF
--- a/composables/useDevnetWallet.ts
+++ b/composables/useDevnetWallet.ts
@@ -98,6 +98,15 @@ export function getDevnetAccount(): PrivateKeyAccount | null {
   return devnetAccount
 }
 
+/** Drop the cached devnet wagmi config + viem account so a subsequent
+ *  `initDevnetWallet` rebuilds from scratch. Called from
+ *  `disconnectDirectWallet` to prevent the next upload from routing through
+ *  the stale config after the user has cleared their key. */
+export function disposeDevnetWallet() {
+  devnetWagmiConfig = null
+  devnetAccount = null
+}
+
 /** Refresh balances for the devnet wallet. */
 async function refreshDevnetBalances() {
   const walletStore = useWalletStore()

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -332,6 +332,18 @@
               </select>
             </div>
             <div>
+              <label class="mb-1 block text-xs text-autonomi-muted">
+                RPC URL <span class="text-autonomi-muted/60">(optional)</span>
+              </label>
+              <input
+                v-model="directWalletRpcInput"
+                type="text"
+                autocomplete="off"
+                placeholder="Defaults to public RPC for the selected chain"
+                class="w-full rounded-md border border-autonomi-border bg-autonomi-dark px-3 py-1.5 font-mono text-xs text-autonomi-text placeholder-autonomi-muted focus:border-autonomi-blue focus:outline-none"
+              />
+            </div>
+            <div>
               <label class="mb-1 block text-xs text-autonomi-muted">Private Key</label>
               <input
                 v-model="directWalletKeyInput"
@@ -602,6 +614,11 @@ async function restartDaemon() {
 const editingDirectWallet = ref(false)
 const directWalletKeyInput = ref('')
 const directWalletNetwork = ref('arbitrum-sepolia')
+/** Optional user-provided RPC URL. When empty, the chain branch in
+ *  `connectDirectWallet` falls back to the public RPC (Sepolia rollup,
+ *  arb1.arbitrum.io). Lets paid-RPC users plug in their own endpoint
+ *  instead of being rate-limited by public infra during merkle uploads. */
+const directWalletRpcInput = ref('')
 const directWalletError = ref('')
 const directWalletActive = ref(false)
 
@@ -617,18 +634,19 @@ async function connectDirectWallet() {
 
     // Configure the network based on selection
     const isSepolia = directWalletNetwork.value === 'arbitrum-sepolia'
+    const rpcOverride = directWalletRpcInput.value.trim() || null
     setDevnetWalletKey(key)
     settingsStore._devnetWalletKeySet = true
     settingsStore.devnetActive = true
     if (isSepolia) {
       settingsStore.devnetChainId = arbitrumSepolia.id
-      settingsStore.devnetRpcUrl = 'https://sepolia-rollup.arbitrum.io/rpc'
+      settingsStore.devnetRpcUrl = rpcOverride ?? 'https://sepolia-rollup.arbitrum.io/rpc'
       settingsStore.devnetTokenAddress = '0x4bc1aCE0E66170375462cB4E6Af42Ad4D5EC689C'
       settingsStore.devnetVaultAddress = '0xd742E8CFEf27A9a884F3EFfA239Ee2F39c276522'
     } else {
       // Arbitrum One mainnet — use mainnet token/vault defaults via wallet-config.
       settingsStore.devnetChainId = arbitrum.id
-      settingsStore.devnetRpcUrl = null
+      settingsStore.devnetRpcUrl = rpcOverride
       settingsStore.devnetTokenAddress = null
       settingsStore.devnetVaultAddress = null
     }
@@ -662,13 +680,14 @@ async function connectDirectWallet() {
     directWalletActive.value = true
     editingDirectWallet.value = false
     directWalletKeyInput.value = ''
+    directWalletRpcInput.value = ''
     toasts.add(`Wallet connected: ${walletStore.paymentAddress}`, 'info')
   } catch (e: any) {
     directWalletError.value = e.message ?? 'Failed to import key'
   }
 }
 
-function disconnectDirectWallet() {
+async function disconnectDirectWallet() {
   walletStore.connected = false
   walletStore.paymentAddress = null
   walletStore.balance = null
@@ -677,6 +696,19 @@ function disconnectDirectWallet() {
   directWalletActive.value = false
   setDevnetWalletKey(null)
   settingsStore._devnetWalletKeySet = false
+  // Clear devnet-routing settings so the next upload falls back to the
+  // external-signer (WalletConnect) path. Leaving these set means the next
+  // upload still tries the direct-wallet route with no key and errors out
+  // with "Wallet not connected".
+  settingsStore.devnetActive = false
+  settingsStore.devnetChainId = null
+  settingsStore.devnetRpcUrl = null
+  settingsStore.devnetTokenAddress = null
+  settingsStore.devnetVaultAddress = null
+  // Drop the module-scope wagmi config + viem account so a re-import has to
+  // rebuild from scratch.
+  const { disposeDevnetWallet } = await import('~/composables/useDevnetWallet')
+  disposeDevnetWallet()
   toasts.add('Wallet disconnected', 'info')
 }
 


### PR DESCRIPTION
## Summary

Two sibling direct-wallet fixes.

- **RPC URL override** — adds an optional \`RPC URL\` input to the direct-wallet import form. Plumbing already honoured \`settings.devnetRpcUrl\`; users on paid RPC keys can now plug them in instead of being rate-limited by public Arbitrum infra during merkle uploads.
- **Disconnect leaks devnet state** — \`disconnectDirectWallet\` previously cleared the wallet store + key but left \`devnetActive\`, the devnet chain id, RPC URL, token/vault overrides, and the module-scope wagmi config + viem account intact. Next upload routed through the direct-wallet path with no signer and errored \"Wallet not connected\". Now also clears the four devnet settings fields and calls a new \`disposeDevnetWallet\` from \`composables/useDevnetWallet.ts\` that nulls the cached config + account.

## Out of scope

The Rust client's attached wallet stays attached after disconnect — no \`detach_wallet\` command exists yet. Not reachable in practice (JS routing gates this), but worth a follow-up.

## Test plan

- [ ] Import a private key with the RPC URL field empty → connects with public RPC fallback
- [ ] Import with a custom RPC URL → balances/uploads use the custom endpoint
- [ ] Disconnect, then trigger an upload → routes through WalletConnect (or fails cleanly with \"connect a wallet\"), not silently \"Wallet not connected\"
- [ ] Disconnect then re-import → fresh wagmi config, no stale account