### PR TITLE
feat(datamap): write new uploads to ~/Documents/Autonomi/Datamaps/

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -138,6 +138,60 @@ pub(crate) fn config_path() -> PathBuf {
         .join("ant-gui")
 }
 
+/// User-addressable directory for persisted datamap files on **fresh
+/// installs**. Lives under `~/Documents/Autonomi/Datamaps/` (or the
+/// platform equivalent of Documents) so the OS file picker can navigate
+/// to them — fixes the macOS gap where `~/Library` is hidden by default
+/// in NSOpenPanel.
+///
+/// Existing installs keep writing into `config_path()` via
+/// `resolve_datamap_output_dir()` so the upgrade does not split their
+/// datamaps across two locations. Only callers that need the "where do
+/// new writes go" answer should use `resolve_datamap_output_dir()`;
+/// this function is the new-install default.
+///
+/// Falls back to `<home>/Documents/Autonomi/Datamaps` if `dirs::document_dir`
+/// can't resolve the platform path (very unusual), and to `./Autonomi/Datamaps`
+/// only if even `dirs::home_dir` fails (effectively a no-home embedded env).
+pub fn datamap_dir() -> PathBuf {
+    dirs::document_dir()
+        .or_else(|| dirs::home_dir().map(|h| h.join("Documents")))
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("Autonomi")
+        .join("Datamaps")
+}
+
+/// Decide where the *next* datamap write should land. Existing installs
+/// (those whose `config_path()` already contains one or more `.datamap`
+/// files) keep writing into the legacy location so a single user does not
+/// end up with their datamaps scattered across two directories after the
+/// upgrade. Fresh installs go to `datamap_dir()` so the OS file picker can
+/// reach them.
+///
+/// Detection is stateless: on every write, we look at the legacy dir's
+/// current contents. After the first new-install write the rule continues
+/// to return `datamap_dir()` because the legacy dir never gains a
+/// `.datamap` file. After the first existing-install write the rule
+/// continues to return `config_path()` because the legacy dir still has
+/// the original `.datamap` files alongside the new one.
+fn resolve_datamap_output_dir() -> PathBuf {
+    let legacy = config_path();
+    let has_legacy_datamaps = legacy
+        .read_dir()
+        .ok()
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .any(|entry| entry.path().extension().and_then(|s| s.to_str()) == Some("datamap"))
+        })
+        .unwrap_or(false);
+    if has_legacy_datamaps {
+        legacy
+    } else {
+        datamap_dir()
+    }
+}
+
 /// Resolve the OS-appropriate default downloads directory. Returns
 /// `~/Downloads` on macOS/Linux and `C:\Users\<name>\Downloads` on Windows,
 /// falling back to `<home>/Downloads` if the platform-specific lookup fails.
@@ -219,8 +273,9 @@ pub fn get_file_metas(paths: &[String]) -> Result<Vec<FileMetaResult>, String> {
         .collect()
 }
 
-/// Persist a serialized DataMap alongside `upload_history.json` using the
-/// canonical msgpack format from `ant_core::data::write_datamap`. The file
+/// Persist a serialized DataMap in the user-addressable datamap directory
+/// (`~/Documents/Autonomi/Datamaps/` on fresh installs, the legacy config
+/// dir on existing installs — see `resolve_datamap_output_dir`). The file
 /// is named after the upload's original basename with `.datamap` appended,
 /// preserving the original extension (e.g. `holiday.jpg` →
 /// `holiday.jpg.datamap`). On collision the upstream `NumericSuffix` policy
