### PR TITLE
fix(updater): widen release-notes panel so real bodies don't take 3 scroll pages

### DIFF
--- a/components/UpdateDialog.vue
+++ b/components/UpdateDialog.vue
@@ -9,7 +9,7 @@
         role="dialog"
         aria-modal="true"
         aria-labelledby="update-dialog-title"
-        class="w-[420px] rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl"
+        class="w-[32rem] rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl"
       >
         <!-- Header -->
         <h2 id="update-dialog-title" class="text-lg font-medium">
@@ -33,7 +33,7 @@
         <!-- Release notes -->
         <div
           v-if="!updaterStore.installing"
-          class="mt-4 max-h-56 overflow-auto rounded-md bg-autonomi-surface p-3"
+          class="mt-4 max-h-96 overflow-auto rounded-md bg-autonomi-surface p-3"
         >
           <h3 class="mb-2 text-xs font-semibold uppercase tracking-wider text-autonomi-muted">Release Notes</h3>
           <div v-if="updaterStore.body" class="prose-sm text-xs leading-relaxed text-autonomi-text" v-html="renderMarkdown(updaterStore.body)" />


### PR DESCRIPTION
## Summary
Bump the Update Available dialog from `w-[420px] × max-h-56` (420px × 224px) → `w-[32rem] × max-h-96` (512px × 384px). Real release-note bodies (e.g. v0.7.1's five "What's new" bullets, each 2–4 lines of wrapped text) currently force the user to scroll three+ pages of the panel to read everything — exactly the moment ("Update now? What changed?") where the content matters most.

## Sizing rationale
| Dialog | Width |
| -- | -- |
| AddNodeDialog / CostEstimateDialog | `w-96` (384px) |
| **UpdateDialog (before)** | `w-[420px]` |
| DatamapSaveAsDialog | `w-[26rem]` (416px) |
| DownloadDialog | `w-[28rem]` (448px) |
| **UpdateDialog (after)** | `w-[32rem]` (512px) |
| DownloadByDatamapDialog | `w-[32rem]` (512px) |
| UploadConfirmDialog | `w-[36rem]` (576px) |

Lands the update dialog alongside the other content-heavy dialog (`DownloadByDatamapDialog`), narrower than the widest (`UploadConfirmDialog`). Height bump (`max-h-56` → `max-h-96`, 224 → 384px) is the dominant axis for vertical content; ~24 lines comfortable.

## Test plan
- [ ] `npm run dev`, trigger an update check, view the dialog with a long release-notes body (v0.7.1 notes work as test material).
- [ ] Verify the panel fits more lines before scrolling kicks in.
- [ ] Verify nothing clips at narrower viewport widths (the dialog is `fixed inset-0 flex items-center justify-center`; 512px fits in any reasonable window).
- [ ] No regression on the "no release notes available" empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)