### PR TITLE
fix(walletconnect): override window.location.origin so the modal shows our URL

### DIFF
--- a/plugins/00.walletconnect-origin.client.ts
+++ b/plugins/00.walletconnect-origin.client.ts
@@ -1,0 +1,33 @@
+import { APPKIT_METADATA } from '~/utils/wallet-config'
+
+/**
+ * Override `window.location.origin` so the WalletConnect modal shows our
+ * production URL instead of the Tauri webview's "tauri://localhost" origin.
+ *
+ * `@walletconnect/utils::populateAppMetadata` silently substitutes
+ * `window.location.origin` for our `metadata.url` regardless of what we
+ * configure in `APPKIT_METADATA`. Reown Cloud verification of the project
+ * would be the canonical fix, but in the meantime overriding the getter
+ * upstream of every read keeps the modal honest.
+ *
+ * Nothing in the app reads `location.origin` itself — verified via grep at
+ * commit time — so the override is global. `00.` prefix forces this plugin
+ * to load before `appkit.client.ts` so the override is in place by the
+ * time AppKit's wallet-connect modal calls `populateAppMetadata` on user
+ * action.
+ */
+export default defineNuxtPlugin(() => {
+  if (typeof window === 'undefined') return
+
+  try {
+    Object.defineProperty(window.location, 'origin', {
+      get: () => APPKIT_METADATA.url,
+      configurable: true,
+    })
+  } catch (err) {
+    // Some browsers / webview versions disallow redefining built-in
+    // location properties. Fail soft — the modal still works, it just
+    // shows the Tauri origin.
+    console.warn('Failed to override window.location.origin:', err)
+  }
+})


### PR DESCRIPTION
## Summary

The WalletConnect modal has been showing 'localhost' as the requesting origin because \`@walletconnect/utils::populateAppMetadata\` reads \`window.location.origin\` and substitutes it for the configured \`metadata.url\`. On Tauri the origin is \`tauri://localhost\` — hence the user-visible \"localhost\" string.

Override \`window.location.origin\` via \`Object.defineProperty\` in a client plugin that loads before AppKit (\`00.\` prefix forces alphabetical-first order). The override returns \`APPKIT_METADATA.url\` (\`https://autonomi.com\`) for every read, so \`populateAppMetadata\` picks the right value.

Grep-verified that nothing in app code reads \`location.origin\` itself, so the override is global and side-effect-free. The redefinition is wrapped in try/catch: if a webview version disallows redefining built-ins, the modal still works (just shows the Tauri origin — current status quo).

## Out of scope

The proper fix is Reown Cloud project verification of our project ID, which needs dashboard access — owner currently unknown. When that lands, this plugin can be removed.

## Test plan

- [ ] Open the WalletConnect connect sheet (Settings → Connect Wallet) on Windows/macOS — origin shown matches \`https://autonomi.com\`, not \`localhost\`
- [ ] Wallet pairing still completes end-to-end (the override should be invisible to wagmi/AppKit's normal flow)
- [ ] No console errors / warnings from the property redefinition