### PR TITLE
fix(walletconnect): label chain picker entries Mainnet vs Testnet

### DIFF
--- a/plugins/appkit.client.ts
+++ b/plugins/appkit.client.ts
@@ -3,6 +3,17 @@ import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 import { arbitrumSepolia } from '@reown/appkit/networks'
 import { WALLETCONNECT_PROJECT_ID, SUPPORTED_CHAIN, APPKIT_METADATA } from '~/utils/wallet-config'
 
+// Default chain `name` values from @reown/appkit/networks (= viem) are
+// "Arbitrum One" and "Arbitrum Sepolia" — bare names with no Mainnet /
+// Testnet hint. The WalletConnect / AppKit chain picker renders this
+// `name` field directly, so non-crypto-native users on the wrong chain
+// can't tell at a glance which one is real money. Spread + override
+// before passing to AppKit so the picker shows the labelled version.
+// (The Settings direct-wallet dropdown is a separate <select> that
+// already has these labels hard-coded.)
+const labelledArbitrumOne = { ...SUPPORTED_CHAIN, name: 'Arbitrum One (Mainnet)' }
+const labelledArbitrumSepolia = { ...arbitrumSepolia, name: 'Arbitrum Sepolia (Testnet)' }
+
 export default defineNuxtPlugin(async () => {
   // In local Anvil devnet mode, skip AppKit entirely — use direct wagmi config.
   // Detected by VITE_DEVNET env var since manifest isn't loaded yet at plugin time.
@@ -22,12 +33,12 @@ export default defineNuxtPlugin(async () => {
     // The user's wallet determines which chain is active.
     const wagmiAdapter = new WagmiAdapter({
       projectId: WALLETCONNECT_PROJECT_ID,
-      networks: [SUPPORTED_CHAIN, arbitrumSepolia],
+      networks: [labelledArbitrumOne, labelledArbitrumSepolia],
     })
 
     const appkit = createAppKit({
       adapters: [wagmiAdapter],
-      networks: [SUPPORTED_CHAIN, arbitrumSepolia],
+      networks: [labelledArbitrumOne, labelledArbitrumSepolia],
       projectId: WALLETCONNECT_PROJECT_ID,
       metadata: APPKIT_METADATA,
       features: {


### PR DESCRIPTION
## Summary

The WalletConnect / AppKit chain selector showed bare names \"Arbitrum One\" and \"Arbitrum Sepolia\" because \`@reown/appkit/networks\` (viem) provides only the canonical chain name. New users with no crypto background can't tell at a glance which chain is real money — same picker, two entries that look interchangeable, real ANT on one side and play tokens on the other.

Spread + override the \`name\` property before passing networks to \`WagmiAdapter\` and \`createAppKit\`. wagmi/viem internals key off chain id, not name, so renaming is cosmetic for the picker UI only.

Closes #39.

## Notes on adjacent surfaces

- The Settings → Direct Wallet \`<select>\` already has the labels hard-coded.
- The sidebar amber \`DEVNET / SEPOLIA TESTNET\` badge is a *status* indicator, not a picker — separate concern.

## Test plan

- [ ] Open the WalletConnect modal — chain entries read \"Arbitrum One (Mainnet)\" and \"Arbitrum Sepolia (Testnet)\"
- [ ] Wallet pairing still completes; no chain-switch errors
- [ ] Sidebar badge text unchanged