@@ -228,18 +283,18 @@ pub fn get_file_metas(paths: &[String]) -> Result<Vec<FileMetaResult>, String> {
 ///
 /// Returns the absolute path to the written file.
 ///
-/// This is the round-trip-safe path: ant-cli, ant-tui, and any other
-/// consumer of the upstream module reads back the same on-disk format. The
-/// read side (`autonomi_ops::read_datamap_file`) still accepts legacy JSON
-/// datamaps written by older builds via the first-byte sniff in upstream's
-/// `read_datamap`, so existing entries in `upload_history.json` keep
-/// working.
+/// Format is the canonical msgpack produced by `ant_core::data::write_datamap`,
+/// so ant-cli, ant-tui, and any other consumer of the upstream module reads
+/// back the same on-disk bytes. The read side (`autonomi_ops::read_datamap_file`)
+/// still accepts legacy JSON datamaps written by older builds via the first-byte
+/// sniff in upstream's `read_datamap`, so existing entries in `upload_history.json`
+/// keep working.
 pub fn write_datamap_for(
     original_name: &str,
     dm: &ant_core::data::DataMap,
 ) -> Result<PathBuf, String> {
-    let dir = config_path();
-    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create config dir: {e}"))?;
+    let dir = resolve_datamap_output_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create datamap dir: {e}"))?;
     ant_core::data::write_datamap(
         &dir,
         original_name,


### PR DESCRIPTION
## Summary

Fixes the macOS gap where NSOpenPanel hides \`~/Library\` by default in the OS file picker, leaving users unable to navigate to their own datamaps. New uploads now land in \`~/Documents/Autonomi/Datamaps/\` (or the platform equivalent), where every OS picker can reach them.

## Zero impact on existing users

Detection is stateless on every \`write_datamap_for\` call:

| Install state | Behavior |
|---|---|
| Existing — \`config_path()\` already has \`.datamap\` files | Keep writing there. No surprise, no scattered state. |
| Fresh — no \`.datamap\` files in legacy dir | Write to \`~/Documents/Autonomi/Datamaps/\`. |

The rule is stable across subsequent writes:
- Existing installs accumulate datamaps in the legacy dir → rule continues to choose legacy. Old datamaps stay reachable via the row affordance (Copy Path / Reveal / DownloadByDatamapDialog list).
- Fresh installs never write to the legacy dir → rule continues to choose Documents.

No migration, no config field, no \`upload_history.json\` rewrite. Existing entries' absolute paths still resolve.

## Files changed

\`src-tauri/src/config.rs\` only:
- New \`datamap_dir()\` — fresh-install default (\`~/Documents/Autonomi/Datamaps/\`)
- New \`resolve_datamap_output_dir()\` — picks legacy vs new based on legacy dir contents
- \`write_datamap_for\` uses \`resolve_datamap_output_dir()\` instead of \`config_path()\`

## Privacy caveat (documented in commit)

\`~/Documents\` is commonly synced by iCloud Drive / OneDrive. A datamap is the key to private data on the network — users who don't want cloud sync exposure can exclude the folder at the sync layer. Same control surface as any other file in Documents. Pre-this-PR the keys lived in non-synced \`~/Library\` / \`%APPDATA%\`; this is a deliberate trade-off favoring discoverability over default-off cloud exposure.

## Test plan

- [ ] CI build clean
- [ ] **Existing-user simulation (Windows):** with \`.datamap\` files already in \`%APPDATA%\autonomi\ant-gui\\`, upload a new file. Confirm the new datamap lands in \`%APPDATA%\autonomi\ant-gui\\` (not Documents). Re-download an old entry — works.
- [ ] **Fresh-install simulation:** rename \`%APPDATA%\autonomi\ant-gui\\` to back it up. Launch the app. Upload a file. Confirm the new datamap lands in \`%USERPROFILE%\Documents\Autonomi\Datamaps\\`. Open the OS picker via Download by Datamap → Browse — confirm you can navigate to and open the new datamap.
- [ ] **macOS (manual UAT on a Mac):** verify the picker can navigate into \`~/Documents/Autonomi/Datamaps/\` (it should — that's the whole point).
- [ ] Existing entry's Copy Path / Reveal still resolves the legacy location.

## Stacks with

This PR conflicts only on \`write_datamap_for\` with #97 (V2-258: msgpack write). Whichever lands first, the second is a trivial rebase — both touch only that function's body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)