### PR TITLE
feat(files): download prefill + datamap row affordances

### DIFF
--- a/components/files/DownloadDialog.vue
+++ b/components/files/DownloadDialog.vue
@@ -28,6 +28,7 @@
             type="text"
             placeholder="myfile.dat"
             class="w-full rounded-md border border-autonomi-border bg-autonomi-surface px-3 py-2 text-sm text-autonomi-text focus:border-autonomi-blue focus:outline-none"
+            @input="onFilenameInput"
             @keyup.enter="confirm"
           />
         </div>
@@ -53,15 +54,22 @@
 </template>
 
 <script setup lang="ts">
+import { useFilesStore } from '~/stores/files'
+
 const props = defineProps<{ open: boolean }>()
 const emit = defineEmits<{
   close: []
   download: [address: string, filename: string]
 }>()
 
+const filesStore = useFilesStore()
+
 const inputEl = ref<HTMLInputElement | null>(null)
 const address = ref('')
 const filename = ref('')
+/** Tracks whether the user has edited the filename since the last prefill,
+ *  so a subsequent address change doesn't clobber their typing. */
+const filenameDirty = ref(false)
 
 const valid = computed(() => {
   const addr = address.value.trim()
@@ -69,17 +77,61 @@ const valid = computed(() => {
   return isHex && filename.value.trim().length > 0
 })
 
+/** Prior upload that matches the currently-typed address, if any. Drives
+ *  both the filename prefill and the extension-append fallback on submit. */
+const matchedEntry = computed(() => {
+  const addr = address.value.trim()
+  if (!/^(0x)?[0-9a-fA-F]{8,}$/.test(addr)) return undefined
+  return filesStore.findUploadByAddress(addr)
+})
+
 watch(() => props.open, (val) => {
   if (val) {
     address.value = ''
     filename.value = ''
+    filenameDirty.value = false
     nextTick(() => inputEl.value?.focus())
   }
 })
 
+watch(matchedEntry, (match) => {
+  if (!match) return
+  if (filenameDirty.value) return
+  filename.value = match.name
+})
+
+function onFilenameInput() {
+  filenameDirty.value = true
+}
+
 function confirm() {
   if (!valid.value) return
-  emit('download', address.value.trim(), filename.value.trim())
+  const typed = filename.value.trim()
+  const final = appendExtensionIfNeeded(typed, matchedEntry.value?.name)
+  emit('download', address.value.trim(), final)
   emit('close')
+}
+
+/** If the user typed a filename without an extension and we know the
+ *  original extension from a history match, append it silently. Keeps
+ *  "screenshot" → "screenshot.png" without nagging, while leaving
+ *  deliberate unextensioned names alone when there's no match to copy from. */
+function appendExtensionIfNeeded(typed: string, originalName?: string): string {
+  if (!originalName) return typed
+  if (hasExtension(typed)) return typed
+  const origExt = extensionOf(originalName)
+  if (!origExt) return typed
+  return `${typed}.${origExt}`
+}
+
+function hasExtension(name: string): boolean {
+  const dot = name.lastIndexOf('.')
+  return dot > 0 && dot < name.length - 1
+}
+
+function extensionOf(name: string): string | null {
+  const dot = name.lastIndexOf('.')
+  if (dot <= 0 || dot === name.length - 1) return null
+  return name.slice(dot + 1)
 }
 </script>

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -91,10 +91,10 @@
                 <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('cost')">
                   Cost {{ uploadSortIndicator('cost') }}
                 </th>
-                <th class="px-4 py-2.5">Address</th>
                 <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('date')">
                   Date {{ uploadSortIndicator('date') }}
                 </th>
+                <th class="px-4 py-2.5">Address</th>
                 <th class="w-px px-2 py-2.5"><span class="sr-only">Actions</span></th>
               </tr>
             </thead>
@@ -134,6 +134,7 @@
                     <span v-if="file.gas_cost" class="block text-[10px] text-autonomi-muted/60">+ {{ file.gas_cost }} gas</span>
                   </template>
                 </td>
+                <td class="px-4 py-2.5 text-autonomi-muted">{{ formatDate(file.date) }}</td>
                 <td class="px-4 py-2.5">
                   <span
                     v-if="file.public_address"
@@ -177,7 +178,6 @@
                   </span>
                   <span v-else class="text-autonomi-muted">-</span>
                 </td>
-                <td class="px-4 py-2.5 text-autonomi-muted">{{ formatDate(file.date) }}</td>
                 <td class="px-2 py-2.5 text-right whitespace-nowrap">
                   <span v-if="isSettled(file)" class="inline-flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
                     <button

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -144,17 +144,33 @@
                     <span class="rounded bg-autonomi-blue/15 px-1 py-px text-[9px] font-sans uppercase tracking-wider">Public</span>
                     {{ truncateAddress(file.public_address, 8, 6) }}
                   </span>
-                  <span
+                  <div
                     v-else-if="file.data_map_file"
-                    class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
-                    :title="`Reveal ${datamapBasename(file.data_map_file)} in its folder`"
-                    @click.stop="openFolder(file.data_map_file)"
+                    class="flex items-center gap-1.5"
                   >
-                    {{ datamapBasename(file.data_map_file) }}
-                  </span>
+                    <span
+                      class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue hover:underline"
+                      title="Reveal datamap file in Finder/Explorer"
+                      @click.stop="openFolder(file.data_map_file)"
+                    >
+                      {{ datamapBasename(file.data_map_file) }}
+                    </span>
+                    <button
+                      type="button"
+                      class="rounded p-0.5 text-autonomi-muted/60 hover:text-autonomi-blue hover:bg-autonomi-surface"
+                      title="Copy datamap file path"
+                      @click.stop="copyDatamapPath(file.data_map_file!)"
+                    >
+                      <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
+                        <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
+                      </svg>
+                    </button>
+                  </div>
                   <span
                     v-else-if="file.address"
                     class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
+                    title="Copy network address"
                     @click.stop="copyAddress(file.address)"
                   >
                     {{ truncateAddress(file.address, 8, 6) }}
@@ -1031,6 +1047,11 @@ function copyAddress(addr: string) {
 function copyPublicAddress(addr: string) {
   navigator.clipboard.writeText(addr)
   toastStore.add('Public address copied — share to let others download this file', 'info')
+}
+
+function copyDatamapPath(path: string) {
+  navigator.clipboard.writeText(path)
+  toastStore.add('Datamap path copied to clipboard', 'info')
 }
 
 function datamapBasename(path: string): string {


### PR DESCRIPTION
## Summary

Three small file-ops UX fixes, scoped per commit.

- **Download-by-Address filename prefill + extension preserve.** When the pasted address matches an entry in upload history, the filename field auto-fills with the original name. On submit, if the user dropped the extension while editing, it's silently appended back from the history match. Fixes the long-standing "type 'screenshot', save 'screenshot' that the OS can't open" foot-gun.
- **Datamap row Copy Path icon + clearer click affordance.** The datamap filename in the uploads table was already click-to-reveal, but visually subtle. Now it picks up a hover underline so the affordance reads as clickable, and a Copy Path icon sits alongside it for users who want the path on the clipboard rather than opened in Explorer.
- **Swap Date and Address columns in the uploads table.** Address now sits adjacent to the row-action column (Retry / ✕ on hover), grouping the interactive controls on the right edge. Date moves inward as a static metadata cell.

No backend changes. No new Tauri commands. Downloads table is unchanged.

## Test plan

- [ ] **Filename prefill** — open Download by Address, paste an address from an existing upload → filename field populates with the original name
- [ ] **Extension preserved** — edit the prefilled filename to drop the extension (e.g. remove `.png`), click Download → saved file still ends with `.png`
- [ ] **No-match passthrough** — paste an address NOT in history → filename stays blank, user types freely, no extension append on submit
- [ ] **Datamap row Copy** — upload a small private file, hover the filename in the datamap cell → it underlines + turns blue; click the Copy icon → clipboard contains the absolute path; toast confirms
- [ ] **Datamap row Reveal** — click the filename text → Finder / Explorer opens focused on the datamap file
- [ ] **Public-row regression** — upload a public file → row still shows the "Public" badge with truncated address, click still copies the network address
- [ ] **Address-only-row regression** — a row with `file.address` but no datamap (legacy / public completion) → still shows truncated address, click still copies
- [ ] **Hover actions** — hover any settled upload row → Retry (if applicable) and ✕ buttons appear on the right edge
- [ ] **Column order** — uploads table reads Name | Status | Size | Cost | Date | Address | (actions on hover)
- [ ] **Cross-platform** — at minimum Windows + macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)