### PR TITLE
fix(files): bump flex gap under filename so the progress bar isn't flush

### DIFF
--- a/pages/files.vue
+++ b/pages/files.vue
@@ -107,7 +107,7 @@
                 @click="onRowClick(file)"
               >
                 <td class="px-4 py-2.5">
-                  <div class="flex flex-col gap-1.5">
+                  <div class="flex flex-col gap-2">
                     <div>{{ file.name }}</div>
                     <ProgressLine
                       v-if="showsProgressBar(file)"
@@ -258,7 +258,7 @@
               @click="onRowClick(file)"
             >
               <td class="px-4 py-2.5">
-                <div class="flex flex-col gap-1.5">
+                <div class="flex flex-col gap-2">
                   <div>{{ file.name }}</div>
                   <ProgressLine
                     v-if="showsProgressBar(file)"


### PR DESCRIPTION
## Summary
Bump the parent `flex flex-col gap-1.5` → `gap-2` on the filename + ProgressLine wrapper in both the upload table and the download table on the Files page. User flagged the bar feeling flush under the filename during the v0.6.8 smoke test; it carried through unchanged on v0.7.0 and v0.7.1.

6px → 8px between the filename and the bar. Subtle but unsticks the visual cramping.

## Why this layout, not `mt-1`?
The notes from the smoke test floated either "add `mt-1` to ProgressLine" or "wrap the bar in a div with top margin." I went with bumping the flex `gap` instead — equivalent visual effect, single layout property, no `margin-top` stacking on flex children. If you'd rather match the `mt-1` already used on the stage-detail line under the StatusBadge (for consistency), happy to switch.

## Test plan
- [ ] `npm run dev` → Files page → drop a file, watch the upload row mid-flight. The ProgressLine sits 8px under the filename instead of 6px.
- [ ] Same for a download row.
- [ ] Rows with no progress bar (settled uploads, removed entries) look unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)