### PR TITLE
chore(ci): skip ci.yml on version-bump commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ env:
 jobs:
   frontend:
     name: frontend (typecheck + test)
+    # Skip on version-bump commits — release.yml does its own validation on the
+    # tag push. The bump commit only edits version strings, so re-running
+    # typecheck/vitest here is a no-op signal. PRs are unaffected (head_commit
+    # is absent on pull_request events).
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release): bump version to ') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -30,6 +35,7 @@ jobs:
 
   rust:
     name: rust (${{ matrix.check }})
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release): bump version to ') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Add a `startsWith()` guard to each ci.yml job so version-bump commits don't trigger the typecheck/vitest/clippy/fmt suite — release.yml already validates the tag push, and the bump commit only edits version strings.
- Prefix matches the convention used since v0.7.0 (`chore(release): bump version to <semver>`).

## Why
Every release lands a bump commit on `main`, which fires ci.yml, then gets tagged and fires release.yml. The ci.yml run on the bump is wasted minutes — the code didn't change. Conservative fix: skip ci.yml on the bump, leave everything else alone.

## How
```yaml
if: ${{ !startsWith(github.event.head_commit.message, 'chore(release): bump version to ') }}
```

Applied to both jobs (`frontend`, `rust`). PRs are unaffected because `github.event.head_commit` is absent on `pull_request` events — `startsWith(null, ...)` returns false, the negation is true, and the job runs.

If the bump-commit format ever changes, the guard silently stops skipping. Re-update this file in the same PR that changes the format.

## Test plan
- [ ] This PR's own ci run is green (proves the guard doesn't break PR-triggered runs).
- [ ] Next release: after merging the bump commit to main, both ci.yml jobs show as `Skipped` in the Actions tab. release.yml fires on the tag push as normal.
- [ ] If ci.yml runs anyway on a future bump commit, double-check `git log -1 --format=%s` on that commit matches the expected prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)