### PR TITLE
fix(wallet): right-align Use Wallet button in earnings suggestion

### DIFF
--- a/pages/wallet.vue
+++ b/pages/wallet.vue
@@ -23,7 +23,7 @@
         <!-- Suggest using payment wallet address (local mode only) -->
         <div
           v-if="!settingsStore.indelibleConnected && walletStore.connected && walletStore.paymentAddress && walletStore.earningsAddress !== walletStore.paymentAddress"
-          class="mt-3 flex items-center gap-3 rounded-md border border-autonomi-blue/20 bg-autonomi-blue/5 px-3 py-2"
+          class="mt-3 flex items-center justify-between gap-3 rounded-md border border-autonomi-blue/20 bg-autonomi-blue/5 px-3 py-2"
         >
           <span class="text-xs text-autonomi-muted">
             Use your connected wallet address for earnings?


### PR DESCRIPTION
## Summary
The \"Use {address}\" button inside the Wallet page's earnings-address suggestion sat flush against the prompt label because the flex container only had a \`gap-3\`, no \`justify\` rule. Add \`justify-between\` so the prompt stays on the left and the button hugs the right edge of the suggestion card.

## Before / After
- Before: \`Use your connected wallet address for earnings?  [Use 0x12…ab]\` (label and button packed at the start, empty space on the right)
- After: \`Use your connected wallet address for earnings?         [Use 0x12…ab]\` (label left, button right)

## Test plan
- [ ] Connect a wallet on the Wallet page with an earnings address that differs from the payment address.
- [ ] Suggestion card renders with the prompt on the left and the button on the right edge.
- [ ] Click the button → earnings address updates to match the payment address; suggestion disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)