### PR TITLE
feat(wallet): display USDC balance alongside ETH and ANT

### DIFF
--- a/composables/useDevnetWallet.ts
+++ b/composables/useDevnetWallet.ts
@@ -4,7 +4,7 @@ import { privateKeyToAccount, type PrivateKeyAccount } from 'viem/accounts'
 import { arbitrum, arbitrumSepolia } from 'viem/chains'
 import { useWalletStore } from '~/stores/wallet'
 import { useSettingsStore, getDevnetWalletKey } from '~/stores/settings'
-import { getTokenAddress, getActiveChainId } from '~/utils/wallet-config'
+import { getTokenAddress, getUsdcAddress, getActiveChainId, USDC_DECIMALS } from '~/utils/wallet-config'
 import { ANVIL_CHAIN_ID } from '~/utils/constants'
 import { formatEther, formatUnits, erc20Abi } from 'viem'
 import { getBalance, readContract } from '@wagmi/core'
@@ -126,8 +126,26 @@ async function refreshDevnetBalances() {
       // Token contract may not exist on this chain
     }
 
+    let usdcFormatted: string | null = null
+    const usdcAddr = getUsdcAddress()
+    if (usdcAddr) {
+      try {
+        const usdcResult = await readContract(devnetWagmiConfig, {
+          address: usdcAddr,
+          abi: erc20Abi,
+          functionName: 'balanceOf',
+          args: [addr],
+          chainId: getActiveChainId(),
+        })
+        usdcFormatted = parseFloat(formatUnits(usdcResult as bigint, USDC_DECIMALS)).toFixed(2)
+      } catch {
+        // USDC may not be deployed on this chain — leave null.
+      }
+    }
+
     walletStore.ethBalance = `${ethFormatted} ETH`
     walletStore.antBalance = `${antFormatted} ANT`
