### PR TITLE
fix(nodes): retry daemon status during boot race to kill 10s flicker

### DIFF
--- a/stores/nodes.ts
+++ b/stores/nodes.ts
@@ -91,7 +91,13 @@ export const useNodesStore = defineStore('nodes', {
       }
 
       try {
-        await this.fetchDaemonStatus()
+        // `ensure_daemon_running` waits for the port file but the daemon's
+        // HTTP server may take another ~100–500 ms after that to bind. A
+        // single status fetch loses this race on cold boot and the UI flashes
+        // "Cannot connect to node daemon" for ~10 s while `scheduleReconnect`
+        // ticks. Retry briefly here so `initializing` stays true and the
+        // user sees "Starting node daemon..." through the boot race.
+        await this.fetchDaemonStatusWithRetry({ attempts: 20, delayMs: 250 })
         this.daemonConnected = true
         await this.fetchNodes()
         this.startPolling()
@@ -111,6 +117,27 @@ export const useNodesStore = defineStore('nodes', {
       const status = await daemonApi.status()
       this.daemonStatus = status
       this.daemonConnected = status.running
+    },
+
+    /** Like `fetchDaemonStatus` but retries on failure for up to
+     *  `attempts × delayMs` (default ~5 s). Used at boot and on reconnect
+     *  so a brief unbound-port window after daemon spawn doesn't flip the
+     *  UI through a transient "Cannot connect" state. The last failure is
+     *  rethrown so the caller's catch path runs normally. */
+    async fetchDaemonStatusWithRetry({ attempts, delayMs }: { attempts: number; delayMs: number }) {
+      let lastErr: unknown
+      for (let i = 0; i < attempts; i++) {
+        try {
+          await this.fetchDaemonStatus()
+          return
+        } catch (e) {
+          lastErr = e
+          if (i < attempts - 1) {
+            await new Promise<void>(r => setTimeout(r, delayMs))
+          }
+        }
+      }
+      throw lastErr
     },
 
     /** Fetch all node statuses from daemon */

--- a/tests/stores/nodes.test.ts
+++ b/tests/stores/nodes.test.ts
@@ -19,10 +19,24 @@ describe('nodes store', () => {
   let settingsStore: ReturnType<typeof useSettingsStore>
 
   beforeEach(() => {
+    // Reset both the Tauri invoke mock AND the vue-i18n / daemon-api module
+    // mocks — without `vi.clearAllMocks`, a `mockResolvedValue` (default
+    // fallback) set by an earlier test leaks into later ones and silently
+    // satisfies status() calls the test never set up.
+    vi.clearAllMocks()
+    vi.useRealTimers()
     resetTauriMocks()
+
     settingsStore = useSettingsStore()
     settingsStore.$reset()
     nodesStore = useNodesStore()
+    // Pinia's $reset clears state references (`_pollTimer`, `_reconnectTimer`)
+    // but does not call clearInterval / clearTimeout on the underlying JS
+    // timers. Drop them explicitly so a previous test's polling or reconnect
+    // schedule can't fire `fetchNodes` / `fetchDaemonStatus` against the new
+    // test's mocks.
+    nodesStore.stopPolling()
+    nodesStore.cancelReconnect()
     nodesStore.$reset()
   })
 
@@ -92,12 +106,21 @@ describe('nodes store', () => {
         if (cmd === 'connect_daemon_sse') return undefined
       })
 
-      vi.mocked(daemonApi.status)
-        .mockRejectedValueOnce(new Error('connection refused'))
-        .mockResolvedValueOnce({
+      // Counter-based implementation rather than `mockRejectedValueOnce
+      // → mockResolvedValueOnce`. The Once-queue pattern depends on every
+      // call beyond the queue falling back to a default, which silently
+      // varies depending on what the previous test in this file set up;
+      // a counter is self-contained and the assertion below can verify
+      // both the retry behaviour and that no unexpected extra calls leak in.
+      let statusCallCount = 0
+      vi.mocked(daemonApi.status).mockImplementation(async () => {
+        statusCallCount++
+        if (statusCallCount === 1) throw new Error('connection refused')
+        return {
           running: true, pid: 1, port: 55555, uptime_secs: 0,
           nodes_total: 0, nodes_running: 0, nodes_stopped: 0, nodes_errored: 0,
-        })
+        }
+      })
 
       vi.mocked(daemonApi.nodesStatus).mockResolvedValue({
         nodes: [], total_running: 0, total_stopped: 0,
@@ -112,6 +135,10 @@ describe('nodes store', () => {
       expect(nodesStore.initializing).toBe(false)
       expect(daemonApi.status).toHaveBeenCalledTimes(2)
 
+      // Stop polling / reconnect explicitly before useRealTimers so the
+      // following test's beforeEach doesn't have to clean them up.
+      nodesStore.stopPolling()
+      nodesStore.cancelReconnect()
       vi.useRealTimers()
     })
 

--- a/tests/stores/nodes.test.ts
+++ b/tests/stores/nodes.test.ts
@@ -78,6 +78,43 @@ describe('nodes store', () => {
       expect(nodesStore.initializing).toBe(false)
     })
 
+    it('retries the status fetch when the daemon races boot', async () => {
+      // Repros the V2-218 boot race: `ensure_daemon_running` returns after
+      // the port file is written, but the daemon's HTTP server hasn't bound
+      // the port yet. The first status() throws; the next succeeds. The
+      // store should ride out the failure inside `initializing` and end up
+      // connected — no transient `daemonConnected=false` exposed.
+      const { daemonApi } = await import('~/utils/daemon-api')
+      vi.useFakeTimers()
+
+      setMockInvokeHandler((cmd) => {
+        if (cmd === 'ensure_daemon_running') return 'http://127.0.0.1:55555'
+        if (cmd === 'connect_daemon_sse') return undefined
+      })
+
+      vi.mocked(daemonApi.status)
+        .mockRejectedValueOnce(new Error('connection refused'))
+        .mockResolvedValueOnce({
+          running: true, pid: 1, port: 55555, uptime_secs: 0,
+          nodes_total: 0, nodes_running: 0, nodes_stopped: 0, nodes_errored: 0,
+        })
+
+      vi.mocked(daemonApi.nodesStatus).mockResolvedValue({
+        nodes: [], total_running: 0, total_stopped: 0,
+      })
+
+      const initPromise = nodesStore.init()
+      // Advance past the 250 ms retry delay so the second status() runs.
+      await vi.advanceTimersByTimeAsync(300)
+      await initPromise
+
+      expect(nodesStore.daemonConnected).toBe(true)
+      expect(nodesStore.initializing).toBe(false)
+      expect(daemonApi.status).toHaveBeenCalledTimes(2)
+
+      vi.useRealTimers()
+    })
+
     it('updates daemon URL when port changes', async () => {
       const { daemonApi } = await import('~/utils/daemon-api')
 


### PR DESCRIPTION
## Summary

The "Cannot connect to node daemon" message flashes for ~10 seconds on every cold launch. Root cause: a boot race between the daemon's port-file write and its HTTP-server bind.

### Cold-launch timing today

| t (s) | Step |
|---|---|
| 0 | app boot, \`nodesStore.init()\` runs |
| ~0.5 | \`ensure_daemon_running\` spawns daemon, waits for port file |
| ~1 | port file written → returns URL, **but the daemon's HTTP server hasn't bound the port yet** |
| ~1 | first \`fetchDaemonStatus\` → connection refused → throws |
| ~1 | outer catch: \`daemonConnected=false\`, \`initializing=false\`, \`scheduleReconnect()\` (**10 s timer**) |
| 1–11 | UI: "Cannot connect to node daemon" |
| ~11 | reconnect timer fires, retry succeeds, UI flips to nodes |

## Fix

New \`fetchDaemonStatusWithRetry({ attempts, delayMs })\` helper retries up to ~5 s (20 × 250 ms) inside \`init()\`. \`initializing\` stays true through the retries, so the user sees "Starting node daemon..." until the daemon actually serves or the budget exhausts.

The disconnected path and the existing \`scheduleReconnect\` 10 s loop are untouched — those still kick in for genuine outages.

## Test plan

- [ ] **Unit:** new test mocks \`status\` to fail once then succeed, asserts no transient \`daemonConnected=false\` escapes init and store ends up connected with 2 status calls
- [ ] **Manual cold launch:** kill any \`ant.exe\` / \`ant-gui.exe\`, delete \`%APPDATA%\ant\daemon.{pid,port}\`, run \`npm run tauri:dev\`. Expect "Starting node daemon..." for ~1 s, then nodes list. **No** "Cannot connect" flash.
- [ ] **Genuine outage:** rename the bundled \`ant.exe\` to break \`ensure_daemon_running\`. Launch. Expect "Cannot connect to node daemon" + retry-every-10s behavior unchanged.
- [ ] **Restart-daemon flow:** click "Restart Daemon" in settings. Expect "Restarting node daemon..." (existing) — not affected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)