### PR TITLE
chore(ci): also skip ci.yml on docs-only commits and PR titles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,20 @@ env:
 jobs:
   frontend:
     name: frontend (typecheck + test)
-    # Skip on version-bump commits — release.yml does its own validation on the
-    # tag push. The bump commit only edits version strings, so re-running
-    # typecheck/vitest here is a no-op signal. PRs are unaffected (head_commit
-    # is absent on pull_request events).
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release): bump version to ') }}
+    # Skip on:
+    # - version-bump commits — release.yml does its own validation on the tag
+    #   push, and the bump commit only edits version strings.
+    # - docs-only changes — `docs:` and `docs(scope):` conventional-commit
+    #   prefixes on push and on PR title. typecheck/vitest don't exercise
+    #   markdown, so running them on README/CONTRIBUTING edits is no-op signal.
+    # `startsWith(null, ...)` returns false, so each absent context evaluates
+    # safely — on push events `pull_request.title` is null and vice versa.
+    if: >-
+      !startsWith(github.event.head_commit.message, 'chore(release): bump version to ')
+      && !startsWith(github.event.head_commit.message, 'docs:')
+      && !startsWith(github.event.head_commit.message, 'docs(')
+      && !startsWith(github.event.pull_request.title, 'docs:')
+      && !startsWith(github.event.pull_request.title, 'docs(')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -35,7 +44,12 @@ jobs:
 
   rust:
     name: rust (${{ matrix.check }})
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release): bump version to ') }}
+    if: >-
+      !startsWith(github.event.head_commit.message, 'chore(release): bump version to ')
+      && !startsWith(github.event.head_commit.message, 'docs:')
+      && !startsWith(github.event.head_commit.message, 'docs(')
+      && !startsWith(github.event.pull_request.title, 'docs:')
+      && !startsWith(github.event.pull_request.title, 'docs(')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
Extend the version-bump skip (merged in #111) with prefix matches for the conventional `docs:` and `docs(scope):` commit-message and PR-title formats. typecheck / vitest / clippy / fmt don't exercise markdown — running them on a README edit is no-op signal.

```yaml
if: >-
  !startsWith(github.event.head_commit.message, 'chore(release): bump version to ')
  && !startsWith(github.event.head_commit.message, 'docs:')
  && !startsWith(github.event.head_commit.message, 'docs(')
  && !startsWith(github.event.pull_request.title, 'docs:')
  && !startsWith(github.event.pull_request.title, 'docs(')
```

`startsWith(null, ...)` returns false, so each absent event context evaluates safely — on push events `pull_request.title` is null and vice versa.

## Why
PR #115 (the i18n docs PR) triggered the full ci suite even though it touches only `README.md` + `CONTRIBUTING-i18n.md`. The current `docs(i18n):` PR title is exactly the convention this matches against.

## Replaces #116
This PR replaces the auto-closed #116 (its base was `chore/ci-skip-version-bumps`, deleted when #111 merged). Same head branch, same commit, rebased onto current main.

## Known gap (non-blocking)
Merge-commit-style PR landings (non-squash) produce a head_commit message of `Merge pull request #NNN from ...`, which doesn't match the docs prefix. The **post-merge** run on main for a docs PR will still fire under that merge strategy. If that becomes annoying, the canonical follow-up is `paths-ignore` at the workflow level:

```yaml
on:
  push:
    branches: [main]
    paths-ignore: ['**.md', 'docs/**']
  pull_request:
    paths-ignore: ['**.md', 'docs/**']
```

That catches the post-merge case without depending on a commit-message convention. Happy to do it in a follow-up if you want belt-and-braces.

## Test plan
- [ ] This PR's own ci run runs (it's a `chore(ci):` title, not `docs(...)`) — proves the guard doesn't accidentally over-skip.
- [ ] PR #115 (after rebase onto post-merge main) — its `docs(i18n):` PR-triggered ci runs should be skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)