+    walletStore.usdcBalance = usdcFormatted ? `${usdcFormatted} USDC` : ''
     walletStore.balance = `${ethFormatted} ETH / ${antFormatted} ANT`
   } catch (err) {
     console.error('Failed to fetch devnet balances:', err)

--- a/composables/useWallet.ts
+++ b/composables/useWallet.ts
@@ -2,7 +2,7 @@ import { getBalance, readContract } from '@wagmi/core'
 import { formatEther, formatUnits, erc20Abi } from 'viem'
 import { useWalletStore } from '~/stores/wallet'
 import { useSettingsStore } from '~/stores/settings'
-import { getTokenAddress, getActiveChainId } from '~/utils/wallet-config'
+import { getTokenAddress, getUsdcAddress, getActiveChainId, USDC_DECIMALS } from '~/utils/wallet-config'
 
 // Module-level guard so the AppKit→walletStore watcher is only installed once
 // across the app's lifetime, no matter how many call sites import useWallet().
@@ -47,8 +47,26 @@ export async function refreshBalances() {
       // ANT token read may fail on chains without the contract deployed.
     }
 
+    let usdcFormatted: string | null = null
+    const usdcAddr = getUsdcAddress()
+    if (usdcAddr) {
+      try {
+        const usdcResult = await readContract(config, {
+          address: usdcAddr,
+          abi: erc20Abi,
+          functionName: 'balanceOf',
+          args: [addr],
+          chainId: getActiveChainId(),
+        })
+        usdcFormatted = parseFloat(formatUnits(usdcResult as bigint, USDC_DECIMALS)).toFixed(2)
+      } catch {
+        // USDC read failed — leave null; the panel hides the row in that case.
+      }
+    }
+
     walletStore.ethBalance = `${ethFormatted} ETH`
     walletStore.antBalance = `${antFormatted} ANT`
+    walletStore.usdcBalance = usdcFormatted ? `${usdcFormatted} USDC` : ''
     walletStore.balance = `${ethFormatted} ETH / ${antFormatted} ANT`
   } catch (err) {
     console.error('Failed to fetch balances:', err)
@@ -95,6 +113,7 @@ async function syncFromAppKit() {
         walletStore.balance = null
         walletStore.ethBalance = null
         walletStore.antBalance = null
+        walletStore.usdcBalance = null
       }
     },
     { immediate: true },

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -674,6 +674,7 @@ function disconnectDirectWallet() {
   walletStore.balance = null
   walletStore.ethBalance = null
   walletStore.antBalance = null
+  walletStore.usdcBalance = null
   directWalletActive.value = false
   setDevnetWalletKey(null)
   settingsStore._devnetWalletKeySet = false

--- a/pages/wallet.vue
+++ b/pages/wallet.vue
@@ -115,6 +115,10 @@
             <span class="text-autonomi-muted">ANT Balance</span>
             <span class="font-mono text-xs text-autonomi-blue">{{ walletStore.antBalance ?? '...' }}</span>
           </div>
+          <div v-if="walletStore.usdcBalance !== ''" class="flex items-center justify-between text-sm">
+            <span class="text-autonomi-muted">USDC Balance</span>
+            <span class="font-mono text-xs">{{ walletStore.usdcBalance ?? '...' }}</span>
+          </div>
           <div class="flex gap-2">
             <button
               class="flex-1 rounded-md border border-autonomi-border py-1.5 text-xs text-autonomi-muted hover:text-autonomi-text"

--- a/stores/wallet.ts
+++ b/stores/wallet.ts
@@ -7,6 +7,10 @@ export const useWalletStore = defineStore('wallet', {
     balance: null as string | null,
     ethBalance: null as string | null,
     antBalance: null as string | null,
+    /** USDC balance read from the active chain. `null` while the read is in
+     *  flight; an empty string ("") when the chain has no known USDC contract
+     *  (e.g. Anvil devnet) so the UI can hide the row instead of showing 0. */
+    usdcBalance: null as string | null,
     connected: false,
   }),
 
@@ -28,6 +32,7 @@ export const useWalletStore = defineStore('wallet', {
       this.balance = null
       this.ethBalance = null
       this.antBalance = null
+      this.usdcBalance = null
       this.connected = false
     },
   },

--- a/utils/wallet-config.ts
+++ b/utils/wallet-config.ts
@@ -8,6 +8,15 @@ export const WALLETCONNECT_PROJECT_ID = 'c57e0bb001a4dc96b54b9ced656a3cb8'
 export const ANT_TOKEN_ADDRESS = '0xa78d8321B20c4Ef90eCd72f2588AA985A4BDb684' as const
 export const PAYMENT_VAULT_ADDRESS = '0x9A3EcAc693b699Fc0B2B6A50B5549e50c2320A26' as const
 
+// Native (non-bridged) USDC ERC-20 contracts by chain id. Display-only —
+// USDC is not a payment route, just shown on the wallet panel for users
+// who hold their stable balance there. 6 decimals.
+export const USDC_ADDRESSES: Record<number, `0x${string}`> = {
+  42161: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831', // Arbitrum One
+  421614: '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d', // Arbitrum Sepolia
+}
+export const USDC_DECIMALS = 6
+
 export const SUPPORTED_CHAIN = arbitrum
 
 export const APPKIT_METADATA = {
@@ -42,4 +51,10 @@ export function getActiveChainId(): number {
     return settings.devnetChainId
   }
   return arbitrum.id
+}
+
+/** USDC contract address for the active chain, or null on chains without
+ *  a known USDC deployment (e.g. local Anvil devnet). */
+export function getUsdcAddress(): `0x${string}` | null {
+  return USDC_ADDRESSES[getActiveChainId()] ?? null
 }


### PR DESCRIPTION
## Summary

Read-only USDC balance display on the wallet panel for users who hold their stable balance there. Native (non-bridged) USDC contract addresses on Arbitrum One and Arbitrum Sepolia are looked up by the active chain id; the panel hides the row entirely on chains without a USDC deployment (Anvil devnet, future networks) — empty-string sentinel distinguishes \"no contract on this chain\" from \"read in flight\" so we never show \"0.00 USDC\" against a chain where USDC isn't deployed.

Same wagmi \`readContract\` pattern as the existing ANT read; mirrored on \`useWallet.ts\` (WalletConnect path) and \`useDevnetWallet.ts\` (direct-key path). USDC has 6 decimals, not 18.

Closes #41.

## Out of scope

USDC as a payment route. Display-only here; paying with USDC instead of ANT would require contract / quote-batch changes well beyond this PR.

## Contracts

- Arbitrum One: \`0xaf88d065e77c8cC2239327C5EDb3A432268e5831\`
- Arbitrum Sepolia: \`0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d\`

## Test plan

- [ ] Wallet panel on Arbitrum One — USDC row shows current balance
- [ ] Wallet panel on Arbitrum Sepolia — same, against test USDC
- [ ] Wallet panel on Anvil devnet — USDC row hidden, no \"0.00 USDC\" placeholder
- [ ] Refresh Balances re-reads USDC alongside ANT/ETH
- [ ] Disconnect clears \`usdcBalance\` (verified via WalletConnect, direct-wallet, and store \`disconnectWallet\` paths)