### PR TITLE
feat(i18n): add French (fr) locale

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -6,6 +6,7 @@
 
 <script setup lang="ts">
 import { invoke } from '@tauri-apps/api/core'
+import { useLocale } from '~/composables/useLocale'
 import { useWallet } from '~/composables/useWallet'
 import { useTheme } from '~/composables/useTheme'
 import { useSettingsStore } from '~/stores/settings'
@@ -31,8 +32,14 @@ const nodesStore = useNodesStore()
 const filesStore = useFilesStore()
 const connectionStore = useConnectionStore()
 
+const { init: initLocale } = useLocale()
+
 onMounted(async () => {
+  // Config first — useLocale.init() reads the persisted choice from
+  // settingsStore.i18nLocale, so the store must be hydrated before we resolve.
   await settingsStore.loadConfig()
+  await initLocale()
+
   await settingsStore.loadDevnetManifest()
   nodesStore.init()
   // Re-probe the saved storage_dir if any — surfaces a banner if it's no

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <header class="flex h-12 items-center justify-between border-b border-autonomi-border bg-autonomi-surface px-4">
     <!-- Page title -->
-    <h1 class="text-sm font-medium text-autonomi-text">{{ pageTitle }}</h1>
+    <h1 class="text-sm font-medium text-autonomi-text">{{ $t(pageTitleKey) }}</h1>
 
     <!-- Right side: status indicators + wallet -->
     <div class="flex items-center gap-4">
@@ -9,7 +9,7 @@
       <div v-if="filesStore.hasActiveTransfers" class="flex items-center gap-2 text-xs">
         <span class="text-autonomi-blue">↑↓</span>
         <span class="text-autonomi-muted">
-          {{ filesStore.pinnedFiles.length }} active
+          {{ $t('header.active_transfers', { count: filesStore.pinnedFiles.length }) }}
         </span>
       </div>
 
@@ -17,27 +17,27 @@
       <div
         v-if="connectionStore.isConnecting"
         class="flex items-center gap-2 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted"
-        title="Connecting to the Autonomi network"
+        :title="$t('header.connecting_tooltip')"
       >
         <div class="h-2.5 w-2.5 animate-spin rounded-full border-2 border-yellow-500 border-t-transparent" />
-        <span>Connecting</span>
+        <span>{{ $t('header.connecting') }}</span>
       </div>
       <div
         v-else-if="connectionStore.isConnected"
         class="flex items-center gap-2 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-text"
-        title="Connected to the Autonomi network"
+        :title="$t('header.connected_tooltip')"
       >
         <span class="text-autonomi-success">●</span>
-        <span>Network</span>
+        <span>{{ $t('header.connected') }}</span>
       </div>
       <button
         v-else-if="connectionStore.hasFailed"
         class="flex items-center gap-2 rounded-md border border-red-500/30 bg-red-500/5 px-2.5 py-1 text-xs text-red-400 hover:bg-red-500/10"
-        title="Connection failed — click to retry"
+        :title="$t('header.offline_tooltip')"
         @click="connectionStore.retry()"
       >
         <span>●</span>
-        <span>Offline · Retry</span>
+        <span>{{ $t('header.offline') }}</span>
       </button>
 
       <!-- Indelible indicator (replaces wallet when connected) -->
@@ -64,7 +64,7 @@
           class="rounded-md bg-autonomi-blue px-2.5 py-1 text-xs font-medium text-white hover:opacity-90"
           @click="openModal"
         >
-          Connect Wallet
+          {{ $t('header.connect_wallet') }}
         </button>
       </template>
     </div>
@@ -98,14 +98,14 @@ function openModal() {
   }
 }
 
-const pageTitle = computed(() => {
-  const titles: Record<string, string> = {
-    '/': 'Nodes',
-    '/files': 'Files',
-    '/wallet': 'Wallet',
-    '/settings': 'Settings',
+const pageTitleKey = computed(() => {
+  const keys: Record<string, string> = {
+    '/': 'nav.nodes',
+    '/files': 'nav.files',
+    '/wallet': 'nav.wallet',
+    '/settings': 'nav.settings',
   }
-  return titles[route.path] ?? 'Autonomi'
+  return keys[route.path] ?? 'header.title'
 })
 
 </script>

--- a/components/AppSidebar.vue
+++ b/components/AppSidebar.vue
@@ -17,15 +17,15 @@
         v-if="isPrereleaseBuild"
         class="mb-2 rounded-md bg-teal-500/10 border border-teal-500/20 px-3 py-1.5 text-center text-xs font-medium text-teal-400"
       >
-        PRE-RELEASE
+        {{ $t('sidebar.pre_release') }}
       </div>
 
       <!-- Network mode indicator -->
       <div
-        v-if="settingsStore.devnetActive && networkLabel"
+        v-if="settingsStore.devnetActive && networkLabelKey"
         class="mb-2 rounded-md bg-amber-500/10 border border-amber-500/20 px-3 py-1.5 text-center text-xs font-medium text-amber-400"
       >
-        {{ networkLabel }}
+        {{ $t(networkLabelKey) }}
       </div>
 
       <!-- Update banner -->
@@ -42,9 +42,9 @@
             v-if="updaterStore.isPrerelease"
             class="text-[10px] font-bold uppercase tracking-wider opacity-70"
           >
-            Pre-Release
+            {{ $t('sidebar.update_pre_release_tag') }}
           </div>
-          <div class="text-xs font-bold uppercase tracking-wide">Update Available</div>
+          <div class="text-xs font-bold uppercase tracking-wide">{{ $t('sidebar.update_available') }}</div>
           <div class="truncate text-xs font-medium opacity-80">v{{ updaterStore.version }}</div>
         </div>
         <span v-if="updaterStore.installing" class="h-4 w-4 animate-spin rounded-full border-2 border-gray-900/30 border-t-gray-900" />
@@ -60,7 +60,7 @@
           : 'text-autonomi-muted hover:bg-autonomi-border/50 hover:text-autonomi-text'"
       >
         <span class="text-base">{{ item.icon }}</span>
-        <span>{{ item.label }}</span>
+        <span>{{ $t(item.labelKey) }}</span>
       </NuxtLink>
     </nav>
 
@@ -74,7 +74,7 @@
           : 'text-autonomi-muted hover:bg-autonomi-border/50 hover:text-autonomi-text'"
       >
         <span class="text-base">⚙</span>
-        <span>Settings</span>
+        <span>{{ $t('nav.settings') }}</span>
       </NuxtLink>
     </div>
   </aside>
@@ -109,18 +109,18 @@ const isPrereleaseBuild = computed(() =>
   /-(?:rc|beta|alpha)\./.test(currentVersion.value ?? ''),
 )
 
-const networkLabel = computed<string | null>(() => {
+const networkLabelKey = computed<string | null>(() => {
   switch (settingsStore.devnetChainId) {
-    case arbitrumSepolia.id: return 'SEPOLIA TESTNET'
-    case ANVIL_CHAIN_ID: return 'DEVNET'
+    case arbitrumSepolia.id: return 'sidebar.network_sepolia'
+    case ANVIL_CHAIN_ID: return 'sidebar.network_devnet'
     default: return null  // mainnet or unset — no badge
   }
 })
 
 const mainNav = computed(() => [
-  { path: '/', label: 'Nodes', icon: '⬡' },
-  { path: '/files', label: 'Files', icon: '◫' },
-  { path: '/wallet', label: 'Wallet', icon: '◎' },
+  { path: '/', labelKey: 'nav.nodes', icon: '⬡' },
+  { path: '/files', labelKey: 'nav.files', icon: '◫' },
+  { path: '/wallet', labelKey: 'nav.wallet', icon: '◎' },
 ])
 
 function isActive(path: string) {

--- a/components/StatusBadge.vue
+++ b/components/StatusBadge.vue
@@ -15,35 +15,43 @@
 </template>
 
 <script setup lang="ts">
-const props = defineProps<{ status: string }>()
+import { useI18n } from 'vue-i18n'
 
-const statusMap: Record<string, { dot: string; label: string; color: string }> = {
+const props = defineProps<{ status: string }>()
+const { t } = useI18n()
+
+// Static-status entries keyed by the backend's status string. `labelKey`
+// resolves to the localized label; dynamic statuses (percentages, "Failed:",
+// "Quote:") bypass this map and surface their raw text — those are
+// untranslated by design until the source emits structured tokens we can
+// interpolate.
+const statusMap: Record<string, { dot: string; labelKey: string; color: string }> = {
   // Node statuses (lowercase, matching ant-core)
-  running: { dot: '●', label: 'Running', color: 'text-autonomi-success' },
-  stopped: { dot: '○', label: 'Stopped', color: 'text-autonomi-muted' },
-  starting: { dot: '◐', label: 'Starting', color: 'text-autonomi-warning' },
-  stopping: { dot: '◐', label: 'Stopping', color: 'text-autonomi-warning' },
-  adding: { dot: '◐', label: 'Adding...', color: 'text-autonomi-warning' },
-  errored: { dot: '●', label: 'Error', color: 'text-autonomi-error' },
-  upgrade_scheduled: { dot: '◐', label: 'Upgrading', color: 'text-autonomi-blue' },
+  running: { dot: '●', labelKey: 'status.node.running', color: 'text-autonomi-success' },
+  stopped: { dot: '○', labelKey: 'status.node.stopped', color: 'text-autonomi-muted' },
+  starting: { dot: '◐', labelKey: 'status.node.starting', color: 'text-autonomi-warning' },
+  stopping: { dot: '◐', labelKey: 'status.node.stopping', color: 'text-autonomi-warning' },
+  adding: { dot: '◐', labelKey: 'status.node.adding', color: 'text-autonomi-warning' },
+  errored: { dot: '●', labelKey: 'status.node.errored', color: 'text-autonomi-error' },
+  upgrade_scheduled: { dot: '◐', labelKey: 'status.node.upgrade_scheduled', color: 'text-autonomi-blue' },
   // File transfer statuses
-  Pending: { dot: '○', label: 'Pending', color: 'text-autonomi-muted' },
-  Quoting: { dot: '◐', label: 'Quoting', color: 'text-autonomi-warning' },
-  'Encrypting…': { dot: '◐', label: 'Encrypting…', color: 'text-autonomi-warning' },
-  'Resolving datamap': { dot: '◐', label: 'Resolving datamap', color: 'text-autonomi-warning' },
-  'Queued: quoting': { dot: '○', label: 'Queued: quoting', color: 'text-autonomi-muted' },
-  'Queued: uploading': { dot: '○', label: 'Queued: uploading', color: 'text-autonomi-muted' },
-  'Connecting to network…': { dot: '◐', label: 'Connecting to network…', color: 'text-autonomi-warning' },
-  'Obtaining quote…': { dot: '◐', label: 'Obtaining quote…', color: 'text-autonomi-warning' },
-  'Saving datamap…': { dot: '◐', label: 'Saving datamap…', color: 'text-autonomi-warning' },
-  'Network unavailable': { dot: '✖', label: 'Network unavailable', color: 'text-autonomi-error' },
-  'Ready to approve': { dot: '●', label: 'Ready to approve', color: 'text-autonomi-blue' },
-  'Awaiting approval': { dot: '◐', label: 'Awaiting approval', color: 'text-autonomi-warning' },
-  Uploading: { dot: '●', label: 'Uploading', color: 'text-autonomi-blue' },
-  Downloading: { dot: '●', label: 'Downloading', color: 'text-autonomi-blue' },
-  Complete: { dot: '●', label: 'Done', color: 'text-autonomi-success' },
-  Done: { dot: '●', label: 'Done', color: 'text-autonomi-success' },
-  Downloaded: { dot: '↓', label: 'Downloaded — click to open', color: 'text-autonomi-blue' },
+  Pending: { dot: '○', labelKey: 'status.file.pending', color: 'text-autonomi-muted' },
+  Quoting: { dot: '◐', labelKey: 'status.file.quoting', color: 'text-autonomi-warning' },
+  'Encrypting…': { dot: '◐', labelKey: 'status.file.encrypting', color: 'text-autonomi-warning' },
+  'Resolving datamap': { dot: '◐', labelKey: 'status.file.resolving_datamap', color: 'text-autonomi-warning' },
+  'Queued: quoting': { dot: '○', labelKey: 'status.file.queued_quoting', color: 'text-autonomi-muted' },
+  'Queued: uploading': { dot: '○', labelKey: 'status.file.queued_uploading', color: 'text-autonomi-muted' },
+  'Connecting to network…': { dot: '◐', labelKey: 'status.file.connecting_to_network', color: 'text-autonomi-warning' },
+  'Obtaining quote…': { dot: '◐', labelKey: 'status.file.obtaining_quote', color: 'text-autonomi-warning' },
+  'Saving datamap…': { dot: '◐', labelKey: 'status.file.saving_datamap', color: 'text-autonomi-warning' },
+  'Network unavailable': { dot: '✖', labelKey: 'status.file.network_unavailable', color: 'text-autonomi-error' },
+  'Ready to approve': { dot: '●', labelKey: 'status.file.ready_to_approve', color: 'text-autonomi-blue' },
+  'Awaiting approval': { dot: '◐', labelKey: 'status.file.awaiting_approval', color: 'text-autonomi-warning' },
+  Uploading: { dot: '●', labelKey: 'status.file.uploading', color: 'text-autonomi-blue' },
+  Downloading: { dot: '●', labelKey: 'status.file.downloading', color: 'text-autonomi-blue' },
+  Complete: { dot: '●', labelKey: 'status.file.done', color: 'text-autonomi-success' },
+  Done: { dot: '●', labelKey: 'status.file.done', color: 'text-autonomi-success' },
+  Downloaded: { dot: '↓', labelKey: 'status.file.downloaded', color: 'text-autonomi-blue' },
 }
 
 const entry = computed(() => {
@@ -58,7 +66,7 @@ const entry = computed(() => {
     return { dot: '●', label: props.status, color: 'text-autonomi-blue', error: false }
   }
   const mapped = statusMap[props.status]
-  if (mapped) return { ...mapped, error: false }
+  if (mapped) return { dot: mapped.dot, label: t(mapped.labelKey), color: mapped.color, error: false }
   return { dot: '?', label: props.status, color: 'text-autonomi-muted', error: false }
 })
 

--- a/components/UpdateDialog.vue
+++ b/components/UpdateDialog.vue
@@ -13,21 +13,21 @@
       >
         <!-- Header -->
         <h2 id="update-dialog-title" class="text-lg font-medium">
-          Update Available
+          {{ $t('updater.dialog.title') }}
         </h2>
         <p class="mt-1 flex items-center gap-2 text-sm text-autonomi-muted">
-          <span>v{{ updaterStore.version }} is ready to install</span>
+          <span>{{ $t('updater.dialog.version_ready', { version: updaterStore.version }) }}</span>
           <span
             v-if="updaterStore.isPrerelease"
             class="rounded bg-teal-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-teal-400"
           >
-            Pre-release
+            {{ $t('updater.dialog.pre_release_badge') }}
           </span>
         </p>
 
         <!-- Download size (shown during download if available) -->
         <p v-if="updaterStore.downloadTotal" class="mt-1 text-xs text-autonomi-muted">
-          Download size: {{ formatBytes(updaterStore.downloadTotal) }}
+          {{ $t('updater.dialog.download_size', { size: formatBytes(updaterStore.downloadTotal) }) }}
         </p>
 
         <!-- Release notes -->
@@ -35,15 +35,15 @@
           v-if="!updaterStore.installing"
           class="mt-4 max-h-56 overflow-auto rounded-md bg-autonomi-surface p-3"
         >
-          <h3 class="mb-2 text-xs font-semibold uppercase tracking-wider text-autonomi-muted">Release Notes</h3>
+          <h3 class="mb-2 text-xs font-semibold uppercase tracking-wider text-autonomi-muted">{{ $t('updater.dialog.release_notes') }}</h3>
           <div v-if="updaterStore.body" class="prose-sm text-xs leading-relaxed text-autonomi-text" v-html="renderMarkdown(updaterStore.body)" />
-          <p v-else class="text-xs text-autonomi-muted">No release notes available for this version.</p>
+          <p v-else class="text-xs text-autonomi-muted">{{ $t('updater.dialog.no_release_notes') }}</p>
         </div>
 
         <!-- Download progress -->
         <div v-if="updaterStore.installing" class="mt-4">
           <div class="flex items-center justify-between text-xs text-autonomi-muted">
-            <span>{{ downloadComplete ? 'Download succeeded, the app will restart shortly' : 'Downloading...' }}</span>
+            <span>{{ downloadComplete ? $t('updater.dialog.download_complete') : $t('updater.dialog.downloading') }}</span>
             <span v-if="!downloadComplete && updaterStore.downloadProgress !== null">{{ updaterStore.downloadProgress }}%</span>
           </div>
           <div class="mt-1.5 h-2 overflow-hidden rounded-full bg-autonomi-surface">
@@ -56,7 +56,7 @@
             {{ formatBytes(updaterStore.downloadedBytes) }} / {{ formatBytes(updaterStore.downloadTotal) }}
           </p>
           <p v-if="!downloadComplete" class="mt-2 text-xs text-autonomi-muted">
-            The app will restart automatically when complete.
+            {{ $t('updater.dialog.auto_restart_hint') }}
           </p>
         </div>
 
@@ -69,10 +69,10 @@
             v-if="updaterStore.installing"
             class="rounded-md border border-autonomi-error/50 px-3 py-1.5 text-sm text-autonomi-error hover:bg-autonomi-error/10 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
             :disabled="downloadComplete"
-            :title="downloadComplete ? 'Installing — please wait' : undefined"
+            :title="downloadComplete ? $t('updater.dialog.installing_tooltip') : undefined"
             @click="cancelDownload"
           >
-            Cancel Download
+            {{ $t('updater.dialog.cancel_download') }}
           </button>
           <span v-else />
 
@@ -82,14 +82,14 @@
               class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
               @click="close"
             >
-              Not Now
+              {{ $t('updater.dialog.not_now') }}
             </button>
             <button
               v-if="!updaterStore.installing"
               class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
               @click="confirm"
             >
-              Update &amp; Restart
+              {{ $t('updater.dialog.update_restart') }}
             </button>
           </div>
         </div>

--- a/components/files/CostEstimateDialog.vue
+++ b/components/files/CostEstimateDialog.vue
@@ -6,14 +6,14 @@
       @click.self="$emit('close')"
     >
       <div role="dialog" aria-modal="true" aria-labelledby="cost-estimate-title" class="w-96 rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl">
-        <h2 id="cost-estimate-title" class="mb-4 text-lg font-medium">Upload Cost Estimate</h2>
+        <h2 id="cost-estimate-title" class="mb-4 text-lg font-medium">{{ $t('files.cost_estimate.title') }}</h2>
 
         <div v-if="loading" class="flex flex-col items-center py-6">
-          <p class="text-sm text-autonomi-muted">Estimating cost...</p>
+          <p class="text-sm text-autonomi-muted">{{ $t('files.cost_estimate.loading') }}</p>
         </div>
 
         <div v-else-if="files.length === 0" class="py-4 text-center text-sm text-autonomi-muted">
-          No files selected
+          {{ $t('files.cost_estimate.no_files') }}
         </div>
 
         <div v-else class="space-y-3">
@@ -27,7 +27,7 @@
               <span v-if="file.size" class="text-autonomi-muted">{{ formatBytes(file.size) }}</span>
               <span v-if="file.cost" class="ml-2 text-autonomi-blue">{{ file.cost }}</span>
               <span v-else class="ml-2 text-autonomi-muted">—</span>
-              <span v-if="file.gas_cost" class="ml-1 text-autonomi-muted">+ {{ file.gas_cost }} gas</span>
+              <span v-if="file.gas_cost" class="ml-1 text-autonomi-muted">{{ $t('files.row.gas_suffix', { gas: file.gas_cost }) }}</span>
             </div>
           </div>
 
@@ -38,7 +38,7 @@
             <template v-if="connectionStore.hasFailed">
               <div class="space-y-2">
                 <p class="text-sm text-yellow-500/80">
-                  Not connected to the Autonomi network — cost estimate unavailable.
+                  {{ $t('files.network.unavailable') }}
                 </p>
                 <p v-if="failedReason" class="text-xs text-autonomi-muted break-words">
                   {{ failedReason }}
@@ -48,26 +48,26 @@
                   class="rounded-md border border-autonomi-blue/40 px-2.5 py-1 text-xs font-medium text-autonomi-blue hover:bg-autonomi-blue/10"
                   @click="connectionStore.retry()"
                 >
-                  Retry connection
+                  {{ $t('files.network.retry_connection') }}
                 </button>
               </div>
             </template>
             <template v-else-if="connectionStore.isConnecting">
               <div class="flex items-center gap-2 text-sm text-autonomi-muted">
                 <div class="h-3 w-3 animate-spin rounded-full border-2 border-yellow-500 border-t-transparent" />
-                <span>Connecting to the Autonomi network…</span>
+                <span>{{ $t('files.network.connecting') }}</span>
               </div>
             </template>
             <template v-else>
               <div class="flex items-center gap-2 text-sm text-autonomi-muted">
                 <div class="h-3 w-3 animate-spin rounded-full border-2 border-autonomi-blue border-t-transparent" />
-                <span>Obtaining quotes from network…</span>
+                <span>{{ $t('files.network.obtaining_quotes') }}</span>
               </div>
             </template>
           </div>
 
           <p v-if="allCostsReal" class="text-xs text-autonomi-muted">
-            Costs queried from the Autonomi network. Gas fees (ETH) apply on top of storage costs.
+            {{ $t('files.cost_estimate.footnote') }}
           </p>
         </div>
 
@@ -76,7 +76,7 @@
             class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
             @click="$emit('close')"
           >
-            Close
+            {{ $t('common.close') }}
           </button>
         </div>
       </div>

--- a/components/files/DatamapSaveAsDialog.vue
+++ b/components/files/DatamapSaveAsDialog.vue
@@ -6,15 +6,15 @@
       @click.self="$emit('close')"
     >
       <div role="dialog" aria-modal="true" aria-labelledby="datamap-saveas-title" class="w-[26rem] rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl">
-        <h2 id="datamap-saveas-title" class="mb-4 text-lg font-medium">Save downloaded file as</h2>
+        <h2 id="datamap-saveas-title" class="mb-4 text-lg font-medium">{{ $t('files.datamap_saveas.title') }}</h2>
 
         <div class="mb-4">
-          <label class="mb-1 block text-xs text-autonomi-muted">Filename</label>
+          <label class="mb-1 block text-xs text-autonomi-muted">{{ $t('files.datamap_saveas.filename_label') }}</label>
           <input
             ref="inputEl"
             v-model="filename"
             type="text"
-            placeholder="myfile.dat"
+            :placeholder="$t('files.datamap_saveas.filename_placeholder')"
             :class="[
               'w-full rounded-md border bg-autonomi-surface px-3 py-2 text-sm text-autonomi-text focus:outline-none',
               filenameError ? 'border-red-500 focus:border-red-500' : 'border-autonomi-border focus:border-autonomi-blue',
@@ -30,14 +30,14 @@
             class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
             @click="$emit('close')"
           >
-            Cancel
+            {{ $t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
             :disabled="!valid"
             @click="confirm"
           >
-            Download
+            {{ $t('common.download') }}
           </button>
         </div>
       </div>

--- a/components/files/DatamapSaveAsDialog.vue
+++ b/components/files/DatamapSaveAsDialog.vue
@@ -22,7 +22,7 @@
             @keyup.enter="confirm"
             @keyup.escape="$emit('close')"
           />
-          <p v-if="filenameError" class="mt-1 text-xs text-red-400">{{ filenameError }}</p>
+          <p v-if="filenameError" class="mt-1 text-xs text-red-400">{{ $t(filenameError) }}</p>
         </div>
 
         <div class="flex justify-end gap-2">

--- a/components/files/DownloadByDatamapDialog.vue
+++ b/components/files/DownloadByDatamapDialog.vue
@@ -6,9 +6,9 @@
       @click.self="$emit('close')"
     >
       <div role="dialog" aria-modal="true" aria-labelledby="datamap-download-title" class="w-[32rem] rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl">
-        <h2 id="datamap-download-title" class="mb-1 text-lg font-medium">Download by Datamap</h2>
+        <h2 id="datamap-download-title" class="mb-1 text-lg font-medium">{{ $t('files.download_by_datamap') }}</h2>
         <p class="mb-4 text-xs text-autonomi-muted">
-          Pick a previous upload to re-download, or browse for a datamap file you received from elsewhere.
+          {{ $t('files.datamap_picker.description') }}
         </p>
 
         <div v-if="candidates.length" class="mb-4 max-h-72 overflow-y-auto rounded-md border border-autonomi-border">
@@ -33,7 +33,7 @@
           </ul>
         </div>
         <div v-else class="mb-4 rounded-md border border-dashed border-autonomi-border px-3 py-6 text-center text-xs text-autonomi-muted">
-          No previous uploads with a saved datamap yet.
+          {{ $t('files.datamap_picker.empty') }}
         </div>
 
         <div class="flex items-center justify-between gap-2">
@@ -41,13 +41,13 @@
             class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
             @click="$emit('browse')"
           >
-            Browse for datamap file…
+            {{ $t('files.datamap_picker.browse_button') }}
           </button>
           <button
             class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
             @click="$emit('close')"
           >
-            Cancel
+            {{ $t('common.cancel') }}
           </button>
         </div>
       </div>

--- a/components/files/DownloadDialog.vue
+++ b/components/files/DownloadDialog.vue
@@ -34,7 +34,7 @@
             @input="onFilenameInput"
             @keyup.enter="confirm"
           />
-          <p v-if="filenameError" class="mt-1 text-xs text-red-400">{{ filenameError }}</p>
+          <p v-if="filenameError" class="mt-1 text-xs text-red-400">{{ $t(filenameError) }}</p>
         </div>
 
         <div class="flex justify-end gap-2">

--- a/components/files/DownloadDialog.vue
+++ b/components/files/DownloadDialog.vue
@@ -6,15 +6,15 @@
       @click.self="$emit('close')"
     >
       <div role="dialog" aria-modal="true" aria-labelledby="download-title" class="w-[28rem] rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl">
-        <h2 id="download-title" class="mb-4 text-lg font-medium">Download File</h2>
+        <h2 id="download-title" class="mb-4 text-lg font-medium">{{ $t('files.download_dialog.title') }}</h2>
 
         <div class="mb-4">
-          <label class="mb-1 block text-xs text-autonomi-muted">File address</label>
+          <label class="mb-1 block text-xs text-autonomi-muted">{{ $t('files.download_dialog.address_label') }}</label>
           <input
             ref="inputEl"
             v-model="address"
             type="text"
-            placeholder="File address (hex)"
+            :placeholder="$t('files.download_dialog.address_placeholder')"
             class="w-full rounded-md border border-autonomi-border bg-autonomi-surface px-3 py-2 font-mono text-sm text-autonomi-text focus:border-autonomi-blue focus:outline-none"
             @keyup.enter="confirm"
             @keyup.escape="$emit('close')"
@@ -22,11 +22,11 @@
         </div>
 
         <div class="mb-4">
-          <label class="mb-1 block text-xs text-autonomi-muted">Save as filename</label>
+          <label class="mb-1 block text-xs text-autonomi-muted">{{ $t('files.download_dialog.filename_label') }}</label>
           <input
             v-model="filename"
             type="text"
-            placeholder="myfile.dat"
+            :placeholder="$t('files.download_dialog.filename_placeholder')"
             :class="[
               'w-full rounded-md border bg-autonomi-surface px-3 py-2 text-sm text-autonomi-text focus:outline-none',
               filenameError ? 'border-red-500 focus:border-red-500' : 'border-autonomi-border focus:border-autonomi-blue',
@@ -42,14 +42,14 @@
             class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
             @click="$emit('close')"
           >
-            Cancel
+            {{ $t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
             :disabled="!valid"
             @click="confirm"
           >
-            Download
+            {{ $t('common.download') }}
           </button>
         </div>
       </div>

--- a/components/files/UploadConfirmDialog.vue
+++ b/components/files/UploadConfirmDialog.vue
@@ -6,7 +6,7 @@
       @click.self="$emit('close')"
     >
       <div role="dialog" aria-modal="true" aria-labelledby="upload-confirm-title" class="w-[36rem] rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl">
-        <h2 id="upload-confirm-title" class="mb-3 text-lg font-medium">Confirm Upload</h2>
+        <h2 id="upload-confirm-title" class="mb-3 text-lg font-medium">{{ $t('files.upload_confirm.title') }}</h2>
 
         <!-- Info banner: dialog is dismissible, job keeps running -->
         <div class="mb-4 flex items-start gap-2 rounded-md border border-autonomi-blue/30 bg-autonomi-blue/5 px-3 py-2">
@@ -14,7 +14,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           <p class="text-xs text-autonomi-muted">
-            You can close this window and come back when the quote is in. The upload stays pending until you approve or cancel it.
+            {{ $t('files.upload_confirm.info_banner') }}
           </p>
         </div>
 
@@ -32,7 +32,7 @@
                   v-if="entry.alreadyStored"
                   class="shrink-0 rounded bg-green-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-green-400"
                 >
-                  Already stored
+                  {{ $t('files.upload_confirm.already_stored_badge') }}
                 </span>
               </span>
               <span class="text-autonomi-muted">{{ entry.size_bytes ? formatBytes(entry.size_bytes) : '-' }}</span>
@@ -46,21 +46,21 @@
                per-file and pretending a single tx covers everything would
                be the same kind of fallback lie we removed for chunk counts. -->
           <div v-if="effectivePaymentMode" class="flex items-baseline justify-between">
-            <span class="text-sm text-autonomi-muted">Payment</span>
+            <span class="text-sm text-autonomi-muted">{{ $t('files.upload_confirm.payment_label') }}</span>
             <div class="text-right">
               <template v-if="effectivePaymentMode === 'mixed' && paymentModeBreakdown">
-                <span class="text-sm font-medium">Mixed</span>
+                <span class="text-sm font-medium">{{ $t('files.upload_confirm.payment_mixed') }}</span>
                 <p class="text-xs text-autonomi-muted">
-                  {{ paymentModeBreakdown.regular }} regular,
-                  {{ paymentModeBreakdown.merkle }} merkle — paid per file.
+                  {{ $t('files.upload_confirm.payment_mixed_detail', {
+                    regular: paymentModeBreakdown.regular,
+                    merkle: paymentModeBreakdown.merkle,
+                  }) }}
                 </p>
               </template>
               <template v-else>
-                <span class="text-sm font-medium">{{ effectivePaymentMode === 'merkle' ? 'Merkle tree' : 'Regular' }}</span>
+                <span class="text-sm font-medium">{{ effectivePaymentMode === 'merkle' ? $t('files.upload_confirm.payment_merkle') : $t('files.upload_confirm.payment_regular') }}</span>
                 <p class="text-xs text-autonomi-muted">
-                  {{ effectivePaymentMode === 'merkle'
-                    ? `Single transaction for ${quotedChunks} chunks — lower gas.`
-                    : `Per-batch payment for ${quotedChunks} chunk${quotedChunks !== 1 ? 's' : ''}.` }}
+                  {{ paymentModeDetail }}
                 </p>
               </template>
             </div>
@@ -75,29 +75,29 @@
                 <svg class="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-                <span>Already stored on the network — free</span>
+                <span>{{ $t('files.upload_confirm.free_title') }}</span>
               </div>
               <p class="text-xs text-autonomi-muted">
-                Every chunk is already present. No ANT or gas will be spent.
+                {{ $t('files.upload_confirm.free_detail') }}
               </p>
             </template>
             <template v-else-if="quotedCost">
               <div class="flex items-center justify-between text-sm font-medium">
-                <span>Network storage cost</span>
+                <span>{{ $t('files.upload_confirm.cost_label') }}</span>
                 <span class="text-autonomi-blue">{{ quotedCost }}</span>
               </div>
               <div class="flex items-center justify-between text-xs text-autonomi-muted">
-                <span>Estimated gas</span>
+                <span>{{ $t('files.upload_confirm.gas_label') }}</span>
                 <span>{{ quotedGas ?? '—' }}</span>
               </div>
               <p v-if="someAlreadyStored" class="text-xs text-green-400">
-                Some files are already stored — that portion costs nothing.
+                {{ $t('files.upload_confirm.some_already_stored') }}
               </p>
             </template>
             <template v-else-if="connectionStore.hasFailed">
               <div class="space-y-2">
                 <div class="text-sm text-yellow-500/80">
-                  Not connected to the Autonomi network — cost estimate unavailable.
+                  {{ $t('files.network.unavailable') }}
                 </div>
                 <div v-if="failedReason" class="text-xs text-autonomi-muted break-words">
                   {{ failedReason }}
@@ -107,27 +107,27 @@
                   class="rounded-md border border-autonomi-blue/40 px-2.5 py-1 text-xs font-medium text-autonomi-blue hover:bg-autonomi-blue/10"
                   @click="connectionStore.retry()"
                 >
-                  Retry connection
+                  {{ $t('files.network.retry_connection') }}
                 </button>
               </div>
             </template>
             <template v-else-if="connectionStore.isConnecting">
               <div class="flex items-center gap-2 text-sm text-autonomi-muted">
                 <div class="h-3 w-3 animate-spin rounded-full border-2 border-yellow-500 border-t-transparent" />
-                <span>Connecting to the Autonomi network…</span>
+                <span>{{ $t('files.network.connecting') }}</span>
               </div>
             </template>
             <template v-else-if="anyQuoting">
               <div class="flex items-center gap-2 text-sm text-autonomi-muted">
                 <div class="h-3 w-3 animate-spin rounded-full border-2 border-autonomi-blue border-t-transparent" />
-                <span>Obtaining quote from network…</span>
+                <span>{{ $t('files.network.obtaining_quote') }}</span>
               </div>
             </template>
           </div>
 
           <!-- Visibility selector -->
           <div>
-            <label class="mb-2 block text-xs font-medium uppercase tracking-wider text-autonomi-muted">Visibility</label>
+            <label class="mb-2 block text-xs font-medium uppercase tracking-wider text-autonomi-muted">{{ $t('files.upload_confirm.visibility_label') }}</label>
             <div class="flex gap-3">
               <!-- Private (default) -->
               <button
@@ -144,10 +144,10 @@
                   >
                     <div v-if="visibility === 'private'" class="h-2 w-2 rounded-full bg-autonomi-blue" />
                   </div>
-                  <span class="text-sm font-medium">Private</span>
+                  <span class="text-sm font-medium">{{ $t('files.upload_confirm.visibility_private') }}</span>
                 </div>
                 <p class="mt-1.5 pl-6 text-xs text-autonomi-muted">
-                  Encrypted and only accessible with your data map. Only you can retrieve the file.
+                  {{ $t('files.upload_confirm.visibility_private_desc') }}
                 </p>
               </button>
 
@@ -167,17 +167,17 @@
                   >
                     <div v-if="visibility === 'public'" class="h-2 w-2 rounded-full bg-autonomi-blue" />
                   </div>
-                  <span class="text-sm font-medium">Public</span>
+                  <span class="text-sm font-medium">{{ $t('files.upload_confirm.visibility_public') }}</span>
                 </div>
                 <p class="mt-1.5 pl-6 text-xs text-autonomi-muted">
-                  Data map is published to the network. Share a single address so anyone can retrieve the file.
+                  {{ $t('files.upload_confirm.visibility_public_desc') }}
                 </p>
               </button>
             </div>
           </div>
 
           <p v-if="quotedCost && !allAlreadyStored && effectivePaymentMode === 'regular'" class="text-xs text-autonomi-muted">
-            Estimated from a single network quote — final cost may vary slightly. Gas fees apply on top.
+            {{ $t('files.upload_confirm.regular_footnote') }}
           </p>
 
           <!-- Buttons grouped by intent: both "back out" actions on the left,
@@ -189,13 +189,13 @@
                 class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
                 @click="$emit('close')"
               >
-                Close
+                {{ $t('common.close') }}
               </button>
               <button
                 class="rounded-md border border-red-500/40 px-3 py-1.5 text-sm text-red-400 hover:bg-red-500/10"
                 @click="$emit('cancelUpload')"
               >
-                Cancel Upload
+                {{ $t('files.upload_confirm.cancel_upload') }}
               </button>
             </div>
             <div class="flex items-center gap-2">
@@ -203,7 +203,7 @@
                 v-if="!canApprove && needsApprovalEntries.length > 1"
                 class="text-xs text-autonomi-muted"
               >
-                Ready: {{ readyCount }} of {{ needsApprovalEntries.length }}
+                {{ $t('files.upload_confirm.ready_count', { ready: readyCount, total: needsApprovalEntries.length }) }}
               </span>
               <button
                 class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
@@ -221,10 +221,13 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { formatBytes } from '~/utils/formatters'
 import { useConnectionStore } from '~/stores/connection'
 import { useFilesStore, type FileEntry } from '~/stores/files'
 import { formatNanoTokens, formatGasCost } from '~/utils/payment'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   open: boolean
@@ -341,8 +344,21 @@ watch(visibility, (val) => {
 
 const approveButtonLabel = computed(() => {
   const n = needsApprovalEntries.value.length
-  if (n <= 1) return 'Approve Upload'
-  return `Approve ${n} Uploads`
+  if (n <= 1) return t('files.upload_confirm.approve_button_one')
+  return t('files.upload_confirm.approve_button_many', { count: n })
+})
+
+/** Mode-detail line under the Payment row for the non-mixed case. Pulled out
+ *  of the template so the `merkle vs regular_one vs regular_many` selection
+ *  doesn't turn into a nested ternary in markup. */
+const paymentModeDetail = computed(() => {
+  const count = quotedChunks.value ?? 0
+  if (effectivePaymentMode.value === 'merkle') {
+    return t('files.upload_confirm.payment_merkle_detail', { count })
+  }
+  return count === 1
+    ? t('files.upload_confirm.payment_regular_detail_one')
+    : t('files.upload_confirm.payment_regular_detail_many', { count })
 })
 
 const failedReason = computed(() =>

--- a/components/nodes/AddNodeDialog.vue
+++ b/components/nodes/AddNodeDialog.vue
@@ -6,10 +6,10 @@
       @click.self="$emit('close')"
     >
       <div role="dialog" aria-modal="true" aria-labelledby="add-node-title" class="w-96 rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl">
-        <h2 id="add-node-title" class="mb-4 text-lg font-medium">Add Nodes</h2>
+        <h2 id="add-node-title" class="mb-4 text-lg font-medium">{{ $t('nodes.add_dialog.title') }}</h2>
 
         <div class="mb-4">
-          <label class="mb-1 block text-xs text-autonomi-muted">Number of nodes</label>
+          <label class="mb-1 block text-xs text-autonomi-muted">{{ $t('nodes.add_dialog.number_label') }}</label>
           <input
             ref="inputEl"
             v-model.number="count"
@@ -20,12 +20,12 @@
             @keyup.enter="confirm"
             @keyup.escape="$emit('close')"
           />
-          <p class="mt-1 text-xs text-autonomi-muted">Between 1 and 50</p>
+          <p class="mt-1 text-xs text-autonomi-muted">{{ $t('nodes.add_dialog.range_hint') }}</p>
         </div>
 
         <div v-if="!earningsSet" class="mb-4 rounded-md border border-autonomi-warning/30 bg-yellow-950/30 p-3">
           <p class="text-xs text-autonomi-warning">
-            No earnings address configured. Set one in the Wallet page before adding nodes.
+            {{ $t('nodes.add_dialog.no_earnings_warning') }}
           </p>
         </div>
 
@@ -34,14 +34,14 @@
             class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
             @click="$emit('close')"
           >
-            Cancel
+            {{ $t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
             :disabled="!valid"
             @click="confirm"
           >
-            Add {{ count }} Node{{ count !== 1 ? 's' : '' }}
+            {{ count === 1 ? $t('nodes.add_dialog.submit_one') : $t('nodes.add_dialog.submit_many', { count }) }}
           </button>
         </div>
       </div>

--- a/components/nodes/NodeDetail.vue
+++ b/components/nodes/NodeDetail.vue
@@ -3,15 +3,15 @@
     <td :colspan="colspan" class="px-4 py-4">
       <div class="grid grid-cols-2 gap-x-8 gap-y-2 text-sm">
         <div>
-          <span class="text-autonomi-muted">Node ID</span>
+          <span class="text-autonomi-muted">{{ $t('nodes.field.node_id') }}</span>
           <p class="font-mono text-xs">{{ node.id }}</p>
         </div>
         <div>
-          <span class="text-autonomi-muted">Status</span>
+          <span class="text-autonomi-muted">{{ $t('nodes.field.status') }}</span>
           <p><StatusBadge :status="node.status" /></p>
         </div>
         <div>
-          <span class="text-autonomi-muted">Version</span>
+          <span class="text-autonomi-muted">{{ $t('nodes.field.version') }}</span>
           <p>
             {{ node.version }}<span
               v-if="node.pending_version"
@@ -20,27 +20,27 @@
           </p>
         </div>
         <div>
-          <span class="text-autonomi-muted">PID</span>
+          <span class="text-autonomi-muted">{{ $t('nodes.field.pid') }}</span>
           <p class="font-mono text-xs">{{ node.pid ?? '-' }}</p>
         </div>
         <div>
-          <span class="text-autonomi-muted">Uptime</span>
+          <span class="text-autonomi-muted">{{ $t('nodes.field.uptime') }}</span>
           <p>{{ node.uptime_secs ? formatUptime(node.uptime_secs) : '-' }}</p>
         </div>
         <div>
-          <span class="text-autonomi-muted">Storage</span>
+          <span class="text-autonomi-muted">{{ $t('nodes.field.storage') }}</span>
           <p>{{ node.storage_bytes != null ? formatBytes(node.storage_bytes) : '-' }}</p>
         </div>
         <div class="col-span-2">
-          <span class="text-autonomi-muted">Data Directory</span>
+          <span class="text-autonomi-muted">{{ $t('nodes.field.data_directory') }}</span>
           <p class="font-mono text-xs">{{ node.data_dir }}</p>
         </div>
         <div class="col-span-2">
-          <span class="text-autonomi-muted">Log Directory</span>
+          <span class="text-autonomi-muted">{{ $t('nodes.field.log_directory') }}</span>
           <p class="font-mono text-xs">{{ node.log_dir }}</p>
         </div>
         <div v-if="node.rewards_address" class="col-span-2">
-          <span class="text-autonomi-muted">Rewards Address</span>
+          <span class="text-autonomi-muted">{{ $t('nodes.field.rewards_address') }}</span>
           <p class="font-mono text-xs">{{ node.rewards_address }}</p>
         </div>
       </div>
@@ -51,21 +51,21 @@
           class="rounded-md bg-autonomi-blue px-3 py-1 text-xs font-medium text-white hover:opacity-90"
           @click="$emit('start', node.id)"
         >
-          Start
+          {{ $t('common.start') }}
         </button>
         <button
           v-if="node.status === 'running'"
           class="rounded-md border border-autonomi-border px-3 py-1 text-xs text-autonomi-muted hover:text-autonomi-text"
           @click="$emit('stop', node.id)"
         >
-          Stop
+          {{ $t('common.stop') }}
         </button>
         <button
           v-if="node.status === 'stopped' || node.status === 'errored'"
           class="rounded-md border border-autonomi-border px-3 py-1 text-xs text-autonomi-muted hover:text-autonomi-text"
           @click="$emit('remove', node.id)"
         >
-          Remove
+          {{ $t('common.remove') }}
         </button>
       </div>
     </td>

--- a/components/nodes/NodeDetailPanel.vue
+++ b/components/nodes/NodeDetailPanel.vue
@@ -2,11 +2,11 @@
   <div class="rounded-xl border border-autonomi-blue/30 bg-autonomi-surface p-5">
     <div class="mb-4 flex items-center justify-between">
       <div class="flex items-center gap-3">
-        <h3 class="text-base font-medium text-autonomi-text">{{ node.name || `Node ${node.id}` }}</h3>
+        <h3 class="text-base font-medium text-autonomi-text">{{ node.name || $t('nodes.node_fallback_name', { id: node.id }) }}</h3>
         <StatusBadge :status="node.status" />
       </div>
       <button
-        aria-label="Close panel"
+        :aria-label="$t('common.close_panel')"
         class="text-autonomi-muted hover:text-autonomi-text"
         @click="$emit('close')"
       >
@@ -18,7 +18,7 @@
 
     <div class="grid grid-cols-2 gap-x-8 gap-y-3 text-sm lg:grid-cols-4">
       <div>
-        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Version</p>
+        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">{{ $t('nodes.field.version') }}</p>
         <p class="text-autonomi-text">
           {{ node.version }}<span
             v-if="node.pending_version"
@@ -27,35 +27,35 @@
         </p>
       </div>
       <div>
-        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">PID</p>
+        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">{{ $t('nodes.field.pid') }}</p>
         <p class="font-mono text-xs text-autonomi-text">{{ node.pid ?? '-' }}</p>
       </div>
       <div>
-        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Uptime</p>
+        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">{{ $t('nodes.field.uptime') }}</p>
         <p class="text-autonomi-text">{{ node.uptime_secs ? formatUptime(node.uptime_secs) : '-' }}</p>
       </div>
       <div>
-        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Storage</p>
+        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">{{ $t('nodes.field.storage') }}</p>
         <p class="text-autonomi-text">{{ node.storage_bytes != null ? formatBytes(node.storage_bytes) : '-' }}</p>
       </div>
       <div v-if="node.data_dir" class="col-span-2">
-        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Data Directory</p>
+        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">{{ $t('nodes.field.data_directory') }}</p>
         <p class="font-mono text-xs text-autonomi-text">{{ node.data_dir }}</p>
       </div>
       <div v-if="node.log_dir" class="col-span-2">
-        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Log Directory</p>
+        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">{{ $t('nodes.field.log_directory') }}</p>
         <p class="font-mono text-xs text-autonomi-text">{{ node.log_dir }}</p>
       </div>
       <div v-if="node.node_port" class="col-span-1">
-        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Port</p>
+        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">{{ $t('nodes.field.port') }}</p>
         <p class="font-mono text-xs text-autonomi-text">{{ node.node_port }}</p>
       </div>
       <div v-if="node.binary_path" class="col-span-2 lg:col-span-3">
-        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Binary</p>
+        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">{{ $t('nodes.field.binary') }}</p>
         <p class="font-mono text-xs text-autonomi-text">{{ node.binary_path }}</p>
       </div>
       <div v-if="node.rewards_address" class="col-span-2 lg:col-span-4">
-        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Rewards Address</p>
+        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">{{ $t('nodes.field.rewards_address') }}</p>
         <p class="font-mono text-xs text-autonomi-text">{{ node.rewards_address }}</p>
       </div>
     </div>
@@ -66,21 +66,21 @@
         class="rounded-md bg-autonomi-blue px-3 py-1.5 text-xs font-medium text-white hover:opacity-90"
         @click="$emit('start', node.id)"
       >
-        Start
+        {{ $t('common.start') }}
       </button>
       <button
         v-if="node.status === 'running'"
         class="rounded-md border border-autonomi-border px-3 py-1.5 text-xs text-autonomi-muted hover:text-autonomi-text"
         @click="$emit('stop', node.id)"
       >
-        Stop
+        {{ $t('common.stop') }}
       </button>
       <button
         v-if="node.status === 'stopped' || node.status === 'errored'"
         class="rounded-md border border-autonomi-error/50 px-3 py-1.5 text-xs text-autonomi-error hover:bg-autonomi-error/10"
         @click="$emit('remove', node.id)"
       >
-        Remove
+        {{ $t('common.remove') }}
       </button>
     </div>
   </div>

--- a/components/nodes/NodeTile.vue
+++ b/components/nodes/NodeTile.vue
@@ -8,7 +8,7 @@
     @click="$emit('select', node.id)"
   >
     <!-- Status indicator dot -->
-    <div class="absolute left-3 top-3" :aria-label="`Status: ${node.status}`" role="img">
+    <div class="absolute left-3 top-3" :aria-label="$t('nodes.field.status_aria', { status: node.status })" role="img">
       <span class="relative flex h-2.5 w-2.5">
         <span
           v-if="node.status === 'running' || node.status === 'adding' || node.status === 'upgrade_scheduled'"
@@ -21,7 +21,7 @@
 
     <!-- Node name / ID -->
     <div class="mb-3 mt-1 pl-5">
-      <p class="text-sm font-medium text-autonomi-text">{{ node.name || `Node ${node.id}` }}</p>
+      <p class="text-sm font-medium text-autonomi-text">{{ node.name || $t('nodes.node_fallback_name', { id: node.id }) }}</p>
       <p v-if="node.version" class="text-[10px] text-autonomi-muted">
         v{{ node.version }}<span
           v-if="node.pending_version"
@@ -33,15 +33,15 @@
     <!-- Stats grid -->
     <div class="grid grid-cols-2 gap-x-3 gap-y-1.5">
       <div>
-        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">PID</p>
+        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">{{ $t('nodes.field.pid') }}</p>
         <p class="text-sm font-mono text-autonomi-text">{{ node.pid ?? '-' }}</p>
       </div>
       <div>
-        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Uptime</p>
+        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">{{ $t('nodes.field.uptime') }}</p>
         <p class="text-sm font-mono text-autonomi-text">{{ node.uptime_secs ? formatUptime(node.uptime_secs) : '-' }}</p>
       </div>
       <div>
-        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">Storage</p>
+        <p class="text-[10px] uppercase tracking-wider text-autonomi-muted">{{ $t('nodes.field.storage') }}</p>
         <p class="text-sm font-mono text-autonomi-text">{{ node.storage_bytes != null ? formatBytes(node.storage_bytes) : '-' }}</p>
       </div>
     </div>

--- a/composables/useLocale.ts
+++ b/composables/useLocale.ts
@@ -3,15 +3,16 @@ import { locale as osLocaleApi } from '@tauri-apps/plugin-os'
 import { useI18n } from 'vue-i18n'
 import { useSettingsStore } from '~/stores/settings'
 
-export const SUPPORTED_LOCALES = ['en', 'ja'] as const
+export const SUPPORTED_LOCALES = ['en', 'ja', 'nl'] as const
 export type SupportedLocale = typeof SUPPORTED_LOCALES[number]
 const DEFAULT_LOCALE: SupportedLocale = 'en'
 
 /** Each locale's name in its own script. Used in the Settings picker so the
- *  user sees "English" / "日本語" regardless of the currently-active UI locale. */
+ *  user sees "English" / "日本語" / "Nederlands" regardless of the currently-active UI locale. */
 export const NATIVE_LOCALE_NAMES: Record<SupportedLocale, string> = {
   en: 'English',
   ja: '日本語',
+  nl: 'Nederlands',
 }
 
 /** Module-scoped cache of the OS-resolved locale. Warmed on the first

--- a/composables/useLocale.ts
+++ b/composables/useLocale.ts
@@ -3,16 +3,18 @@ import { locale as osLocaleApi } from '@tauri-apps/plugin-os'
 import { useI18n } from 'vue-i18n'
 import { useSettingsStore } from '~/stores/settings'
 
-export const SUPPORTED_LOCALES = ['en', 'ja', 'nl'] as const
+export const SUPPORTED_LOCALES = ['en', 'ja', 'nl', 'fr'] as const
 export type SupportedLocale = typeof SUPPORTED_LOCALES[number]
 const DEFAULT_LOCALE: SupportedLocale = 'en'
 
 /** Each locale's name in its own script. Used in the Settings picker so the
- *  user sees "English" / "日本語" / "Nederlands" regardless of the currently-active UI locale. */
+ *  user sees "English" / "日本語" / "Nederlands" / "Français" regardless of
+ *  the currently-active UI locale. */
 export const NATIVE_LOCALE_NAMES: Record<SupportedLocale, string> = {
   en: 'English',
   ja: '日本語',
   nl: 'Nederlands',
+  fr: 'Français',
 }
 
 /** Module-scoped cache of the OS-resolved locale. Warmed on the first

--- a/composables/useLocale.ts
+++ b/composables/useLocale.ts
@@ -1,0 +1,80 @@
+import { ref } from 'vue'
+import { locale as osLocaleApi } from '@tauri-apps/plugin-os'
+import { useI18n } from 'vue-i18n'
+import { useSettingsStore } from '~/stores/settings'
+
+export const SUPPORTED_LOCALES = ['en', 'ja'] as const
+export type SupportedLocale = typeof SUPPORTED_LOCALES[number]
+const DEFAULT_LOCALE: SupportedLocale = 'en'
+
+/** Each locale's name in its own script. Used in the Settings picker so the
+ *  user sees "English" / "日本語" regardless of the currently-active UI locale. */
+export const NATIVE_LOCALE_NAMES: Record<SupportedLocale, string> = {
+  en: 'English',
+  ja: '日本語',
+}
+
+/** Module-scoped cache of the OS-resolved locale. Warmed on the first
+ *  detectOsLocale() call so the Settings picker can render
+ *  "System default: <name>" synchronously after app init. */
+const osLocaleRef = ref<SupportedLocale | null>(null)
+
+function isSupported(value: string): value is SupportedLocale {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(value)
+}
+
+function normalizeLocale(raw: string | null | undefined): SupportedLocale {
+  if (!raw) return DEFAULT_LOCALE
+  const base = raw.toLowerCase().split('-')[0]
+  return isSupported(base) ? base : DEFAULT_LOCALE
+}
+
+export async function detectOsLocale(): Promise<SupportedLocale> {
+  if (osLocaleRef.value !== null) return osLocaleRef.value
+  try {
+    osLocaleRef.value = normalizeLocale(await osLocaleApi())
+  } catch {
+    osLocaleRef.value = DEFAULT_LOCALE
+  }
+  return osLocaleRef.value
+}
+
+export function useLocale() {
+  const { locale, t } = useI18n()
+  const settings = useSettingsStore()
+
+  /**
+   * Resolve and apply the locale to use at app start. Order:
+   *   1. Persisted user choice (`settings.i18nLocale`) if supported.
+   *   2. OS locale via tauri-plugin-os, region-stripped.
+   *   3. Fallback `en`.
+   *
+   * Always warms the OS-locale cache so the Settings picker can render its
+   * "System default: <name>" label without an extra round-trip.
+   */
+  async function init() {
+    const persisted = settings.i18nLocale
+    if (persisted && isSupported(persisted)) {
+      locale.value = persisted
+      // Warm the OS cache for the Settings picker label even when the
+      // persisted choice overrides it.
+      detectOsLocale().catch(() => {})
+      return
+    }
+    locale.value = await detectOsLocale()
+  }
+
+  /** Switch the active locale. `null` means "follow system" — the persisted
+   *  choice is cleared and the live locale falls back to the OS reading. */
+  async function setLocale(next: SupportedLocale | null) {
+    if (next === null) {
+      await settings.setI18nLocale(null)
+      locale.value = await detectOsLocale()
+      return
+    }
+    await settings.setI18nLocale(next)
+    locale.value = next
+  }
+
+  return { locale, setLocale, init, t, osLocale: osLocaleRef }
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -225,6 +225,23 @@
       "no_earnings_warning": "No earnings address configured. Set one in the Wallet page before adding nodes.",
       "submit_one": "Add 1 Node",
       "submit_many": "Add {count} Nodes"
+    },
+    "toast": {
+      "added": "Added {count} node(s)",
+      "add_failed": "Failed to add nodes: {error}",
+      "started": "Node {id} started",
+      "start_failed": "Failed to start node {id}: {error}",
+      "stopped": "Node {id} stopped",
+      "stop_failed": "Failed to stop node {id}: {error}",
+      "removed": "Node {id} removed",
+      "remove_failed": "Failed to remove node {id}: {error}",
+      "no_stopped": "No stopped nodes to start",
+      "no_running": "No running nodes to stop",
+      "node_failed": "Node {id} failed: {error}",
+      "started_count": "Started {count} node(s)",
+      "stopped_count": "Stopped {count} node(s)",
+      "start_all_failed": "Failed to start all: {error}",
+      "stop_all_failed": "Failed to stop all: {error}"
     }
   },
   "files": {
@@ -287,7 +304,14 @@
       "public_address_copied": "Public address copied — share to let others download this file",
       "datamap_path_copied": "Datamap path copied to clipboard",
       "already_stored_one": "1 file already stored — saving datamap",
-      "already_stored_many": "{count} files already stored — saving datamap"
+      "already_stored_many": "{count} files already stored — saving datamap",
+      "upload_complete": "Upload complete: {name}",
+      "upload_failed": "Upload failed: {name} — {error}",
+      "payment_failed": "Payment failed: {error}",
+      "download_complete": "Download complete: {name}",
+      "download_failed": "Download failed: {name} — {error}",
+      "datamap_missing": "Cannot download: datamap file missing or unreadable",
+      "datamap_read_failed": "Could not read datamap: {error}"
     },
     "error": {
       "wallet_not_connected": "Wallet not connected",
@@ -383,6 +407,34 @@
       "earnings_saved": "Earnings address saved",
       "earnings_set_to_payment": "Earnings address set to payment wallet",
       "wallet_disconnected": "Wallet disconnected"
+    }
+  },
+  "updater": {
+    "dialog": {
+      "title": "Update Available",
+      "version_ready": "v{version} is ready to install",
+      "pre_release_badge": "Pre-release",
+      "download_size": "Download size: {size}",
+      "release_notes": "Release Notes",
+      "no_release_notes": "No release notes available for this version.",
+      "downloading": "Downloading…",
+      "download_complete": "Download succeeded, the app will restart shortly",
+      "auto_restart_hint": "The app will restart automatically when complete.",
+      "cancel_download": "Cancel Download",
+      "installing_tooltip": "Installing — please wait",
+      "not_now": "Not Now",
+      "update_restart": "Update & Restart"
+    },
+    "toast": {
+      "install_no_restart": "Update to v{version} installed but the app didn't restart. Quit and reopen Autonomi to finish updating.",
+      "install_failed": "Update install failed: {error}"
+    }
+  },
+  "validators": {
+    "filename": {
+      "has_special_chars": "Filename cannot contain special characters",
+      "ends_with_dot_or_space": "Filename cannot end with a dot or space",
+      "reserved_on_windows": "That name is reserved on Windows"
     }
   },
   "status": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,34 @@
+{
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "UI display language",
+      "system_default": "System default: {name}",
+      "system_default_pending": "System default"
+    }
+  },
+  "nav": {
+    "nodes": "Nodes",
+    "files": "Files",
+    "wallet": "Wallet",
+    "settings": "Settings"
+  },
+  "header": {
+    "title": "Autonomi",
+    "active_transfers": "{count} active",
+    "connecting": "Connecting",
+    "connecting_tooltip": "Connecting to the Autonomi network",
+    "connected": "Network",
+    "connected_tooltip": "Connected to the Autonomi network",
+    "offline": "Offline · Retry",
+    "offline_tooltip": "Connection failed — click to retry",
+    "connect_wallet": "Connect Wallet"
+  },
+  "sidebar": {
+    "pre_release": "PRE-RELEASE",
+    "update_available": "Update Available",
+    "update_pre_release_tag": "Pre-Release",
+    "network_devnet": "DEVNET",
+    "network_sepolia": "SEPOLIA TESTNET"
+  }
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -5,6 +5,149 @@
       "description": "UI display language",
       "system_default": "System default: {name}",
       "system_default_pending": "System default"
+    },
+    "indelible": {
+      "title": "Indelible Enterprise",
+      "subtitle_connected": "Connected to managed storage gateway",
+      "subtitle_setup": "Connect to a self-hosted Indelible gateway for managed storage",
+      "connected_badge": "Connected",
+      "server_label": "Server",
+      "signed_in_as": "Signed in as",
+      "disconnect": "Disconnect",
+      "server_url_label": "Server URL",
+      "server_url_placeholder": "https://files.acme.com",
+      "api_key_label": "API Key",
+      "api_key_placeholder": "Your API token",
+      "test_connect": "Test & Connect",
+      "testing": "Testing…",
+      "configure": "Configure Connection"
+    },
+    "storage": {
+      "title": "Storage Directory",
+      "description": "Where node data is stored on disk",
+      "default": "Default",
+      "browse": "Browse",
+      "warning": "Only applies to newly added nodes. Existing nodes keep their current directory."
+    },
+    "downloads": {
+      "title": "Downloads Directory",
+      "description": "Where downloaded files are saved",
+      "not_set": "Not set",
+      "browse": "Browse"
+    },
+    "alert": {
+      "title": "Alert Sound",
+      "description": "Play sound on critical node failures",
+      "aria_toggle": "Toggle alert sound"
+    },
+    "theme": {
+      "title": "Light Mode",
+      "description": "Switch between dark and light themes",
+      "aria_toggle": "Toggle light mode"
+    },
+    "advanced": {
+      "hide": "▾ Hide Advanced",
+      "show": "▸ Show Advanced"
+    },
+    "daemon": {
+      "title": "Node daemon",
+      "description": "Restart the background service that supervises your nodes. Your running nodes keep running — only the supervisor is swapped.",
+      "restart": "Restart daemon",
+      "restarting": "Restarting…"
+    },
+    "concurrency": {
+      "title": "Upload concurrency",
+      "description_1": "This controls how many quotes/uploads can be running at the same time.",
+      "description_2": "Note that this has a very large impact on performance."
+    },
+    "prerelease": {
+      "title": "Pre-release builds",
+      "description": "Receive auto-updates for pre-release builds (rc / beta) in addition to stable releases. Off by default.",
+      "restart_required": "Restart the app to apply this change.",
+      "restart_now": "Restart now"
+    },
+    "direct_wallet": {
+      "title": "Direct Wallet",
+      "description": "Connect with a private key (bypasses WalletConnect)",
+      "connected_badge": "Connected",
+      "address_label": "Address",
+      "disconnect": "Disconnect",
+      "network_label": "Network",
+      "network_sepolia_option": "Arbitrum Sepolia (testnet)",
+      "network_arbitrum_option": "Arbitrum One (mainnet)",
+      "rpc_url_label": "RPC URL",
+      "rpc_url_optional": "(optional)",
+      "rpc_url_placeholder": "Defaults to public RPC for the selected chain",
+      "private_key_label": "Private Key",
+      "private_key_placeholder": "0x... or raw hex",
+      "connect": "Connect",
+      "import_button": "Import Private Key"
+    },
+    "diagnostics": {
+      "title": "Diagnostics",
+      "summary": "{entries} log entries ({errors} errors)",
+      "copy_button": "Copy to Clipboard",
+      "clear_button": "Clear",
+      "empty": "No log entries",
+      "hide_log": "▾ Hide Log",
+      "show_log": "▸ Show Log"
+    },
+    "upload_history": {
+      "title": "Upload history",
+      "summary_one": "{count} settled entry in upload_history.json. DataMaps on disk and chunks on the network are untouched.",
+      "summary_many": "{count} settled entries in upload_history.json. DataMaps on disk and chunks on the network are untouched.",
+      "clear_button": "Clear history",
+      "confirm_one": "Clear 1 upload entry from history?\n\nThis removes the local row + persisted record. The DataMaps on disk and the chunks on the network are unaffected.",
+      "confirm_many": "Clear {count} upload entries from history?\n\nThis removes the local row + persisted record. The DataMaps on disk and the chunks on the network are unaffected."
+    },
+    "software": {
+      "title": "Software",
+      "version_label": "Version",
+      "last_checked": "Last checked {label}",
+      "check_button": "Check for Updates",
+      "checking": "Checking…"
+    },
+    "about": {
+      "title": "About",
+      "node_version_label": "Node daemon version"
+    },
+    "relative_time": {
+      "just_now": "just now",
+      "seconds_ago": "{n}s ago",
+      "minutes_ago": "{n} min ago",
+      "hours_ago": "{n}h ago",
+      "days_ago": "{n}d ago"
+    },
+    "picker": {
+      "storage_title": "Select Storage Directory",
+      "downloads_title": "Select Downloads Directory"
+    },
+    "error": {
+      "private_key_invalid": "Invalid private key — must be 64 hex characters",
+      "invalid_eth_address": "Invalid EVM address format"
+    },
+    "toast": {
+      "upload_history_cleared": "Upload history cleared",
+      "update_check_failed": "Update check failed",
+      "update_available": "Update available: v{version}",
+      "on_latest_version": "You're on the latest version (v{version})",
+      "daemon_restarted": "Daemon restarted",
+      "daemon_restart_failed": "Failed to restart daemon: {error}",
+      "storage_dir_updated": "Storage directory updated",
+      "storage_dir_verified": "Storage directory verified",
+      "storage_dir_unwritable": "Cannot use that folder for node storage",
+      "select_directory_failed": "Failed to select directory",
+      "downloads_dir_updated": "Downloads directory updated",
+      "earnings_updated": "Earnings address updated",
+      "daemon_url_updated": "Daemon URL updated",
+      "diagnostics_copied": "Diagnostics copied to clipboard",
+      "diagnostics_copy_failed": "Failed to copy to clipboard",
+      "log_cleared": "Log cleared",
+      "indelible_connected": "Connected to Indelible",
+      "indelible_disconnected": "Disconnected from Indelible",
+      "wallet_connected": "Wallet connected: {address}",
+      "wallet_disconnected": "Wallet disconnected",
+      "wallet_attach_failed": "Wallet attach (Rust side) failed: {error}"
     }
   },
   "nav": {
@@ -30,5 +173,245 @@
     "update_pre_release_tag": "Pre-Release",
     "network_devnet": "DEVNET",
     "network_sepolia": "SEPOLIA TESTNET"
+  },
+  "common": {
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "close": "Close",
+    "download": "Download",
+    "start": "Start",
+    "stop": "Stop",
+    "remove": "Remove",
+    "close_panel": "Close panel"
+  },
+  "nodes": {
+    "add_button": "+ Add Nodes",
+    "start_all": "Start All",
+    "stop_all": "Stop All",
+    "running_count": "{count} running",
+    "stopped_count": "{count} stopped",
+    "errored_count": "{count} errored",
+    "filter_placeholder": "Filter...",
+    "filter_aria_label": "Filter nodes",
+    "starting_daemon": "Starting node daemon…",
+    "restarting_daemon": "Restarting node daemon…",
+    "nodes_keep_running": "Your nodes keep running.",
+    "daemon_disconnected": "Cannot connect to node daemon",
+    "daemon_retrying": "Retrying automatically…",
+    "empty_title": "No nodes yet",
+    "empty_hint": "Click \"+ Add Nodes\" to get started",
+    "confirm_action": "Confirm action",
+    "remove_node_message": "Remove node {id}? This will delete all its data.",
+    "stop_all_message": "Stop all {count} running nodes?",
+    "node_fallback_name": "Node {id}",
+    "field": {
+      "node_id": "Node ID",
+      "status": "Status",
+      "version": "Version",
+      "pid": "PID",
+      "uptime": "Uptime",
+      "storage": "Storage",
+      "data_directory": "Data Directory",
+      "log_directory": "Log Directory",
+      "port": "Port",
+      "binary": "Binary",
+      "rewards_address": "Rewards Address",
+      "status_aria": "Status: {status}"
+    },
+    "add_dialog": {
+      "title": "Add Nodes",
+      "number_label": "Number of nodes",
+      "range_hint": "Between 1 and 50",
+      "no_earnings_warning": "No earnings address configured. Set one in the Wallet page before adding nodes.",
+      "submit_one": "Add 1 Node",
+      "submit_many": "Add {count} Nodes"
+    }
+  },
+  "files": {
+    "upload_button": "Upload File(s)",
+    "estimate_button": "Estimate Cost",
+    "download_by_address": "Download by Address",
+    "download_by_datamap": "Download by Datamap",
+    "uploads_heading": "Uploads",
+    "downloads_heading": "Downloads",
+    "clear": "Clear",
+    "drop_files": "Drop files to upload",
+    "uploads_empty_title": "No uploads yet",
+    "uploads_empty_hint": "Drag files here, or use the buttons above",
+    "downloads_empty_title": "No downloads yet",
+    "downloads_empty_hint": "Use \"Download by Address\" or \"Download by Datamap\"",
+    "table": {
+      "name": "Name",
+      "status": "Status",
+      "size": "Size",
+      "cost": "Cost",
+      "date": "Date",
+      "address": "Address",
+      "saved_to": "Saved to",
+      "actions": "Actions"
+    },
+    "row": {
+      "free_already_stored": "Free — already stored",
+      "gas_suffix": "+ {gas} gas",
+      "public_badge": "Public",
+      "retry": "↻ Retry",
+      "public_tooltip": "Public upload — click to copy the shareable network address",
+      "reveal_datamap_tooltip": "Reveal datamap file in Finder/Explorer",
+      "copy_datamap_tooltip": "Copy datamap file path",
+      "copy_address_tooltip": "Copy network address",
+      "retry_tooltip": "Retry upload",
+      "remove_tooltip": "Remove from list"
+    },
+    "stage": {
+      "encrypting": "Encrypting…",
+      "quoting_pct": "Quoting · {pct}%",
+      "quoting_indeterminate": "Quoting…",
+      "storing_pct": "Storing · {pct}%",
+      "storing_indeterminate": "Storing…",
+      "resolving_pct": "Resolving datamap · {pct}%",
+      "resolving_indeterminate": "Resolving datamap…",
+      "downloading_pct": "Downloading · {pct}%",
+      "downloading_indeterminate": "Downloading…"
+    },
+    "picker": {
+      "upload_title": "Select files to upload",
+      "datamap_title": "Select a datamap file to download",
+      "estimate_title": "Select files to estimate cost",
+      "datamap_filter": "Datamap"
+    },
+    "toast": {
+      "upload_requires_wallet": "Upload requires a wallet",
+      "download_requires_network": "Download requires network connection",
+      "open_folder_failed": "Could not open folder",
+      "address_copied": "Address copied to clipboard",
+      "public_address_copied": "Public address copied — share to let others download this file",
+      "datamap_path_copied": "Datamap path copied to clipboard",
+      "already_stored_one": "1 file already stored — saving datamap",
+      "already_stored_many": "{count} files already stored — saving datamap"
+    },
+    "error": {
+      "wallet_not_connected": "Wallet not connected",
+      "not_connected_to_network": "Not connected to network"
+    },
+    "network": {
+      "unavailable": "Not connected to the Autonomi network — cost estimate unavailable.",
+      "retry_connection": "Retry connection",
+      "connecting": "Connecting to the Autonomi network…",
+      "obtaining_quote": "Obtaining quote from network…",
+      "obtaining_quotes": "Obtaining quotes from network…"
+    },
+    "datamap_saveas": {
+      "title": "Save downloaded file as",
+      "filename_label": "Filename",
+      "filename_placeholder": "myfile.dat"
+    },
+    "download_dialog": {
+      "title": "Download File",
+      "address_label": "File address",
+      "address_placeholder": "File address (hex)",
+      "filename_label": "Save as filename",
+      "filename_placeholder": "myfile.dat"
+    },
+    "datamap_picker": {
+      "description": "Pick a previous upload to re-download, or browse for a datamap file you received from elsewhere.",
+      "empty": "No previous uploads with a saved datamap yet.",
+      "browse_button": "Browse for datamap file…"
+    },
+    "cost_estimate": {
+      "title": "Upload Cost Estimate",
+      "loading": "Estimating cost…",
+      "no_files": "No files selected",
+      "footnote": "Costs queried from the Autonomi network. Gas fees (ETH) apply on top of storage costs."
+    },
+    "upload_confirm": {
+      "title": "Confirm Upload",
+      "info_banner": "You can close this window and come back when the quote is in. The upload stays pending until you approve or cancel it.",
+      "already_stored_badge": "Already stored",
+      "payment_label": "Payment",
+      "payment_mixed": "Mixed",
+      "payment_mixed_detail": "{regular} regular, {merkle} merkle — paid per file.",
+      "payment_merkle": "Merkle tree",
+      "payment_regular": "Regular",
+      "payment_merkle_detail": "Single transaction for {count} chunks — lower gas.",
+      "payment_regular_detail_one": "Per-batch payment for 1 chunk.",
+      "payment_regular_detail_many": "Per-batch payment for {count} chunks.",
+      "free_title": "Already stored on the network — free",
+      "free_detail": "Every chunk is already present. No ANT or gas will be spent.",
+      "cost_label": "Network storage cost",
+      "gas_label": "Estimated gas",
+      "some_already_stored": "Some files are already stored — that portion costs nothing.",
+      "visibility_label": "Visibility",
+      "visibility_private": "Private",
+      "visibility_private_desc": "Encrypted and only accessible with your data map. Only you can retrieve the file.",
+      "visibility_public": "Public",
+      "visibility_public_desc": "Data map is published to the network. Share a single address so anyone can retrieve the file.",
+      "regular_footnote": "Estimated from a single network quote — final cost may vary slightly. Gas fees apply on top.",
+      "cancel_upload": "Cancel Upload",
+      "ready_count": "Ready: {ready} of {total}",
+      "approve_button_one": "Approve Upload",
+      "approve_button_many": "Approve {count} Uploads"
+    }
+  },
+  "wallet": {
+    "earnings_heading": "Earnings Address",
+    "earnings_description": "Where your node earnings are sent",
+    "earnings_not_configured": "Not configured",
+    "edit": "Edit",
+    "save": "Save",
+    "earnings_use_payment_prompt": "Use your connected wallet address for earnings?",
+    "earnings_use_payment_button": "Use {address}",
+    "earnings_placeholder": "0x...",
+    "managed_storage_heading": "Managed Storage",
+    "managed_storage_org": "Storage managed by {org}",
+    "managed_storage_description": "Uploads are routed through your organisation's Indelible gateway. No local wallet required.",
+    "payment_wallet_heading": "Payment Wallet",
+    "payment_optional_hint": "Optional — required for file uploads",
+    "connect_prompt": "Connect a wallet to pay for file storage",
+    "network_arbitrum_sepolia": "Arbitrum Sepolia testnet",
+    "network_arbitrum_one": "Arbitrum One network required",
+    "import_key_hint": "Or import a private key in {link}",
+    "import_key_hint_link_text": "Settings > Advanced",
+    "address_label": "Address",
+    "eth_balance_label": "ETH Balance",
+    "ant_balance_label": "ANT Balance",
+    "usdc_balance_label": "USDC Balance",
+    "refresh_balances": "Refresh Balances",
+    "disconnect": "Disconnect",
+    "toast": {
+      "import_key_in_settings": "Import a private key in Settings > Advanced",
+      "invalid_address": "Invalid address: must be 0x + 40 hex characters",
+      "earnings_saved": "Earnings address saved",
+      "earnings_set_to_payment": "Earnings address set to payment wallet",
+      "wallet_disconnected": "Wallet disconnected"
+    }
+  },
+  "status": {
+    "node": {
+      "running": "Running",
+      "stopped": "Stopped",
+      "starting": "Starting",
+      "stopping": "Stopping",
+      "adding": "Adding…",
+      "errored": "Error",
+      "upgrade_scheduled": "Upgrading"
+    },
+    "file": {
+      "pending": "Pending",
+      "quoting": "Quoting",
+      "encrypting": "Encrypting…",
+      "resolving_datamap": "Resolving datamap",
+      "queued_quoting": "Queued: quoting",
+      "queued_uploading": "Queued: uploading",
+      "connecting_to_network": "Connecting to network…",
+      "obtaining_quote": "Obtaining quote…",
+      "saving_datamap": "Saving datamap…",
+      "network_unavailable": "Network unavailable",
+      "ready_to_approve": "Ready to approve",
+      "awaiting_approval": "Awaiting approval",
+      "uploading": "Uploading",
+      "downloading": "Downloading",
+      "done": "Done",
+      "downloaded": "Downloaded — click to open"
+    }
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,470 @@
+{
+  "_translator_notes": "Machine-translated baseline. Community polish via PR welcome.",
+  "settings": {
+    "language": {
+      "label": "Langue",
+      "description": "Langue d'affichage de l'interface",
+      "system_default": "Système par défaut : {name}",
+      "system_default_pending": "Système par défaut"
+    },
+    "indelible": {
+      "title": "Indelible Enterprise",
+      "subtitle_connected": "Connecté à la passerelle de stockage gérée",
+      "subtitle_setup": "Connectez-vous à une passerelle Indelible auto-hébergée pour le stockage géré",
+      "connected_badge": "Connecté",
+      "server_label": "Serveur",
+      "signed_in_as": "Connecté en tant que",
+      "disconnect": "Déconnecter",
+      "server_url_label": "URL du serveur",
+      "server_url_placeholder": "https://files.acme.com",
+      "api_key_label": "Clé API",
+      "api_key_placeholder": "Votre jeton API",
+      "test_connect": "Tester & connecter",
+      "testing": "Test en cours…",
+      "configure": "Configurer la connexion"
+    },
+    "storage": {
+      "title": "Dossier de stockage",
+      "description": "Emplacement des données de nœud sur le disque",
+      "default": "Par défaut",
+      "browse": "Parcourir",
+      "warning": "S'applique uniquement aux nouveaux nœuds ajoutés. Les nœuds existants conservent leur dossier actuel."
+    },
+    "downloads": {
+      "title": "Dossier de téléchargements",
+      "description": "Emplacement où les fichiers téléchargés sont enregistrés",
+      "not_set": "Non défini",
+      "browse": "Parcourir"
+    },
+    "alert": {
+      "title": "Son d'alerte",
+      "description": "Jouer un son lors d'échecs critiques de nœud",
+      "aria_toggle": "Activer/désactiver le son d'alerte"
+    },
+    "theme": {
+      "title": "Mode clair",
+      "description": "Basculer entre les thèmes sombre et clair",
+      "aria_toggle": "Activer/désactiver le mode clair"
+    },
+    "advanced": {
+      "hide": "▾ Masquer les options avancées",
+      "show": "▸ Afficher les options avancées"
+    },
+    "daemon": {
+      "title": "Démon de nœud",
+      "description": "Redémarre le service en arrière-plan qui supervise vos nœuds. Vos nœuds en cours d'exécution continuent — seul le superviseur est remplacé.",
+      "restart": "Redémarrer le démon",
+      "restarting": "Redémarrage…"
+    },
+    "concurrency": {
+      "title": "Parallélisme des téléversements",
+      "description_1": "Contrôle combien de devis/téléversements peuvent s'exécuter simultanément.",
+      "description_2": "À noter : cela a un impact très important sur les performances."
+    },
+    "prerelease": {
+      "title": "Versions préliminaires",
+      "description": "Recevoir les mises à jour automatiques des versions préliminaires (rc / beta) en plus des versions stables. Désactivé par défaut.",
+      "restart_required": "Redémarrez l'application pour appliquer ce changement.",
+      "restart_now": "Redémarrer maintenant"
+    },
+    "direct_wallet": {
+      "title": "Portefeuille direct",
+      "description": "Se connecter avec une clé privée (contourne WalletConnect)",
+      "connected_badge": "Connecté",
+      "address_label": "Adresse",
+      "disconnect": "Déconnecter",
+      "network_label": "Réseau",
+      "network_sepolia_option": "Arbitrum Sepolia (testnet)",
+      "network_arbitrum_option": "Arbitrum One (mainnet)",
+      "rpc_url_label": "URL RPC",
+      "rpc_url_optional": "(facultatif)",
+      "rpc_url_placeholder": "RPC public par défaut pour la chaîne sélectionnée",
+      "private_key_label": "Clé privée",
+      "private_key_placeholder": "0x... ou hex brut",
+      "connect": "Connecter",
+      "import_button": "Importer une clé privée"
+    },
+    "diagnostics": {
+      "title": "Diagnostics",
+      "summary": "{entries} entrées de journal ({errors} erreurs)",
+      "copy_button": "Copier dans le presse-papiers",
+      "clear_button": "Effacer",
+      "empty": "Aucune entrée de journal",
+      "hide_log": "▾ Masquer le journal",
+      "show_log": "▸ Afficher le journal"
+    },
+    "upload_history": {
+      "title": "Historique des téléversements",
+      "summary_one": "{count} entrée finalisée dans upload_history.json. Les DataMaps sur le disque et les chunks sur le réseau ne sont pas modifiés.",
+      "summary_many": "{count} entrées finalisées dans upload_history.json. Les DataMaps sur le disque et les chunks sur le réseau ne sont pas modifiés.",
+      "clear_button": "Effacer l'historique",
+      "confirm_one": "Effacer 1 entrée de téléversement de l'historique ?\n\nCela supprime la ligne locale + l'enregistrement persistant. Les DataMaps sur le disque et les chunks sur le réseau ne sont pas affectés.",
+      "confirm_many": "Effacer {count} entrées de téléversement de l'historique ?\n\nCela supprime les lignes locales + les enregistrements persistants. Les DataMaps sur le disque et les chunks sur le réseau ne sont pas affectés."
+    },
+    "software": {
+      "title": "Logiciel",
+      "version_label": "Version",
+      "last_checked": "Dernière vérification {label}",
+      "check_button": "Vérifier les mises à jour",
+      "checking": "Vérification…"
+    },
+    "about": {
+      "title": "À propos",
+      "node_version_label": "Version du démon de nœud"
+    },
+    "relative_time": {
+      "just_now": "à l'instant",
+      "seconds_ago": "il y a {n} s",
+      "minutes_ago": "il y a {n} min",
+      "hours_ago": "il y a {n} h",
+      "days_ago": "il y a {n} j"
+    },
+    "picker": {
+      "storage_title": "Sélectionner le dossier de stockage",
+      "downloads_title": "Sélectionner le dossier de téléchargements"
+    },
+    "error": {
+      "private_key_invalid": "Clé privée invalide — doit comporter 64 caractères hexadécimaux",
+      "invalid_eth_address": "Format d'adresse EVM invalide"
+    },
+    "toast": {
+      "upload_history_cleared": "Historique des téléversements effacé",
+      "update_check_failed": "Échec de la vérification des mises à jour",
+      "update_available": "Mise à jour disponible : v{version}",
+      "on_latest_version": "Vous utilisez la dernière version (v{version})",
+      "daemon_restarted": "Démon redémarré",
+      "daemon_restart_failed": "Échec du redémarrage du démon : {error}",
+      "storage_dir_updated": "Dossier de stockage mis à jour",
+      "storage_dir_verified": "Dossier de stockage vérifié",
+      "storage_dir_unwritable": "Impossible d'utiliser ce dossier pour le stockage des nœuds",
+      "select_directory_failed": "Échec de la sélection du dossier",
+      "downloads_dir_updated": "Dossier de téléchargements mis à jour",
+      "earnings_updated": "Adresse de gains mise à jour",
+      "daemon_url_updated": "URL du démon mise à jour",
+      "diagnostics_copied": "Diagnostics copiés dans le presse-papiers",
+      "diagnostics_copy_failed": "Échec de la copie dans le presse-papiers",
+      "log_cleared": "Journal effacé",
+      "indelible_connected": "Connecté à Indelible",
+      "indelible_disconnected": "Déconnecté d'Indelible",
+      "wallet_connected": "Portefeuille connecté : {address}",
+      "wallet_disconnected": "Portefeuille déconnecté",
+      "wallet_attach_failed": "Échec de la liaison du portefeuille (côté Rust) : {error}"
+    }
+  },
+  "nav": {
+    "nodes": "Nœuds",
+    "files": "Fichiers",
+    "wallet": "Portefeuille",
+    "settings": "Paramètres"
+  },
+  "header": {
+    "title": "Autonomi",
+    "active_transfers": "{count} actif(s)",
+    "connecting": "Connexion",
+    "connecting_tooltip": "Connexion au réseau Autonomi",
+    "connected": "Réseau",
+    "connected_tooltip": "Connecté au réseau Autonomi",
+    "offline": "Hors ligne · Réessayer",
+    "offline_tooltip": "Échec de la connexion — cliquez pour réessayer",
+    "connect_wallet": "Connecter le portefeuille"
+  },
+  "sidebar": {
+    "pre_release": "PRÉ-VERSION",
+    "update_available": "Mise à jour disponible",
+    "update_pre_release_tag": "Pré-version",
+    "network_devnet": "DEVNET",
+    "network_sepolia": "SEPOLIA TESTNET"
+  },
+  "common": {
+    "cancel": "Annuler",
+    "confirm": "Confirmer",
+    "close": "Fermer",
+    "download": "Télécharger",
+    "start": "Démarrer",
+    "stop": "Arrêter",
+    "remove": "Supprimer",
+    "close_panel": "Fermer le panneau"
+  },
+  "nodes": {
+    "add_button": "+ Ajouter des nœuds",
+    "start_all": "Tout démarrer",
+    "stop_all": "Tout arrêter",
+    "running_count": "{count} en cours",
+    "stopped_count": "{count} arrêté(s)",
+    "errored_count": "{count} en erreur",
+    "filter_placeholder": "Filtrer...",
+    "filter_aria_label": "Filtrer les nœuds",
+    "starting_daemon": "Démarrage du démon de nœud…",
+    "restarting_daemon": "Redémarrage du démon de nœud…",
+    "nodes_keep_running": "Vos nœuds continuent de fonctionner.",
+    "daemon_disconnected": "Impossible de se connecter au démon de nœud",
+    "daemon_retrying": "Nouvelle tentative automatique…",
+    "empty_title": "Aucun nœud pour l'instant",
+    "empty_hint": "Cliquez sur \"+ Ajouter des nœuds\" pour commencer",
+    "confirm_action": "Confirmer l'action",
+    "remove_node_message": "Supprimer le nœud {id} ? Toutes ses données seront supprimées.",
+    "stop_all_message": "Arrêter les {count} nœuds en cours d'exécution ?",
+    "node_fallback_name": "Nœud {id}",
+    "field": {
+      "node_id": "ID du nœud",
+      "status": "Statut",
+      "version": "Version",
+      "pid": "PID",
+      "uptime": "Disponibilité",
+      "storage": "Stockage",
+      "data_directory": "Dossier de données",
+      "log_directory": "Dossier des journaux",
+      "port": "Port",
+      "binary": "Binaire",
+      "rewards_address": "Adresse de récompenses",
+      "status_aria": "Statut : {status}"
+    },
+    "add_dialog": {
+      "title": "Ajouter des nœuds",
+      "number_label": "Nombre de nœuds",
+      "range_hint": "Entre 1 et 50",
+      "no_earnings_warning": "Aucune adresse de gains configurée. Définissez-en une dans la page Portefeuille avant d'ajouter des nœuds.",
+      "submit_one": "Ajouter 1 nœud",
+      "submit_many": "Ajouter {count} nœuds"
+    },
+    "toast": {
+      "added": "{count} nœuds ajoutés",
+      "add_failed": "Échec de l'ajout de nœuds : {error}",
+      "started": "Nœud {id} démarré",
+      "start_failed": "Échec du démarrage du nœud {id} : {error}",
+      "stopped": "Nœud {id} arrêté",
+      "stop_failed": "Échec de l'arrêt du nœud {id} : {error}",
+      "removed": "Nœud {id} supprimé",
+      "remove_failed": "Échec de la suppression du nœud {id} : {error}",
+      "no_stopped": "Aucun nœud arrêté à démarrer",
+      "no_running": "Aucun nœud en cours d'exécution à arrêter",
+      "node_failed": "Nœud {id} en échec : {error}",
+      "started_count": "{count} nœuds démarrés",
+      "stopped_count": "{count} nœuds arrêtés",
+      "start_all_failed": "Échec du démarrage global : {error}",
+      "stop_all_failed": "Échec de l'arrêt global : {error}"
+    }
+  },
+  "files": {
+    "upload_button": "Téléverser des fichiers",
+    "estimate_button": "Estimer le coût",
+    "download_by_address": "Télécharger par adresse",
+    "download_by_datamap": "Télécharger par DataMap",
+    "uploads_heading": "Téléversements",
+    "downloads_heading": "Téléchargements",
+    "clear": "Effacer",
+    "drop_files": "Déposez des fichiers à téléverser",
+    "uploads_empty_title": "Aucun téléversement pour l'instant",
+    "uploads_empty_hint": "Glissez des fichiers ici, ou utilisez les boutons ci-dessus",
+    "downloads_empty_title": "Aucun téléchargement pour l'instant",
+    "downloads_empty_hint": "Utilisez \"Télécharger par adresse\" ou \"Télécharger par DataMap\"",
+    "table": {
+      "name": "Nom",
+      "status": "Statut",
+      "size": "Taille",
+      "cost": "Coût",
+      "date": "Date",
+      "address": "Adresse",
+      "saved_to": "Enregistré dans",
+      "actions": "Actions"
+    },
+    "row": {
+      "free_already_stored": "Gratuit — déjà stocké",
+      "gas_suffix": "+ {gas} gas",
+      "public_badge": "Public",
+      "retry": "↻ Réessayer",
+      "public_tooltip": "Téléversement public — cliquez pour copier l'adresse réseau partageable",
+      "reveal_datamap_tooltip": "Afficher le fichier DataMap dans Finder/Explorateur",
+      "copy_datamap_tooltip": "Copier le chemin du fichier DataMap",
+      "copy_address_tooltip": "Copier l'adresse réseau",
+      "retry_tooltip": "Réessayer le téléversement",
+      "remove_tooltip": "Retirer de la liste"
+    },
+    "stage": {
+      "encrypting": "Chiffrement…",
+      "quoting_pct": "Devis · {pct}%",
+      "quoting_indeterminate": "Obtention du devis…",
+      "storing_pct": "Stockage · {pct}%",
+      "storing_indeterminate": "Stockage…",
+      "resolving_pct": "Résolution du DataMap · {pct}%",
+      "resolving_indeterminate": "Résolution du DataMap…",
+      "downloading_pct": "Téléchargement · {pct}%",
+      "downloading_indeterminate": "Téléchargement…"
+    },
+    "picker": {
+      "upload_title": "Sélectionner les fichiers à téléverser",
+      "datamap_title": "Sélectionner un fichier DataMap à télécharger",
+      "estimate_title": "Sélectionner les fichiers à estimer",
+      "datamap_filter": "DataMap"
+    },
+    "toast": {
+      "upload_requires_wallet": "Le téléversement nécessite un portefeuille",
+      "download_requires_network": "Le téléchargement nécessite une connexion réseau",
+      "open_folder_failed": "Impossible d'ouvrir le dossier",
+      "address_copied": "Adresse copiée dans le presse-papiers",
+      "public_address_copied": "Adresse publique copiée — partagez-la pour permettre à d'autres de télécharger ce fichier",
+      "datamap_path_copied": "Chemin du DataMap copié dans le presse-papiers",
+      "already_stored_one": "1 fichier déjà stocké — enregistrement du DataMap",
+      "already_stored_many": "{count} fichiers déjà stockés — enregistrement des DataMaps",
+      "upload_complete": "Téléversement terminé : {name}",
+      "upload_failed": "Échec du téléversement : {name} — {error}",
+      "payment_failed": "Échec du paiement : {error}",
+      "download_complete": "Téléchargement terminé : {name}",
+      "download_failed": "Échec du téléchargement : {name} — {error}",
+      "datamap_missing": "Téléchargement impossible : fichier DataMap manquant ou illisible",
+      "datamap_read_failed": "Impossible de lire le DataMap : {error}"
+    },
+    "error": {
+      "wallet_not_connected": "Portefeuille non connecté",
+      "not_connected_to_network": "Non connecté au réseau"
+    },
+    "network": {
+      "unavailable": "Non connecté au réseau Autonomi — estimation du coût indisponible.",
+      "retry_connection": "Réessayer la connexion",
+      "connecting": "Connexion au réseau Autonomi…",
+      "obtaining_quote": "Obtention du devis depuis le réseau…",
+      "obtaining_quotes": "Obtention des devis depuis le réseau…"
+    },
+    "datamap_saveas": {
+      "title": "Enregistrer le fichier téléchargé sous",
+      "filename_label": "Nom de fichier",
+      "filename_placeholder": "monfichier.dat"
+    },
+    "download_dialog": {
+      "title": "Télécharger le fichier",
+      "address_label": "Adresse du fichier",
+      "address_placeholder": "Adresse du fichier (hex)",
+      "filename_label": "Enregistrer sous",
+      "filename_placeholder": "monfichier.dat"
+    },
+    "datamap_picker": {
+      "description": "Choisissez un téléversement précédent à re-télécharger, ou parcourez vers un fichier DataMap reçu d'ailleurs.",
+      "empty": "Aucun téléversement précédent avec un DataMap enregistré.",
+      "browse_button": "Parcourir vers un fichier DataMap…"
+    },
+    "cost_estimate": {
+      "title": "Estimation du coût de téléversement",
+      "loading": "Estimation du coût…",
+      "no_files": "Aucun fichier sélectionné",
+      "footnote": "Coûts obtenus auprès du réseau Autonomi. Les frais de gas (ETH) s'ajoutent aux coûts de stockage."
+    },
+    "upload_confirm": {
+      "title": "Confirmer le téléversement",
+      "info_banner": "Vous pouvez fermer cette fenêtre et revenir une fois le devis arrivé. Le téléversement reste en attente jusqu'à approbation ou annulation.",
+      "already_stored_badge": "Déjà stocké",
+      "payment_label": "Paiement",
+      "payment_mixed": "Mixte",
+      "payment_mixed_detail": "{regular} régulier, {merkle} Merkle — paiement par fichier.",
+      "payment_merkle": "Arbre de Merkle",
+      "payment_regular": "Régulier",
+      "payment_merkle_detail": "Transaction unique pour {count} chunks — gas réduit.",
+      "payment_regular_detail_one": "Paiement par lot pour 1 chunk.",
+      "payment_regular_detail_many": "Paiement par lot pour {count} chunks.",
+      "free_title": "Déjà stocké sur le réseau — gratuit",
+      "free_detail": "Chaque chunk est déjà présent. Aucun ANT ni gas ne sera dépensé.",
+      "cost_label": "Coût de stockage réseau",
+      "gas_label": "Gas estimé",
+      "some_already_stored": "Certains fichiers sont déjà stockés — cette partie est gratuite.",
+      "visibility_label": "Visibilité",
+      "visibility_private": "Privé",
+      "visibility_private_desc": "Chiffré et accessible uniquement avec votre DataMap. Vous seul pouvez récupérer le fichier.",
+      "visibility_public": "Public",
+      "visibility_public_desc": "Le DataMap est publié sur le réseau. Partagez une seule adresse pour que n'importe qui puisse récupérer le fichier.",
+      "regular_footnote": "Estimé à partir d'un seul devis réseau — le coût final peut légèrement varier. Les frais de gas s'ajoutent.",
+      "cancel_upload": "Annuler le téléversement",
+      "ready_count": "Prêt : {ready} sur {total}",
+      "approve_button_one": "Approuver le téléversement",
+      "approve_button_many": "Approuver {count} téléversements"
+    }
+  },
+  "wallet": {
+    "earnings_heading": "Adresse de gains",
+    "earnings_description": "Destination des gains de vos nœuds",
+    "earnings_not_configured": "Non configuré",
+    "edit": "Modifier",
+    "save": "Enregistrer",
+    "earnings_use_payment_prompt": "Utiliser l'adresse de votre portefeuille connecté pour les gains ?",
+    "earnings_use_payment_button": "Utiliser {address}",
+    "earnings_placeholder": "0x...",
+    "managed_storage_heading": "Stockage géré",
+    "managed_storage_org": "Stockage géré par {org}",
+    "managed_storage_description": "Les téléversements sont acheminés via la passerelle Indelible de votre organisation. Aucun portefeuille local requis.",
+    "payment_wallet_heading": "Portefeuille de paiement",
+    "payment_optional_hint": "Facultatif — requis pour les téléversements de fichiers",
+    "connect_prompt": "Connectez un portefeuille pour payer le stockage de fichiers",
+    "network_arbitrum_sepolia": "Testnet Arbitrum Sepolia",
+    "network_arbitrum_one": "Réseau Arbitrum One requis",
+    "import_key_hint": "Ou importez une clé privée dans {link}",
+    "import_key_hint_link_text": "Paramètres > Avancé",
+    "address_label": "Adresse",
+    "eth_balance_label": "Solde ETH",
+    "ant_balance_label": "Solde ANT",
+    "usdc_balance_label": "Solde USDC",
+    "refresh_balances": "Actualiser les soldes",
+    "disconnect": "Déconnecter",
+    "toast": {
+      "import_key_in_settings": "Importez une clé privée dans Paramètres > Avancé",
+      "invalid_address": "Adresse invalide : doit être 0x + 40 caractères hexadécimaux",
+      "earnings_saved": "Adresse de gains enregistrée",
+      "earnings_set_to_payment": "Adresse de gains définie sur le portefeuille de paiement",
+      "wallet_disconnected": "Portefeuille déconnecté"
+    }
+  },
+  "updater": {
+    "dialog": {
+      "title": "Mise à jour disponible",
+      "version_ready": "v{version} est prête à être installée",
+      "pre_release_badge": "Pré-version",
+      "download_size": "Taille du téléchargement : {size}",
+      "release_notes": "Notes de version",
+      "no_release_notes": "Aucune note de version disponible pour cette version.",
+      "downloading": "Téléchargement…",
+      "download_complete": "Téléchargement réussi, l'application va redémarrer sous peu",
+      "auto_restart_hint": "L'application redémarrera automatiquement une fois terminé.",
+      "cancel_download": "Annuler le téléchargement",
+      "installing_tooltip": "Installation — veuillez patienter",
+      "not_now": "Plus tard",
+      "update_restart": "Mettre à jour & redémarrer"
+    },
+    "toast": {
+      "install_no_restart": "La mise à jour v{version} a été installée mais l'application n'a pas redémarré. Quittez Autonomi et rouvrez-le.",
+      "install_failed": "Échec de l'installation de la mise à jour : {error}"
+    }
+  },
+  "validators": {
+    "filename": {
+      "has_special_chars": "Le nom de fichier ne peut pas contenir de caractères spéciaux",
+      "ends_with_dot_or_space": "Le nom de fichier ne peut pas se terminer par un point ou un espace",
+      "reserved_on_windows": "Ce nom est réservé sous Windows"
+    }
+  },
+  "status": {
+    "node": {
+      "running": "En cours",
+      "stopped": "Arrêté",
+      "starting": "Démarrage",
+      "stopping": "Arrêt",
+      "adding": "Ajout…",
+      "errored": "Erreur",
+      "upgrade_scheduled": "Mise à niveau"
+    },
+    "file": {
+      "pending": "En attente",
+      "quoting": "Devis",
+      "encrypting": "Chiffrement…",
+      "resolving_datamap": "Résolution du DataMap",
+      "queued_quoting": "En file : devis",
+      "queued_uploading": "En file : téléversement",
+      "connecting_to_network": "Connexion au réseau…",
+      "obtaining_quote": "Obtention du devis…",
+      "saving_datamap": "Enregistrement du DataMap…",
+      "network_unavailable": "Réseau indisponible",
+      "ready_to_approve": "Prêt à approuver",
+      "awaiting_approval": "En attente d'approbation",
+      "uploading": "Téléversement",
+      "downloading": "Téléchargement",
+      "done": "Terminé",
+      "downloaded": "Téléchargé — cliquez pour ouvrir"
+    }
+  }
+}

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -6,6 +6,149 @@
       "description": "UI 表示言語",
       "system_default": "システムのデフォルト: {name}",
       "system_default_pending": "システムのデフォルト"
+    },
+    "indelible": {
+      "title": "Indelible Enterprise",
+      "subtitle_connected": "管理ストレージゲートウェイに接続済み",
+      "subtitle_setup": "管理ストレージ用のセルフホスト Indelible ゲートウェイに接続",
+      "connected_badge": "接続済み",
+      "server_label": "サーバー",
+      "signed_in_as": "サインインユーザー",
+      "disconnect": "切断",
+      "server_url_label": "サーバー URL",
+      "server_url_placeholder": "https://files.acme.com",
+      "api_key_label": "API キー",
+      "api_key_placeholder": "API トークン",
+      "test_connect": "テストして接続",
+      "testing": "テスト中…",
+      "configure": "接続を設定"
+    },
+    "storage": {
+      "title": "ストレージディレクトリ",
+      "description": "ノードデータを保存するディスク上の場所",
+      "default": "デフォルト",
+      "browse": "参照",
+      "warning": "新しく追加するノードにのみ適用されます。既存のノードは現在のディレクトリを使い続けます。"
+    },
+    "downloads": {
+      "title": "ダウンロードディレクトリ",
+      "description": "ダウンロードしたファイルの保存先",
+      "not_set": "未設定",
+      "browse": "参照"
+    },
+    "alert": {
+      "title": "アラート音",
+      "description": "重大なノード障害時に音を鳴らす",
+      "aria_toggle": "アラート音を切り替え"
+    },
+    "theme": {
+      "title": "ライトモード",
+      "description": "ダーク/ライトテーマを切り替え",
+      "aria_toggle": "ライトモードを切り替え"
+    },
+    "advanced": {
+      "hide": "▾ 詳細設定を隠す",
+      "show": "▸ 詳細設定を表示"
+    },
+    "daemon": {
+      "title": "ノードデーモン",
+      "description": "ノードを管理するバックグラウンドサービスを再起動します。稼働中のノードはそのまま動き続け、スーパーバイザのみが入れ替わります。",
+      "restart": "デーモンを再起動",
+      "restarting": "再起動中…"
+    },
+    "concurrency": {
+      "title": "アップロード並列数",
+      "description_1": "同時に実行できる見積もり/アップロードの数を制御します。",
+      "description_2": "パフォーマンスに大きく影響します。"
+    },
+    "prerelease": {
+      "title": "プレリリースビルド",
+      "description": "安定版に加えて、プレリリースビルド (rc / beta) の自動更新を受け取ります。デフォルトはオフです。",
+      "restart_required": "この変更を反映するにはアプリを再起動してください。",
+      "restart_now": "今すぐ再起動"
+    },
+    "direct_wallet": {
+      "title": "ダイレクトウォレット",
+      "description": "秘密鍵で接続 (WalletConnect を使わない)",
+      "connected_badge": "接続済み",
+      "address_label": "アドレス",
+      "disconnect": "切断",
+      "network_label": "ネットワーク",
+      "network_sepolia_option": "Arbitrum Sepolia (テストネット)",
+      "network_arbitrum_option": "Arbitrum One (メインネット)",
+      "rpc_url_label": "RPC URL",
+      "rpc_url_optional": "(任意)",
+      "rpc_url_placeholder": "選択したチェーンの公開 RPC をデフォルトで使用",
+      "private_key_label": "秘密鍵",
+      "private_key_placeholder": "0x... または 16 進文字列",
+      "connect": "接続",
+      "import_button": "秘密鍵をインポート"
+    },
+    "diagnostics": {
+      "title": "診断情報",
+      "summary": "{entries} 件のログ ({errors} 件のエラー)",
+      "copy_button": "クリップボードにコピー",
+      "clear_button": "クリア",
+      "empty": "ログエントリがありません",
+      "hide_log": "▾ ログを隠す",
+      "show_log": "▸ ログを表示"
+    },
+    "upload_history": {
+      "title": "アップロード履歴",
+      "summary_one": "upload_history.json に {count} 件の確定済みエントリ。ディスク上のデータマップとネットワーク上のチャンクは影響を受けません。",
+      "summary_many": "upload_history.json に {count} 件の確定済みエントリ。ディスク上のデータマップとネットワーク上のチャンクは影響を受けません。",
+      "clear_button": "履歴をクリア",
+      "confirm_one": "アップロード履歴から 1 件のエントリをクリアしますか？\n\nローカルの行と保存記録が削除されます。ディスク上のデータマップとネットワーク上のチャンクは影響を受けません。",
+      "confirm_many": "アップロード履歴から {count} 件のエントリをクリアしますか？\n\nローカルの行と保存記録が削除されます。ディスク上のデータマップとネットワーク上のチャンクは影響を受けません。"
+    },
+    "software": {
+      "title": "ソフトウェア",
+      "version_label": "バージョン",
+      "last_checked": "最終確認 {label}",
+      "check_button": "アップデートを確認",
+      "checking": "確認中…"
+    },
+    "about": {
+      "title": "情報",
+      "node_version_label": "ノードデーモンバージョン"
+    },
+    "relative_time": {
+      "just_now": "たった今",
+      "seconds_ago": "{n} 秒前",
+      "minutes_ago": "{n} 分前",
+      "hours_ago": "{n} 時間前",
+      "days_ago": "{n} 日前"
+    },
+    "picker": {
+      "storage_title": "ストレージディレクトリを選択",
+      "downloads_title": "ダウンロードディレクトリを選択"
+    },
+    "error": {
+      "private_key_invalid": "秘密鍵が無効です — 64 桁の 16 進文字が必要です",
+      "invalid_eth_address": "EVM アドレスの形式が無効です"
+    },
+    "toast": {
+      "upload_history_cleared": "アップロード履歴をクリアしました",
+      "update_check_failed": "アップデート確認に失敗しました",
+      "update_available": "アップデートあり: v{version}",
+      "on_latest_version": "最新バージョンを使用中 (v{version})",
+      "daemon_restarted": "デーモンを再起動しました",
+      "daemon_restart_failed": "デーモンの再起動に失敗: {error}",
+      "storage_dir_updated": "ストレージディレクトリを更新しました",
+      "storage_dir_verified": "ストレージディレクトリを確認しました",
+      "storage_dir_unwritable": "そのフォルダはノードストレージに使用できません",
+      "select_directory_failed": "ディレクトリの選択に失敗しました",
+      "downloads_dir_updated": "ダウンロードディレクトリを更新しました",
+      "earnings_updated": "報酬アドレスを更新しました",
+      "daemon_url_updated": "デーモン URL を更新しました",
+      "diagnostics_copied": "診断情報をクリップボードにコピーしました",
+      "diagnostics_copy_failed": "クリップボードへのコピーに失敗しました",
+      "log_cleared": "ログをクリアしました",
+      "indelible_connected": "Indelible に接続しました",
+      "indelible_disconnected": "Indelible から切断しました",
+      "wallet_connected": "ウォレット接続: {address}",
+      "wallet_disconnected": "ウォレットを切断しました",
+      "wallet_attach_failed": "ウォレット接続 (Rust 側) に失敗: {error}"
     }
   },
   "nav": {
@@ -31,5 +174,245 @@
     "update_pre_release_tag": "プレリリース",
     "network_devnet": "DEVNET",
     "network_sepolia": "SEPOLIA テストネット"
+  },
+  "common": {
+    "cancel": "キャンセル",
+    "confirm": "確定",
+    "close": "閉じる",
+    "download": "ダウンロード",
+    "start": "開始",
+    "stop": "停止",
+    "remove": "削除",
+    "close_panel": "パネルを閉じる"
+  },
+  "nodes": {
+    "add_button": "+ ノードを追加",
+    "start_all": "すべて開始",
+    "stop_all": "すべて停止",
+    "running_count": "{count} 実行中",
+    "stopped_count": "{count} 停止中",
+    "errored_count": "{count} エラー",
+    "filter_placeholder": "フィルター…",
+    "filter_aria_label": "ノードをフィルター",
+    "starting_daemon": "ノードデーモンを起動中…",
+    "restarting_daemon": "ノードデーモンを再起動中…",
+    "nodes_keep_running": "ノードは稼働を継続します。",
+    "daemon_disconnected": "ノードデーモンに接続できません",
+    "daemon_retrying": "自動的に再試行中…",
+    "empty_title": "ノードがまだありません",
+    "empty_hint": "「+ ノードを追加」をクリックして開始",
+    "confirm_action": "操作を確認",
+    "remove_node_message": "ノード {id} を削除しますか？すべてのデータが削除されます。",
+    "stop_all_message": "実行中のノード {count} 件をすべて停止しますか？",
+    "node_fallback_name": "ノード {id}",
+    "field": {
+      "node_id": "ノード ID",
+      "status": "ステータス",
+      "version": "バージョン",
+      "pid": "PID",
+      "uptime": "稼働時間",
+      "storage": "ストレージ",
+      "data_directory": "データディレクトリ",
+      "log_directory": "ログディレクトリ",
+      "port": "ポート",
+      "binary": "バイナリ",
+      "rewards_address": "報酬アドレス",
+      "status_aria": "ステータス: {status}"
+    },
+    "add_dialog": {
+      "title": "ノードを追加",
+      "number_label": "ノード数",
+      "range_hint": "1〜50 の範囲",
+      "no_earnings_warning": "報酬アドレスが設定されていません。ノードを追加する前にウォレットページで設定してください。",
+      "submit_one": "1 ノードを追加",
+      "submit_many": "{count} ノードを追加"
+    }
+  },
+  "files": {
+    "upload_button": "ファイルをアップロード",
+    "estimate_button": "コストを見積もる",
+    "download_by_address": "アドレスからダウンロード",
+    "download_by_datamap": "データマップからダウンロード",
+    "uploads_heading": "アップロード",
+    "downloads_heading": "ダウンロード",
+    "clear": "クリア",
+    "drop_files": "ファイルをドロップしてアップロード",
+    "uploads_empty_title": "アップロードがまだありません",
+    "uploads_empty_hint": "ここにファイルをドラッグするか、上のボタンを使用してください",
+    "downloads_empty_title": "ダウンロードがまだありません",
+    "downloads_empty_hint": "「アドレスからダウンロード」または「データマップからダウンロード」を使用してください",
+    "table": {
+      "name": "名前",
+      "status": "ステータス",
+      "size": "サイズ",
+      "cost": "コスト",
+      "date": "日付",
+      "address": "アドレス",
+      "saved_to": "保存先",
+      "actions": "操作"
+    },
+    "row": {
+      "free_already_stored": "無料 — 保存済み",
+      "gas_suffix": "+ {gas} gas",
+      "public_badge": "公開",
+      "retry": "↻ 再試行",
+      "public_tooltip": "公開アップロード — クリックして共有可能なネットワークアドレスをコピー",
+      "reveal_datamap_tooltip": "データマップファイルを Finder/Explorer で表示",
+      "copy_datamap_tooltip": "データマップファイルパスをコピー",
+      "copy_address_tooltip": "ネットワークアドレスをコピー",
+      "retry_tooltip": "アップロードを再試行",
+      "remove_tooltip": "リストから削除"
+    },
+    "stage": {
+      "encrypting": "暗号化中…",
+      "quoting_pct": "見積もり中 · {pct}%",
+      "quoting_indeterminate": "見積もり中…",
+      "storing_pct": "保存中 · {pct}%",
+      "storing_indeterminate": "保存中…",
+      "resolving_pct": "データマップを解決中 · {pct}%",
+      "resolving_indeterminate": "データマップを解決中…",
+      "downloading_pct": "ダウンロード中 · {pct}%",
+      "downloading_indeterminate": "ダウンロード中…"
+    },
+    "picker": {
+      "upload_title": "アップロードするファイルを選択",
+      "datamap_title": "ダウンロードするデータマップファイルを選択",
+      "estimate_title": "コストを見積もるファイルを選択",
+      "datamap_filter": "データマップ"
+    },
+    "toast": {
+      "upload_requires_wallet": "アップロードにはウォレットが必要です",
+      "download_requires_network": "ダウンロードにはネットワーク接続が必要です",
+      "open_folder_failed": "フォルダを開けませんでした",
+      "address_copied": "アドレスをクリップボードにコピーしました",
+      "public_address_copied": "公開アドレスをコピーしました — 他の人がこのファイルをダウンロードできるよう共有してください",
+      "datamap_path_copied": "データマップパスをクリップボードにコピーしました",
+      "already_stored_one": "1 ファイルが既に保存されています — データマップを保存中",
+      "already_stored_many": "{count} ファイルが既に保存されています — データマップを保存中"
+    },
+    "error": {
+      "wallet_not_connected": "ウォレットが接続されていません",
+      "not_connected_to_network": "ネットワークに接続されていません"
+    },
+    "network": {
+      "unavailable": "Autonomi ネットワークに接続されていません — コスト見積もりを取得できません。",
+      "retry_connection": "再接続",
+      "connecting": "Autonomi ネットワークに接続中…",
+      "obtaining_quote": "ネットワークから見積もりを取得中…",
+      "obtaining_quotes": "ネットワークから見積もりを取得中…"
+    },
+    "datamap_saveas": {
+      "title": "ダウンロードファイルの保存名",
+      "filename_label": "ファイル名",
+      "filename_placeholder": "myfile.dat"
+    },
+    "download_dialog": {
+      "title": "ファイルをダウンロード",
+      "address_label": "ファイルアドレス",
+      "address_placeholder": "ファイルアドレス (16 進)",
+      "filename_label": "保存ファイル名",
+      "filename_placeholder": "myfile.dat"
+    },
+    "datamap_picker": {
+      "description": "以前のアップロードから再ダウンロードするものを選ぶか、他から受け取ったデータマップファイルを参照してください。",
+      "empty": "保存されたデータマップを持つアップロードがまだありません。",
+      "browse_button": "データマップファイルを参照…"
+    },
+    "cost_estimate": {
+      "title": "アップロードコスト見積もり",
+      "loading": "コストを見積もり中…",
+      "no_files": "ファイルが選択されていません",
+      "footnote": "Autonomi ネットワークから取得したコストです。ストレージコストに加えてガス料金 (ETH) がかかります。"
+    },
+    "upload_confirm": {
+      "title": "アップロードを確認",
+      "info_banner": "このウィンドウは閉じても見積もりが届いたら戻ってこれます。承認またはキャンセルするまでアップロードは保留されます。",
+      "already_stored_badge": "保存済み",
+      "payment_label": "支払い",
+      "payment_mixed": "混在",
+      "payment_mixed_detail": "通常 {regular} 件、Merkle {merkle} 件 — ファイルごとに支払い。",
+      "payment_merkle": "Merkle ツリー",
+      "payment_regular": "通常",
+      "payment_merkle_detail": "{count} チャンクを 1 トランザクションで処理 — ガス代を削減。",
+      "payment_regular_detail_one": "1 チャンクのバッチ支払い。",
+      "payment_regular_detail_many": "{count} チャンクのバッチ支払い。",
+      "free_title": "ネットワークに保存済み — 無料",
+      "free_detail": "すべてのチャンクが既に存在します。ANT もガスも消費されません。",
+      "cost_label": "ネットワークストレージコスト",
+      "gas_label": "推定ガス代",
+      "some_already_stored": "一部のファイルは既に保存されています — その分は無料です。",
+      "visibility_label": "公開設定",
+      "visibility_private": "プライベート",
+      "visibility_private_desc": "暗号化され、データマップでのみアクセス可能です。あなただけがこのファイルを取得できます。",
+      "visibility_public": "公開",
+      "visibility_public_desc": "データマップがネットワークに公開されます。1 つのアドレスを共有して誰でもファイルを取得できるようにします。",
+      "regular_footnote": "ネットワークから 1 回見積もり — 最終コストはわずかに変動する可能性があります。ガス代が別途かかります。",
+      "cancel_upload": "アップロードをキャンセル",
+      "ready_count": "準備完了: {total} 件中 {ready} 件",
+      "approve_button_one": "アップロードを承認",
+      "approve_button_many": "{count} 件のアップロードを承認"
+    }
+  },
+  "wallet": {
+    "earnings_heading": "報酬アドレス",
+    "earnings_description": "ノードの報酬の送信先",
+    "earnings_not_configured": "未設定",
+    "edit": "編集",
+    "save": "保存",
+    "earnings_use_payment_prompt": "接続中のウォレットアドレスを報酬用に使いますか？",
+    "earnings_use_payment_button": "{address} を使う",
+    "earnings_placeholder": "0x...",
+    "managed_storage_heading": "管理ストレージ",
+    "managed_storage_org": "{org} が管理するストレージ",
+    "managed_storage_description": "アップロードは組織の Indelible ゲートウェイ経由で処理されます。ローカルウォレットは不要です。",
+    "payment_wallet_heading": "支払いウォレット",
+    "payment_optional_hint": "任意 — ファイルアップロードには必要",
+    "connect_prompt": "ファイルストレージ料金の支払い用ウォレットを接続",
+    "network_arbitrum_sepolia": "Arbitrum Sepolia テストネット",
+    "network_arbitrum_one": "Arbitrum One ネットワークが必要",
+    "import_key_hint": "または {link} で秘密鍵をインポート",
+    "import_key_hint_link_text": "設定 > 詳細設定",
+    "address_label": "アドレス",
+    "eth_balance_label": "ETH 残高",
+    "ant_balance_label": "ANT 残高",
+    "usdc_balance_label": "USDC 残高",
+    "refresh_balances": "残高を更新",
+    "disconnect": "切断",
+    "toast": {
+      "import_key_in_settings": "設定 > 詳細設定で秘密鍵をインポートしてください",
+      "invalid_address": "アドレスが無効です: 0x + 40 桁の 16 進文字が必要です",
+      "earnings_saved": "報酬アドレスを保存しました",
+      "earnings_set_to_payment": "報酬アドレスを支払いウォレットに設定しました",
+      "wallet_disconnected": "ウォレットを切断しました"
+    }
+  },
+  "status": {
+    "node": {
+      "running": "実行中",
+      "stopped": "停止",
+      "starting": "起動中",
+      "stopping": "停止中",
+      "adding": "追加中…",
+      "errored": "エラー",
+      "upgrade_scheduled": "アップグレード中"
+    },
+    "file": {
+      "pending": "待機中",
+      "quoting": "見積もり中",
+      "encrypting": "暗号化中…",
+      "resolving_datamap": "データマップを解決中",
+      "queued_quoting": "キュー: 見積もり中",
+      "queued_uploading": "キュー: アップロード中",
+      "connecting_to_network": "ネットワークに接続中…",
+      "obtaining_quote": "見積もりを取得中…",
+      "saving_datamap": "データマップを保存中…",
+      "network_unavailable": "ネットワーク利用不可",
+      "ready_to_approve": "承認の準備完了",
+      "awaiting_approval": "承認待ち",
+      "uploading": "アップロード中",
+      "downloading": "ダウンロード中",
+      "done": "完了",
+      "downloaded": "ダウンロード完了 — クリックして開く"
+    }
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,5 +1,5 @@
 {
-  "_machine_translated": true,
+  "_translator_notes": "Machine-translated baseline. Community polish via PR welcome.",
   "settings": {
     "language": {
       "label": "言語",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -226,6 +226,23 @@
       "no_earnings_warning": "報酬アドレスが設定されていません。ノードを追加する前にウォレットページで設定してください。",
       "submit_one": "1 ノードを追加",
       "submit_many": "{count} ノードを追加"
+    },
+    "toast": {
+      "added": "{count} ノードを追加しました",
+      "add_failed": "ノードの追加に失敗: {error}",
+      "started": "ノード {id} を開始しました",
+      "start_failed": "ノード {id} の開始に失敗: {error}",
+      "stopped": "ノード {id} を停止しました",
+      "stop_failed": "ノード {id} の停止に失敗: {error}",
+      "removed": "ノード {id} を削除しました",
+      "remove_failed": "ノード {id} の削除に失敗: {error}",
+      "no_stopped": "開始できる停止中のノードがありません",
+      "no_running": "停止できる実行中のノードがありません",
+      "node_failed": "ノード {id} 失敗: {error}",
+      "started_count": "{count} ノードを開始しました",
+      "stopped_count": "{count} ノードを停止しました",
+      "start_all_failed": "すべての開始に失敗: {error}",
+      "stop_all_failed": "すべての停止に失敗: {error}"
     }
   },
   "files": {
@@ -288,7 +305,14 @@
       "public_address_copied": "公開アドレスをコピーしました — 他の人がこのファイルをダウンロードできるよう共有してください",
       "datamap_path_copied": "データマップパスをクリップボードにコピーしました",
       "already_stored_one": "1 ファイルが既に保存されています — データマップを保存中",
-      "already_stored_many": "{count} ファイルが既に保存されています — データマップを保存中"
+      "already_stored_many": "{count} ファイルが既に保存されています — データマップを保存中",
+      "upload_complete": "アップロード完了: {name}",
+      "upload_failed": "アップロード失敗: {name} — {error}",
+      "payment_failed": "支払い失敗: {error}",
+      "download_complete": "ダウンロード完了: {name}",
+      "download_failed": "ダウンロード失敗: {name} — {error}",
+      "datamap_missing": "ダウンロードできません: データマップファイルが見つからないか読み取れません",
+      "datamap_read_failed": "データマップを読み取れませんでした: {error}"
     },
     "error": {
       "wallet_not_connected": "ウォレットが接続されていません",
@@ -384,6 +408,34 @@
       "earnings_saved": "報酬アドレスを保存しました",
       "earnings_set_to_payment": "報酬アドレスを支払いウォレットに設定しました",
       "wallet_disconnected": "ウォレットを切断しました"
+    }
+  },
+  "updater": {
+    "dialog": {
+      "title": "アップデートあり",
+      "version_ready": "v{version} のインストール準備が完了",
+      "pre_release_badge": "プレリリース",
+      "download_size": "ダウンロードサイズ: {size}",
+      "release_notes": "リリースノート",
+      "no_release_notes": "このバージョンのリリースノートはありません。",
+      "downloading": "ダウンロード中…",
+      "download_complete": "ダウンロード成功 — 間もなくアプリが再起動します",
+      "auto_restart_hint": "完了するとアプリが自動的に再起動します。",
+      "cancel_download": "ダウンロードをキャンセル",
+      "installing_tooltip": "インストール中 — お待ちください",
+      "not_now": "後で",
+      "update_restart": "アップデートして再起動"
+    },
+    "toast": {
+      "install_no_restart": "v{version} のアップデートはインストールされましたが、アプリが再起動しませんでした。Autonomi を終了して開き直してください。",
+      "install_failed": "アップデートのインストールに失敗: {error}"
+    }
+  },
+  "validators": {
+    "filename": {
+      "has_special_chars": "ファイル名に特殊文字を含めることはできません",
+      "ends_with_dot_or_space": "ファイル名はドットまたはスペースで終わることはできません",
+      "reserved_on_windows": "この名前は Windows の予約名です"
     }
   },
   "status": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,0 +1,35 @@
+{
+  "_machine_translated": true,
+  "settings": {
+    "language": {
+      "label": "言語",
+      "description": "UI 表示言語",
+      "system_default": "システムのデフォルト: {name}",
+      "system_default_pending": "システムのデフォルト"
+    }
+  },
+  "nav": {
+    "nodes": "ノード",
+    "files": "ファイル",
+    "wallet": "ウォレット",
+    "settings": "設定"
+  },
+  "header": {
+    "title": "Autonomi",
+    "active_transfers": "{count} 件処理中",
+    "connecting": "接続中",
+    "connecting_tooltip": "Autonomi ネットワークに接続中",
+    "connected": "ネットワーク",
+    "connected_tooltip": "Autonomi ネットワークに接続済み",
+    "offline": "オフライン · 再試行",
+    "offline_tooltip": "接続に失敗しました — クリックして再試行",
+    "connect_wallet": "ウォレットを接続"
+  },
+  "sidebar": {
+    "pre_release": "プレリリース",
+    "update_available": "アップデート利用可能",
+    "update_pre_release_tag": "プレリリース",
+    "network_devnet": "DEVNET",
+    "network_sepolia": "SEPOLIA テストネット"
+  }
+}

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,0 +1,470 @@
+{
+  "_translator_notes": "Machine-translated baseline. Community polish via PR welcome.",
+  "settings": {
+    "language": {
+      "label": "Taal",
+      "description": "Weergavetaal van de gebruikersinterface",
+      "system_default": "Systeemstandaard: {name}",
+      "system_default_pending": "Systeemstandaard"
+    },
+    "indelible": {
+      "title": "Indelible Enterprise",
+      "subtitle_connected": "Verbonden met beheerde opslag-gateway",
+      "subtitle_setup": "Verbind met een zelf-gehoste Indelible-gateway voor beheerde opslag",
+      "connected_badge": "Verbonden",
+      "server_label": "Server",
+      "signed_in_as": "Aangemeld als",
+      "disconnect": "Verbinding verbreken",
+      "server_url_label": "Server-URL",
+      "server_url_placeholder": "https://files.acme.com",
+      "api_key_label": "API-sleutel",
+      "api_key_placeholder": "Jouw API-token",
+      "test_connect": "Testen & verbinden",
+      "testing": "Testen…",
+      "configure": "Verbinding instellen"
+    },
+    "storage": {
+      "title": "Opslagmap",
+      "description": "Waar nodegegevens op schijf worden opgeslagen",
+      "default": "Standaard",
+      "browse": "Bladeren",
+      "warning": "Geldt alleen voor nieuw toegevoegde nodes. Bestaande nodes behouden hun huidige map."
+    },
+    "downloads": {
+      "title": "Downloadmap",
+      "description": "Waar gedownloade bestanden worden opgeslagen",
+      "not_set": "Niet ingesteld",
+      "browse": "Bladeren"
+    },
+    "alert": {
+      "title": "Waarschuwingsgeluid",
+      "description": "Geluid afspelen bij kritieke node-storingen",
+      "aria_toggle": "Waarschuwingsgeluid in-/uitschakelen"
+    },
+    "theme": {
+      "title": "Lichte modus",
+      "description": "Schakel tussen donker en licht thema",
+      "aria_toggle": "Lichte modus in-/uitschakelen"
+    },
+    "advanced": {
+      "hide": "▾ Geavanceerd verbergen",
+      "show": "▸ Geavanceerd tonen"
+    },
+    "daemon": {
+      "title": "Node-daemon",
+      "description": "Start de achtergrondservice opnieuw die je nodes beheert. Draaiende nodes blijven actief — alleen de supervisor wordt vervangen.",
+      "restart": "Daemon opnieuw starten",
+      "restarting": "Opnieuw starten…"
+    },
+    "concurrency": {
+      "title": "Upload-parallelliteit",
+      "description_1": "Bepaalt hoeveel offertes/uploads tegelijk kunnen lopen.",
+      "description_2": "Let op: dit heeft een grote invloed op de prestaties."
+    },
+    "prerelease": {
+      "title": "Pre-release-builds",
+      "description": "Ontvang automatische updates voor pre-release-builds (rc / beta) naast stabiele releases. Standaard uit.",
+      "restart_required": "Start de app opnieuw om deze wijziging toe te passen.",
+      "restart_now": "Nu opnieuw starten"
+    },
+    "direct_wallet": {
+      "title": "Directe portemonnee",
+      "description": "Verbinden met een privésleutel (omzeilt WalletConnect)",
+      "connected_badge": "Verbonden",
+      "address_label": "Adres",
+      "disconnect": "Verbinding verbreken",
+      "network_label": "Netwerk",
+      "network_sepolia_option": "Arbitrum Sepolia (testnet)",
+      "network_arbitrum_option": "Arbitrum One (mainnet)",
+      "rpc_url_label": "RPC-URL",
+      "rpc_url_optional": "(optioneel)",
+      "rpc_url_placeholder": "Standaard de openbare RPC voor de gekozen keten",
+      "private_key_label": "Privésleutel",
+      "private_key_placeholder": "0x... of ruwe hex",
+      "connect": "Verbinden",
+      "import_button": "Privésleutel importeren"
+    },
+    "diagnostics": {
+      "title": "Diagnostiek",
+      "summary": "{entries} logregels ({errors} fouten)",
+      "copy_button": "Naar klembord kopiëren",
+      "clear_button": "Wissen",
+      "empty": "Geen logregels",
+      "hide_log": "▾ Log verbergen",
+      "show_log": "▸ Log tonen"
+    },
+    "upload_history": {
+      "title": "Uploadgeschiedenis",
+      "summary_one": "{count} afgeronde regel in upload_history.json. DataMaps op schijf en chunks op het netwerk blijven onaangeroerd.",
+      "summary_many": "{count} afgeronde regels in upload_history.json. DataMaps op schijf en chunks op het netwerk blijven onaangeroerd.",
+      "clear_button": "Geschiedenis wissen",
+      "confirm_one": "1 upload-regel uit de geschiedenis wissen?\n\nHiermee verwijder je de lokale regel + opgeslagen record. De DataMaps op schijf en de chunks op het netwerk blijven onaangeroerd.",
+      "confirm_many": "{count} upload-regels uit de geschiedenis wissen?\n\nHiermee verwijder je de lokale regels + opgeslagen records. De DataMaps op schijf en de chunks op het netwerk blijven onaangeroerd."
+    },
+    "software": {
+      "title": "Software",
+      "version_label": "Versie",
+      "last_checked": "Laatst gecontroleerd {label}",
+      "check_button": "Op updates controleren",
+      "checking": "Controleren…"
+    },
+    "about": {
+      "title": "Over",
+      "node_version_label": "Node-daemon-versie"
+    },
+    "relative_time": {
+      "just_now": "zojuist",
+      "seconds_ago": "{n}s geleden",
+      "minutes_ago": "{n} min geleden",
+      "hours_ago": "{n}u geleden",
+      "days_ago": "{n}d geleden"
+    },
+    "picker": {
+      "storage_title": "Opslagmap kiezen",
+      "downloads_title": "Downloadmap kiezen"
+    },
+    "error": {
+      "private_key_invalid": "Ongeldige privésleutel — moet 64 hex-tekens zijn",
+      "invalid_eth_address": "Ongeldig EVM-adresformaat"
+    },
+    "toast": {
+      "upload_history_cleared": "Uploadgeschiedenis gewist",
+      "update_check_failed": "Update-controle mislukt",
+      "update_available": "Update beschikbaar: v{version}",
+      "on_latest_version": "Je gebruikt de nieuwste versie (v{version})",
+      "daemon_restarted": "Daemon opnieuw gestart",
+      "daemon_restart_failed": "Daemon opnieuw starten mislukt: {error}",
+      "storage_dir_updated": "Opslagmap bijgewerkt",
+      "storage_dir_verified": "Opslagmap geverifieerd",
+      "storage_dir_unwritable": "Deze map kan niet worden gebruikt voor node-opslag",
+      "select_directory_failed": "Kon map niet selecteren",
+      "downloads_dir_updated": "Downloadmap bijgewerkt",
+      "earnings_updated": "Verdienstenadres bijgewerkt",
+      "daemon_url_updated": "Daemon-URL bijgewerkt",
+      "diagnostics_copied": "Diagnostiek naar klembord gekopieerd",
+      "diagnostics_copy_failed": "Kon niet naar klembord kopiëren",
+      "log_cleared": "Log gewist",
+      "indelible_connected": "Verbonden met Indelible",
+      "indelible_disconnected": "Verbinding met Indelible verbroken",
+      "wallet_connected": "Portemonnee verbonden: {address}",
+      "wallet_disconnected": "Portemonnee losgekoppeld",
+      "wallet_attach_failed": "Portemonnee koppelen (Rust-zijde) mislukt: {error}"
+    }
+  },
+  "nav": {
+    "nodes": "Nodes",
+    "files": "Bestanden",
+    "wallet": "Portemonnee",
+    "settings": "Instellingen"
+  },
+  "header": {
+    "title": "Autonomi",
+    "active_transfers": "{count} actief",
+    "connecting": "Verbinden",
+    "connecting_tooltip": "Verbinden met het Autonomi-netwerk",
+    "connected": "Netwerk",
+    "connected_tooltip": "Verbonden met het Autonomi-netwerk",
+    "offline": "Offline · Opnieuw",
+    "offline_tooltip": "Verbinding mislukt — klik om opnieuw te proberen",
+    "connect_wallet": "Portemonnee koppelen"
+  },
+  "sidebar": {
+    "pre_release": "PRE-RELEASE",
+    "update_available": "Update beschikbaar",
+    "update_pre_release_tag": "Pre-release",
+    "network_devnet": "DEVNET",
+    "network_sepolia": "SEPOLIA TESTNET"
+  },
+  "common": {
+    "cancel": "Annuleren",
+    "confirm": "Bevestigen",
+    "close": "Sluiten",
+    "download": "Downloaden",
+    "start": "Starten",
+    "stop": "Stoppen",
+    "remove": "Verwijderen",
+    "close_panel": "Paneel sluiten"
+  },
+  "nodes": {
+    "add_button": "+ Nodes toevoegen",
+    "start_all": "Alles starten",
+    "stop_all": "Alles stoppen",
+    "running_count": "{count} actief",
+    "stopped_count": "{count} gestopt",
+    "errored_count": "{count} met fout",
+    "filter_placeholder": "Filter...",
+    "filter_aria_label": "Nodes filteren",
+    "starting_daemon": "Node-daemon starten…",
+    "restarting_daemon": "Node-daemon opnieuw starten…",
+    "nodes_keep_running": "Je nodes blijven draaien.",
+    "daemon_disconnected": "Kan geen verbinding maken met node-daemon",
+    "daemon_retrying": "Wordt automatisch opnieuw geprobeerd…",
+    "empty_title": "Nog geen nodes",
+    "empty_hint": "Klik op \"+ Nodes toevoegen\" om te beginnen",
+    "confirm_action": "Actie bevestigen",
+    "remove_node_message": "Node {id} verwijderen? Alle gegevens worden verwijderd.",
+    "stop_all_message": "Alle {count} draaiende nodes stoppen?",
+    "node_fallback_name": "Node {id}",
+    "field": {
+      "node_id": "Node-ID",
+      "status": "Status",
+      "version": "Versie",
+      "pid": "PID",
+      "uptime": "Uptime",
+      "storage": "Opslag",
+      "data_directory": "Datamap",
+      "log_directory": "Logmap",
+      "port": "Poort",
+      "binary": "Binary",
+      "rewards_address": "Beloningsadres",
+      "status_aria": "Status: {status}"
+    },
+    "add_dialog": {
+      "title": "Nodes toevoegen",
+      "number_label": "Aantal nodes",
+      "range_hint": "Tussen 1 en 50",
+      "no_earnings_warning": "Geen verdienstenadres ingesteld. Stel er een in op de Portemonnee-pagina voordat je nodes toevoegt.",
+      "submit_one": "1 node toevoegen",
+      "submit_many": "{count} nodes toevoegen"
+    },
+    "toast": {
+      "added": "{count} nodes toegevoegd",
+      "add_failed": "Nodes toevoegen mislukt: {error}",
+      "started": "Node {id} gestart",
+      "start_failed": "Node {id} starten mislukt: {error}",
+      "stopped": "Node {id} gestopt",
+      "stop_failed": "Node {id} stoppen mislukt: {error}",
+      "removed": "Node {id} verwijderd",
+      "remove_failed": "Node {id} verwijderen mislukt: {error}",
+      "no_stopped": "Geen gestopte nodes om te starten",
+      "no_running": "Geen draaiende nodes om te stoppen",
+      "node_failed": "Node {id} fout: {error}",
+      "started_count": "{count} nodes gestart",
+      "stopped_count": "{count} nodes gestopt",
+      "start_all_failed": "Alles starten mislukt: {error}",
+      "stop_all_failed": "Alles stoppen mislukt: {error}"
+    }
+  },
+  "files": {
+    "upload_button": "Bestand(en) uploaden",
+    "estimate_button": "Kosten schatten",
+    "download_by_address": "Download op adres",
+    "download_by_datamap": "Download via DataMap",
+    "uploads_heading": "Uploads",
+    "downloads_heading": "Downloads",
+    "clear": "Wissen",
+    "drop_files": "Sleep bestanden om te uploaden",
+    "uploads_empty_title": "Nog geen uploads",
+    "uploads_empty_hint": "Sleep bestanden hierheen, of gebruik de knoppen hierboven",
+    "downloads_empty_title": "Nog geen downloads",
+    "downloads_empty_hint": "Gebruik \"Download op adres\" of \"Download via DataMap\"",
+    "table": {
+      "name": "Naam",
+      "status": "Status",
+      "size": "Grootte",
+      "cost": "Kosten",
+      "date": "Datum",
+      "address": "Adres",
+      "saved_to": "Opgeslagen in",
+      "actions": "Acties"
+    },
+    "row": {
+      "free_already_stored": "Gratis — al opgeslagen",
+      "gas_suffix": "+ {gas} gas",
+      "public_badge": "Publiek",
+      "retry": "↻ Opnieuw",
+      "public_tooltip": "Publieke upload — klik om het deelbare netwerkadres te kopiëren",
+      "reveal_datamap_tooltip": "DataMap-bestand tonen in Finder/Verkenner",
+      "copy_datamap_tooltip": "Pad van DataMap-bestand kopiëren",
+      "copy_address_tooltip": "Netwerkadres kopiëren",
+      "retry_tooltip": "Upload opnieuw proberen",
+      "remove_tooltip": "Verwijderen uit lijst"
+    },
+    "stage": {
+      "encrypting": "Versleutelen…",
+      "quoting_pct": "Offerte · {pct}%",
+      "quoting_indeterminate": "Offerte ophalen…",
+      "storing_pct": "Opslaan · {pct}%",
+      "storing_indeterminate": "Opslaan…",
+      "resolving_pct": "DataMap oplossen · {pct}%",
+      "resolving_indeterminate": "DataMap oplossen…",
+      "downloading_pct": "Downloaden · {pct}%",
+      "downloading_indeterminate": "Downloaden…"
+    },
+    "picker": {
+      "upload_title": "Bestanden om te uploaden selecteren",
+      "datamap_title": "DataMap-bestand om te downloaden selecteren",
+      "estimate_title": "Bestanden voor kostenschatting selecteren",
+      "datamap_filter": "DataMap"
+    },
+    "toast": {
+      "upload_requires_wallet": "Upload vereist een portemonnee",
+      "download_requires_network": "Download vereist een netwerkverbinding",
+      "open_folder_failed": "Kon map niet openen",
+      "address_copied": "Adres naar klembord gekopieerd",
+      "public_address_copied": "Publiek adres gekopieerd — deel het om anderen dit bestand te laten downloaden",
+      "datamap_path_copied": "DataMap-pad naar klembord gekopieerd",
+      "already_stored_one": "1 bestand al opgeslagen — DataMap wordt bewaard",
+      "already_stored_many": "{count} bestanden al opgeslagen — DataMaps worden bewaard",
+      "upload_complete": "Upload voltooid: {name}",
+      "upload_failed": "Upload mislukt: {name} — {error}",
+      "payment_failed": "Betaling mislukt: {error}",
+      "download_complete": "Download voltooid: {name}",
+      "download_failed": "Download mislukt: {name} — {error}",
+      "datamap_missing": "Kan niet downloaden: DataMap-bestand ontbreekt of is onleesbaar",
+      "datamap_read_failed": "Kon DataMap niet lezen: {error}"
+    },
+    "error": {
+      "wallet_not_connected": "Portemonnee niet verbonden",
+      "not_connected_to_network": "Niet verbonden met netwerk"
+    },
+    "network": {
+      "unavailable": "Niet verbonden met het Autonomi-netwerk — kostenschatting niet beschikbaar.",
+      "retry_connection": "Verbinding opnieuw proberen",
+      "connecting": "Verbinden met het Autonomi-netwerk…",
+      "obtaining_quote": "Offerte ophalen uit het netwerk…",
+      "obtaining_quotes": "Offertes ophalen uit het netwerk…"
+    },
+    "datamap_saveas": {
+      "title": "Gedownload bestand opslaan als",
+      "filename_label": "Bestandsnaam",
+      "filename_placeholder": "mijnbestand.dat"
+    },
+    "download_dialog": {
+      "title": "Bestand downloaden",
+      "address_label": "Bestandsadres",
+      "address_placeholder": "Bestandsadres (hex)",
+      "filename_label": "Opslaan als bestandsnaam",
+      "filename_placeholder": "mijnbestand.dat"
+    },
+    "datamap_picker": {
+      "description": "Kies een eerdere upload om opnieuw te downloaden, of blader naar een DataMap-bestand dat je elders hebt ontvangen.",
+      "empty": "Nog geen eerdere uploads met opgeslagen DataMap.",
+      "browse_button": "Bladeren naar DataMap-bestand…"
+    },
+    "cost_estimate": {
+      "title": "Schatting upload-kosten",
+      "loading": "Kosten schatten…",
+      "no_files": "Geen bestanden geselecteerd",
+      "footnote": "Kosten opgevraagd bij het Autonomi-netwerk. Gas-kosten (ETH) komen bovenop de opslagkosten."
+    },
+    "upload_confirm": {
+      "title": "Upload bevestigen",
+      "info_banner": "Je kunt dit venster sluiten en terugkomen wanneer de offerte er is. De upload blijft in afwachting tot je hem goedkeurt of annuleert.",
+      "already_stored_badge": "Al opgeslagen",
+      "payment_label": "Betaling",
+      "payment_mixed": "Gemengd",
+      "payment_mixed_detail": "{regular} regulier, {merkle} Merkle — per bestand betaald.",
+      "payment_merkle": "Merkle-boom",
+      "payment_regular": "Regulier",
+      "payment_merkle_detail": "Eén transactie voor {count} chunks — lagere gas-kosten.",
+      "payment_regular_detail_one": "Per-batch-betaling voor 1 chunk.",
+      "payment_regular_detail_many": "Per-batch-betaling voor {count} chunks.",
+      "free_title": "Al opgeslagen op het netwerk — gratis",
+      "free_detail": "Elke chunk is al aanwezig. Er worden geen ANT of gas uitgegeven.",
+      "cost_label": "Netwerkopslagkosten",
+      "gas_label": "Geschatte gas-kosten",
+      "some_already_stored": "Sommige bestanden zijn al opgeslagen — dat deel kost niets.",
+      "visibility_label": "Zichtbaarheid",
+      "visibility_private": "Privé",
+      "visibility_private_desc": "Versleuteld en alleen toegankelijk met je DataMap. Alleen jij kunt het bestand ophalen.",
+      "visibility_public": "Publiek",
+      "visibility_public_desc": "DataMap wordt op het netwerk gepubliceerd. Deel één adres zodat iedereen het bestand kan ophalen.",
+      "regular_footnote": "Geschat op basis van één netwerk-offerte — de uiteindelijke kosten kunnen iets afwijken. Gas-kosten komen erbij.",
+      "cancel_upload": "Upload annuleren",
+      "ready_count": "Klaar: {ready} van {total}",
+      "approve_button_one": "Upload goedkeuren",
+      "approve_button_many": "{count} uploads goedkeuren"
+    }
+  },
+  "wallet": {
+    "earnings_heading": "Verdienstenadres",
+    "earnings_description": "Waar je node-verdiensten naartoe worden gestuurd",
+    "earnings_not_configured": "Niet ingesteld",
+    "edit": "Bewerken",
+    "save": "Opslaan",
+    "earnings_use_payment_prompt": "Het adres van je gekoppelde portemonnee gebruiken voor verdiensten?",
+    "earnings_use_payment_button": "Gebruik {address}",
+    "earnings_placeholder": "0x...",
+    "managed_storage_heading": "Beheerde opslag",
+    "managed_storage_org": "Opslag beheerd door {org}",
+    "managed_storage_description": "Uploads worden via de Indelible-gateway van je organisatie geleid. Geen lokale portemonnee nodig.",
+    "payment_wallet_heading": "Betalingsportemonnee",
+    "payment_optional_hint": "Optioneel — nodig voor bestandsuploads",
+    "connect_prompt": "Koppel een portemonnee om voor bestandsopslag te betalen",
+    "network_arbitrum_sepolia": "Arbitrum Sepolia testnet",
+    "network_arbitrum_one": "Arbitrum One netwerk vereist",
+    "import_key_hint": "Of importeer een privésleutel in {link}",
+    "import_key_hint_link_text": "Instellingen > Geavanceerd",
+    "address_label": "Adres",
+    "eth_balance_label": "ETH-saldo",
+    "ant_balance_label": "ANT-saldo",
+    "usdc_balance_label": "USDC-saldo",
+    "refresh_balances": "Saldi vernieuwen",
+    "disconnect": "Verbinding verbreken",
+    "toast": {
+      "import_key_in_settings": "Importeer een privésleutel in Instellingen > Geavanceerd",
+      "invalid_address": "Ongeldig adres: moet 0x + 40 hex-tekens zijn",
+      "earnings_saved": "Verdienstenadres opgeslagen",
+      "earnings_set_to_payment": "Verdienstenadres ingesteld op betalingsportemonnee",
+      "wallet_disconnected": "Portemonnee losgekoppeld"
+    }
+  },
+  "updater": {
+    "dialog": {
+      "title": "Update beschikbaar",
+      "version_ready": "v{version} is klaar om te installeren",
+      "pre_release_badge": "Pre-release",
+      "download_size": "Downloadgrootte: {size}",
+      "release_notes": "Release-notities",
+      "no_release_notes": "Geen release-notities beschikbaar voor deze versie.",
+      "downloading": "Downloaden...",
+      "download_complete": "Download geslaagd, de app start binnenkort opnieuw",
+      "auto_restart_hint": "De app start automatisch opnieuw wanneer het klaar is.",
+      "cancel_download": "Download annuleren",
+      "installing_tooltip": "Installeren — een moment geduld",
+      "not_now": "Niet nu",
+      "update_restart": "Bijwerken & opnieuw starten"
+    },
+    "toast": {
+      "install_no_restart": "Update v{version} is geïnstalleerd, maar de app is niet opnieuw gestart. Sluit Autonomi af en open opnieuw.",
+      "install_failed": "Installeren van update mislukt: {error}"
+    }
+  },
+  "validators": {
+    "filename": {
+      "has_special_chars": "Bestandsnaam mag geen speciale tekens bevatten",
+      "ends_with_dot_or_space": "Bestandsnaam mag niet eindigen op een punt of spatie",
+      "reserved_on_windows": "Deze naam is gereserveerd op Windows"
+    }
+  },
+  "status": {
+    "node": {
+      "running": "Actief",
+      "stopped": "Gestopt",
+      "starting": "Starten",
+      "stopping": "Stoppen",
+      "adding": "Toevoegen…",
+      "errored": "Fout",
+      "upgrade_scheduled": "Bijwerken"
+    },
+    "file": {
+      "pending": "In afwachting",
+      "quoting": "Offerte",
+      "encrypting": "Versleutelen…",
+      "resolving_datamap": "DataMap oplossen",
+      "queued_quoting": "In wachtrij: offerte",
+      "queued_uploading": "In wachtrij: uploaden",
+      "connecting_to_network": "Verbinden met netwerk…",
+      "obtaining_quote": "Offerte ophalen…",
+      "saving_datamap": "DataMap opslaan…",
+      "network_unavailable": "Netwerk niet beschikbaar",
+      "ready_to_approve": "Klaar voor goedkeuring",
+      "awaiting_approval": "Wacht op goedkeuring",
+      "uploading": "Uploaden",
+      "downloading": "Downloaden",
+      "done": "Klaar",
+      "downloaded": "Gedownload — klik om te openen"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",
         "@tauri-apps/plugin-opener": "^2.0.0",
+        "@tauri-apps/plugin-os": "^2.3.2",
         "@tauri-apps/plugin-process": "^2.0.0",
         "@tauri-apps/plugin-updater": "^2.0.0",
         "@wagmi/core": "^3.4.0",
@@ -21,6 +22,7 @@
         "pinia": "^2.2.0",
         "viem": "^2.47.1",
         "vue": "^3.5.0",
+        "vue-i18n": "^11.4.2",
         "vue-router": "^4.4.0"
       },
       "devDependencies": {
@@ -1064,6 +1066,67 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.2.tgz",
+      "integrity": "sha512-7fpuCcVmeLv2T9qHsARqGvh8xt+sV2fH+Q+gMHFwB/rPXzo85DpbJFKn7dBH1L5p0c2cSh2DW+2h/64EKrISmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/devtools-types": "11.4.2",
+        "@intlify/message-compiler": "11.4.2",
+        "@intlify/shared": "11.4.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/devtools-types": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.2.tgz",
+      "integrity": "sha512-3u8EN1kB6EMSi96KXs5k7a8y2X2g4+h3X6iwVZU47cP4n+mTuq//WMjG588BzSp/2XQ/dTXo2BLUXX+XS+PNfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.4.2",
+        "@intlify/shared": "11.4.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.2.tgz",
+      "integrity": "sha512-a6CDSGSMTGrg0BjD97x8TBYPf7qQMDlZipJ6UDfv/pd4OIym8TMlHu3MsH0bTNnRdAG2D6EFEykIgiQPqvtTkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "11.4.2",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.2.tgz",
+      "integrity": "sha512-NzpHbguRCsOHDwxmlBa9qu/imc+/QWgsYUaK6FZeNC0wK8QfAbhqrktEp/haVzxU1aikH8IX4ytD+mfFEMi/9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -5446,6 +5509,15 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
       "integrity": "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-os": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-os/-/plugin-os-2.3.2.tgz",
+      "integrity": "sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
@@ -14534,6 +14606,27 @@
       "resolved": "https://registry.npmjs.org/vue-devtools-stub/-/vue-devtools-stub-0.1.0.tgz",
       "integrity": "sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==",
       "license": "MIT"
+    },
+    "node_modules/vue-i18n": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.2.tgz",
+      "integrity": "sha512-sADDeKXqAGsPX6tK3t3y2ZiMpbVWN12tG+MhTiJ06rVoh58eGtM4wFyw3uWGbVkXByVp9Ne/AP+nSSzI+J9OAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.4.2",
+        "@intlify/devtools-types": "11.4.2",
+        "@intlify/shared": "11.4.2",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
     },
     "node_modules/vue-router": {
       "version": "4.6.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",
     "@tauri-apps/plugin-opener": "^2.0.0",
+    "@tauri-apps/plugin-os": "^2.3.2",
     "@tauri-apps/plugin-process": "^2.0.0",
     "@tauri-apps/plugin-updater": "^2.0.0",
     "@wagmi/core": "^3.4.0",
@@ -30,6 +31,7 @@
     "pinia": "^2.2.0",
     "viem": "^2.47.1",
     "vue": "^3.5.0",
+    "vue-i18n": "^11.4.2",
     "vue-router": "^4.4.0"
   },
   "devDependencies": {

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -7,13 +7,13 @@
           class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
           @click="uploadFiles"
         >
-          Upload File(s)
+          {{ $t('files.upload_button') }}
         </button>
         <button
           class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
           @click="estimateCost"
         >
-          Estimate Cost
+          {{ $t('files.estimate_button') }}
         </button>
       </div>
 
@@ -22,13 +22,13 @@
           class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
           @click="showDownloadDialog = true"
         >
-          Download by Address
+          {{ $t('files.download_by_address') }}
         </button>
         <button
           class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
           @click="openDownloadByDatamap"
         >
-          Download by Datamap
+          {{ $t('files.download_by_datamap') }}
         </button>
       </div>
     </div>
@@ -36,7 +36,7 @@
     <!-- Uploads table + drop zone -->
     <section class="mb-6">
       <div class="mb-2 flex items-center justify-between">
-        <h2 class="text-sm font-medium text-autonomi-text">Uploads</h2>
+        <h2 class="text-sm font-medium text-autonomi-text">{{ $t('files.uploads_heading') }}</h2>
         <!-- Bulk "Clear history" lives in Settings → Storage now (V2-232).
              Per-row × on hover handles the common case of trimming a single
              failed/complete entry; bulk wipe is gated behind a confirmation
@@ -61,7 +61,7 @@
               <svg class="mx-auto mb-2 h-8 w-8 text-autonomi-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
               </svg>
-              <p class="text-sm font-medium text-autonomi-blue">Drop files to upload</p>
+              <p class="text-sm font-medium text-autonomi-blue">{{ $t('files.drop_files') }}</p>
             </div>
           </div>
         </Transition>
@@ -73,8 +73,8 @@
           <svg class="mb-3 h-8 w-8 text-autonomi-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
           </svg>
-          <p class="text-sm text-autonomi-muted">No uploads yet</p>
-          <p class="mt-1 text-xs text-autonomi-muted">Drag files here, or use the buttons above</p>
+          <p class="text-sm text-autonomi-muted">{{ $t('files.uploads_empty_title') }}</p>
+          <p class="mt-1 text-xs text-autonomi-muted">{{ $t('files.uploads_empty_hint') }}</p>
         </div>
 
         <div v-else class="overflow-hidden rounded-lg border border-autonomi-border">
@@ -82,20 +82,20 @@
             <thead class="bg-autonomi-surface">
               <tr class="text-left text-xs uppercase tracking-wider text-autonomi-muted">
                 <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('name')">
-                  Name {{ uploadSortIndicator('name') }}
+                  {{ $t('files.table.name') }} {{ uploadSortIndicator('name') }}
                 </th>
-                <th class="px-4 py-2.5">Status</th>
+                <th class="px-4 py-2.5">{{ $t('files.table.status') }}</th>
                 <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('size_bytes')">
-                  Size {{ uploadSortIndicator('size_bytes') }}
+                  {{ $t('files.table.size') }} {{ uploadSortIndicator('size_bytes') }}
                 </th>
                 <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('cost')">
-                  Cost {{ uploadSortIndicator('cost') }}
+                  {{ $t('files.table.cost') }} {{ uploadSortIndicator('cost') }}
                 </th>
                 <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('date')">
-                  Date {{ uploadSortIndicator('date') }}
+                  {{ $t('files.table.date') }} {{ uploadSortIndicator('date') }}
                 </th>
-                <th class="px-4 py-2.5">Address</th>
-                <th class="w-px px-2 py-2.5"><span class="sr-only">Actions</span></th>
+                <th class="px-4 py-2.5">{{ $t('files.table.address') }}</th>
+                <th class="w-px px-2 py-2.5"><span class="sr-only">{{ $t('files.table.actions') }}</span></th>
               </tr>
             </thead>
             <tbody class="divide-y divide-autonomi-border">
@@ -130,11 +130,11 @@
                 <td class="px-4 py-2.5 text-autonomi-muted">{{ file.size_bytes ? formatBytes(file.size_bytes) : '-' }}</td>
                 <td class="px-4 py-2.5 text-autonomi-muted">
                   <template v-if="file.alreadyStored">
-                    <span class="text-green-400">Free — already stored</span>
+                    <span class="text-green-400">{{ $t('files.row.free_already_stored') }}</span>
                   </template>
                   <template v-else>
                     <span>{{ file.cost ?? '-' }}</span>
-                    <span v-if="file.gas_cost" class="block text-[10px] text-autonomi-muted/60">+ {{ file.gas_cost }} gas</span>
+                    <span v-if="file.gas_cost" class="block text-[10px] text-autonomi-muted/60">{{ $t('files.row.gas_suffix', { gas: file.gas_cost }) }}</span>
                   </template>
                 </td>
                 <td class="px-4 py-2.5 text-autonomi-muted">{{ formatDate(file.date) }}</td>
@@ -142,10 +142,10 @@
                   <span
                     v-if="file.public_address"
                     class="inline-flex cursor-pointer items-center gap-1.5 font-mono text-xs text-autonomi-blue hover:text-autonomi-blue/80"
-                    title="Public upload — click to copy the shareable network address"
+                    :title="$t('files.row.public_tooltip')"
                     @click.stop="copyPublicAddress(file.public_address)"
                   >
-                    <span class="rounded bg-autonomi-blue/15 px-1 py-px text-[9px] font-sans uppercase tracking-wider">Public</span>
+                    <span class="rounded bg-autonomi-blue/15 px-1 py-px text-[9px] font-sans uppercase tracking-wider">{{ $t('files.row.public_badge') }}</span>
                     {{ truncateAddress(file.public_address, 8, 6) }}
                   </span>
                   <div
@@ -154,7 +154,7 @@
                   >
                     <span
                       class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue hover:underline"
-                      title="Reveal datamap file in Finder/Explorer"
+                      :title="$t('files.row.reveal_datamap_tooltip')"
                       @click.stop="openFolder(file.data_map_file)"
                     >
                       {{ datamapBasename(file.data_map_file) }}
@@ -162,7 +162,7 @@
                     <button
                       type="button"
                       class="rounded p-0.5 text-autonomi-muted/60 hover:text-autonomi-blue hover:bg-autonomi-surface"
-                      title="Copy datamap file path"
+                      :title="$t('files.row.copy_datamap_tooltip')"
                       @click.stop="copyDatamapPath(file.data_map_file!)"
                     >
                       <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -174,7 +174,7 @@
                   <span
                     v-else-if="file.address"
                     class="cursor-pointer font-mono text-xs text-autonomi-muted hover:text-autonomi-blue"
-                    title="Copy network address"
+                    :title="$t('files.row.copy_address_tooltip')"
                     @click.stop="copyAddress(file.address)"
                   >
                     {{ truncateAddress(file.address, 8, 6) }}
@@ -186,14 +186,14 @@
                     <button
                       v-if="canRetry(file)"
                       class="rounded px-1.5 py-0.5 text-[11px] text-autonomi-muted hover:bg-autonomi-surface hover:text-autonomi-blue"
-                      title="Retry upload"
+                      :title="$t('files.row.retry_tooltip')"
                       @click.stop="onRetry(file)"
                     >
-                      ↻ Retry
+                      {{ $t('files.row.retry') }}
                     </button>
                     <button
                       class="rounded px-1.5 py-0.5 text-[11px] text-autonomi-muted hover:bg-autonomi-surface hover:text-autonomi-error"
-                      title="Remove from list"
+                      :title="$t('files.row.remove_tooltip')"
                       @click.stop="onRemove(file)"
                     >
                       ✕
@@ -210,13 +210,13 @@
     <!-- Downloads table -->
     <section>
       <div class="mb-2 flex items-center justify-between">
-        <h2 class="text-sm font-medium text-autonomi-text">Downloads</h2>
+        <h2 class="text-sm font-medium text-autonomi-text">{{ $t('files.downloads_heading') }}</h2>
         <button
           v-if="hasSettledDownloads"
           class="text-xs text-autonomi-muted hover:text-autonomi-text"
           @click="filesStore.clearDownloads()"
         >
-          Clear
+          {{ $t('files.clear') }}
         </button>
       </div>
 
@@ -227,8 +227,8 @@
         <svg class="mb-3 h-8 w-8 text-autonomi-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
         </svg>
-        <p class="text-sm text-autonomi-muted">No downloads yet</p>
-        <p class="mt-1 text-xs text-autonomi-muted">Use "Download by Address" or "Download by Datamap"</p>
+        <p class="text-sm text-autonomi-muted">{{ $t('files.downloads_empty_title') }}</p>
+        <p class="mt-1 text-xs text-autonomi-muted">{{ $t('files.downloads_empty_hint') }}</p>
       </div>
 
       <div v-else class="overflow-hidden rounded-lg border border-autonomi-border">
@@ -236,17 +236,17 @@
           <thead class="bg-autonomi-surface">
             <tr class="text-left text-xs uppercase tracking-wider text-autonomi-muted">
               <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleDownloadSort('name')">
-                Name {{ downloadSortIndicator('name') }}
+                {{ $t('files.table.name') }} {{ downloadSortIndicator('name') }}
               </th>
-              <th class="px-4 py-2.5">Status</th>
+              <th class="px-4 py-2.5">{{ $t('files.table.status') }}</th>
               <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleDownloadSort('size_bytes')">
-                Size {{ downloadSortIndicator('size_bytes') }}
+                {{ $t('files.table.size') }} {{ downloadSortIndicator('size_bytes') }}
               </th>
-              <th class="px-4 py-2.5">Saved to</th>
+              <th class="px-4 py-2.5">{{ $t('files.table.saved_to') }}</th>
               <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleDownloadSort('date')">
-                Date {{ downloadSortIndicator('date') }}
+                {{ $t('files.table.date') }} {{ downloadSortIndicator('date') }}
               </th>
-              <th class="w-px px-2 py-2.5"><span class="sr-only">Actions</span></th>
+              <th class="w-px px-2 py-2.5"><span class="sr-only">{{ $t('files.table.actions') }}</span></th>
             </tr>
           </thead>
           <tbody class="divide-y divide-autonomi-border">
@@ -286,7 +286,7 @@
                 <span v-if="isSettled(file)" class="inline-flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
                   <button
                     class="rounded px-1.5 py-0.5 text-[11px] text-autonomi-muted hover:bg-autonomi-surface hover:text-autonomi-error"
-                    title="Remove from list"
+                    :title="$t('files.row.remove_tooltip')"
                     @click.stop="onRemove(file)"
                   >
                     ✕
@@ -344,12 +344,15 @@ import { invoke } from '@tauri-apps/api/core'
 import { getCurrentWebview } from '@tauri-apps/api/webview'
 import { open as openFileDialog } from '@tauri-apps/plugin-dialog'
 import { revealItemInDir } from '@tauri-apps/plugin-opener'
+import { useI18n } from 'vue-i18n'
 import { useFilesStore, type FileEntry } from '~/stores/files'
 import { formatBytes, truncateAddress } from '~/utils/formatters'
 import { formatNanoTokens, formatGasCost } from '~/utils/payment'
 import { useSettingsStore } from '~/stores/settings'
 import { useToastStore } from '~/stores/toasts'
 import { useConnectionStore } from '~/stores/connection'
+
+const { t } = useI18n()
 
 interface FileMeta {
   path: string
@@ -521,15 +524,15 @@ function stageDetail(file: FileEntry): string | null {
   switch (file.stage) {
     case 'encrypting':
       // Encryption has no total until it finishes — fall back to a spinner.
-      return 'Encrypting…'
+      return t('files.stage.encrypting')
     case 'quoting':
-      return pct !== null ? `Quoting · ${pct}%` : 'Quoting…'
+      return pct !== null ? t('files.stage.quoting_pct', { pct }) : t('files.stage.quoting_indeterminate')
     case 'uploading':
-      return pct !== null ? `Storing · ${pct}%` : 'Storing…'
+      return pct !== null ? t('files.stage.storing_pct', { pct }) : t('files.stage.storing_indeterminate')
     case 'resolving':
-      return pct !== null ? `Resolving datamap · ${pct}%` : 'Resolving datamap…'
+      return pct !== null ? t('files.stage.resolving_pct', { pct }) : t('files.stage.resolving_indeterminate')
     case 'downloading':
-      return pct !== null ? `Downloading · ${pct}%` : 'Downloading…'
+      return pct !== null ? t('files.stage.downloading_pct', { pct }) : t('files.stage.downloading_indeterminate')
     default:
       return null
   }
@@ -663,7 +666,7 @@ async function uploadFiles() {
   try {
     const selected = await openFileDialog({
       multiple: true,
-      title: 'Select files to upload',
+      title: t('files.picker.upload_title'),
     })
     if (!selected) return
     const paths = Array.isArray(selected) ? selected : [selected]
@@ -771,9 +774,9 @@ function kickScheduler() {
     if (!wagmiConfig) {
       filesStore.updateEntry(uploadHead.id, {
         status: 'failed',
-        error: 'Wallet not connected',
+        error: t('files.error.wallet_not_connected'),
       })
-      toastStore.add('Upload requires a wallet', 'warning')
+      toastStore.add(t('files.toast.upload_requires_wallet'), 'warning')
       continue
     }
 
@@ -817,7 +820,7 @@ watch(
     showUploadConfirm.value = false
     selectedFileIds.value = []
     toastStore.add(
-      `${n} file${n !== 1 ? 's' : ''} already stored — saving datamap`,
+      n === 1 ? t('files.toast.already_stored_one') : t('files.toast.already_stored_many', { count: n }),
       'info',
     )
   },
@@ -897,8 +900,8 @@ async function browseForDatamap() {
   try {
     selected = await openFileDialog({
       multiple: false,
-      title: 'Select a datamap file to download',
-      filters: [{ name: 'Datamap', extensions: ['datamap'] }],
+      title: t('files.picker.datamap_title'),
+      filters: [{ name: t('files.picker.datamap_filter'), extensions: ['datamap'] }],
     })
   } catch (err) {
     console.error('File dialog error:', err)
@@ -930,8 +933,8 @@ async function startDatamapDownload(filename: string) {
     invoke('retry_autonomi_client').catch(() => {})
     const connected = await waitForConnection()
     if (!connected) {
-      filesStore.updateEntry(id, { status: 'failed', error: 'Not connected to network' })
-      toastStore.add('Download requires network connection', 'warning')
+      filesStore.updateEntry(id, { status: 'failed', error: t('files.error.not_connected_to_network') })
+      toastStore.add(t('files.toast.download_requires_network'), 'warning')
       return
     }
   }
@@ -951,8 +954,8 @@ async function handleDownload(address: string, filename: string) {
     invoke('retry_autonomi_client').catch(() => {})
     const connected = await waitForConnection()
     if (!connected) {
-      filesStore.updateEntry(id, { status: 'failed', error: 'Not connected to network' })
-      toastStore.add('Download requires network connection', 'warning')
+      filesStore.updateEntry(id, { status: 'failed', error: t('files.error.not_connected_to_network') })
+      toastStore.add(t('files.toast.download_requires_network'), 'warning')
       return
     }
   }
@@ -971,7 +974,7 @@ async function estimateCost() {
   try {
     const selected = await openFileDialog({
       multiple: true,
-      title: 'Select files to estimate cost',
+      title: t('files.picker.estimate_title'),
     })
     if (!selected) return
 
@@ -1056,23 +1059,23 @@ async function openFolder(path: string) {
   try {
     await revealItemInDir(path)
   } catch {
-    toastStore.add('Could not open folder', 'warning')
+    toastStore.add(t('files.toast.open_folder_failed'), 'warning')
   }
 }
 
 function copyAddress(addr: string) {
   navigator.clipboard.writeText(addr)
-  toastStore.add('Address copied to clipboard', 'info')
+  toastStore.add(t('files.toast.address_copied'), 'info')
 }
 
 function copyPublicAddress(addr: string) {
   navigator.clipboard.writeText(addr)
-  toastStore.add('Public address copied — share to let others download this file', 'info')
+  toastStore.add(t('files.toast.public_address_copied'), 'info')
 }
 
 function copyDatamapPath(path: string) {
   navigator.clipboard.writeText(path)
-  toastStore.add('Datamap path copied to clipboard', 'info')
+  toastStore.add(t('files.toast.datamap_path_copied'), 'info')
 }
 
 function datamapBasename(path: string): string {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,37 +7,37 @@
         :disabled="!nodesStore.daemonConnected"
         @click="showAddDialog = true"
       >
-        + Add Nodes
+        {{ $t('nodes.add_button') }}
       </button>
       <button
         class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text disabled:opacity-40 disabled:cursor-not-allowed"
         :disabled="!nodesStore.daemonConnected"
         @click="nodesStore.startAll()"
       >
-        Start All
+        {{ $t('nodes.start_all') }}
       </button>
       <button
         class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text disabled:opacity-40 disabled:cursor-not-allowed"
         :disabled="!nodesStore.daemonConnected"
         @click="confirmStopAll"
       >
-        Stop All
+        {{ $t('nodes.stop_all') }}
       </button>
 
       <div class="flex-1" />
 
       <!-- Summary stats -->
       <div class="flex items-center gap-4 text-xs text-autonomi-muted">
-        <span><span class="text-autonomi-success">●</span> {{ nodesStore.running }} running</span>
-        <span v-if="nodesStore.stopped > 0"><span class="text-autonomi-muted">○</span> {{ nodesStore.stopped }} stopped</span>
-        <span v-if="nodesStore.errored > 0"><span class="text-autonomi-error">●</span> {{ nodesStore.errored }} errored</span>
+        <span><span class="text-autonomi-success">●</span> {{ $t('nodes.running_count', { count: nodesStore.running }) }}</span>
+        <span v-if="nodesStore.stopped > 0"><span class="text-autonomi-muted">○</span> {{ $t('nodes.stopped_count', { count: nodesStore.stopped }) }}</span>
+        <span v-if="nodesStore.errored > 0"><span class="text-autonomi-error">●</span> {{ $t('nodes.errored_count', { count: nodesStore.errored }) }}</span>
       </div>
 
       <input
         v-model="filterText"
         type="text"
-        placeholder="Filter..."
-        aria-label="Filter nodes"
+        :placeholder="$t('nodes.filter_placeholder')"
+        :aria-label="$t('nodes.filter_aria_label')"
         class="w-48 rounded-md border border-autonomi-border bg-autonomi-dark px-3 py-1.5 text-sm text-autonomi-text placeholder-autonomi-muted focus:border-autonomi-blue focus:outline-none"
       />
 
@@ -46,15 +46,15 @@
     <!-- Initializing state -->
     <div v-if="nodesStore.initializing" class="flex flex-col items-center justify-center py-20">
       <div class="mb-3 h-6 w-6 animate-spin rounded-full border-2 border-autonomi-blue border-t-transparent" />
-      <p class="text-sm text-autonomi-muted">Starting node daemon...</p>
+      <p class="text-sm text-autonomi-muted">{{ $t('nodes.starting_daemon') }}</p>
     </div>
 
     <!-- Restarting state — takes priority over disconnected so the UI doesn't
          flicker the "Cannot connect" panel during an intentional restart. -->
     <div v-else-if="nodesStore.restarting" class="flex flex-col items-center justify-center py-20">
       <div class="mb-3 h-6 w-6 animate-spin rounded-full border-2 border-autonomi-blue border-t-transparent" />
-      <p class="text-sm text-autonomi-muted">Restarting node daemon...</p>
-      <p class="mt-1 text-xs text-autonomi-muted">Your nodes keep running.</p>
+      <p class="text-sm text-autonomi-muted">{{ $t('nodes.restarting_daemon') }}</p>
+      <p class="mt-1 text-xs text-autonomi-muted">{{ $t('nodes.nodes_keep_running') }}</p>
     </div>
 
     <!-- Disconnected state -->
@@ -64,8 +64,8 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
         </svg>
       </div>
-      <p class="mt-3 text-sm text-autonomi-muted">Cannot connect to node daemon</p>
-      <p class="mt-1 text-xs text-autonomi-muted">Retrying automatically...</p>
+      <p class="mt-3 text-sm text-autonomi-muted">{{ $t('nodes.daemon_disconnected') }}</p>
+      <p class="mt-1 text-xs text-autonomi-muted">{{ $t('nodes.daemon_retrying') }}</p>
     </div>
 
     <!-- Empty state -->
@@ -75,8 +75,8 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3m-19.5 0a4.5 4.5 0 01.9-2.7L5.737 5.1a3.375 3.375 0 012.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 01.9 2.7m0 0a3 3 0 01-3 3m0 3h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008zm-3 6h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008z" />
         </svg>
       </div>
-      <p class="mt-3 text-sm text-autonomi-muted">No nodes yet</p>
-      <p class="mt-1 text-xs text-autonomi-muted">Click "+ Add Nodes" to get started</p>
+      <p class="mt-3 text-sm text-autonomi-muted">{{ $t('nodes.empty_title') }}</p>
+      <p class="mt-1 text-xs text-autonomi-muted">{{ $t('nodes.empty_hint') }}</p>
     </div>
 
     <!-- Tile view -->
@@ -120,20 +120,20 @@
         class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
         @click.self="confirmDialog = null"
       >
-        <div role="dialog" aria-modal="true" aria-label="Confirm action" class="w-80 rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl">
+        <div role="dialog" aria-modal="true" :aria-label="$t('nodes.confirm_action')" class="w-80 rounded-lg border border-autonomi-border bg-autonomi-dark p-6 shadow-xl">
           <p class="mb-4 text-sm">{{ confirmDialog.message }}</p>
           <div class="flex justify-end gap-2">
             <button
               class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted"
               @click="confirmDialog = null"
             >
-              Cancel
+              {{ $t('common.cancel') }}
             </button>
             <button
               class="rounded-md bg-autonomi-error px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
               @click="executeConfirm"
             >
-              Confirm
+              {{ $t('common.confirm') }}
             </button>
           </div>
         </div>
@@ -143,8 +143,10 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { useNodesStore } from '~/stores/nodes'
 
+const { t } = useI18n()
 const nodesStore = useNodesStore()
 const filterText = ref('')
 const selectedId = ref<number | null>(null)
@@ -181,7 +183,7 @@ function toggleSelect(id: number) {
 
 function confirmRemove(id: number) {
   confirmDialog.value = {
-    message: `Remove node ${id}? This will delete all its data.`,
+    message: t('nodes.remove_node_message', { id }),
     action: () => {
       nodesStore.removeNode(id)
       if (selectedId.value === id) selectedId.value = null
@@ -191,7 +193,7 @@ function confirmRemove(id: number) {
 
 function confirmStopAll() {
   confirmDialog.value = {
-    message: `Stop all ${nodesStore.running} running nodes?`,
+    message: t('nodes.stop_all_message', { count: nodesStore.running }),
     action: () => nodesStore.stopAll(),
   }
 }

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -4,20 +4,20 @@
     <div v-if="settingsStore.indelibleConnected" class="rounded-lg border border-green-500/20 bg-green-500/5 p-4">
       <div class="flex items-center justify-between">
         <div class="min-w-0 flex-1">
-          <h3 class="text-sm font-medium text-green-400">Indelible Enterprise</h3>
-          <p class="text-xs text-autonomi-muted">Connected to managed storage gateway</p>
+          <h3 class="text-sm font-medium text-green-400">{{ $t('settings.indelible.title') }}</h3>
+          <p class="text-xs text-autonomi-muted">{{ $t('settings.indelible.subtitle_connected') }}</p>
         </div>
         <span class="ml-3 shrink-0 rounded-full bg-green-500/10 px-2.5 py-0.5 text-xs font-medium text-green-400">
-          Connected
+          {{ $t('settings.indelible.connected_badge') }}
         </span>
       </div>
       <div class="mt-3 space-y-2">
         <div class="rounded-md bg-autonomi-dark px-3 py-2">
-          <p class="text-xs text-autonomi-muted">Server</p>
+          <p class="text-xs text-autonomi-muted">{{ $t('settings.indelible.server_label') }}</p>
           <p class="truncate font-mono text-xs text-autonomi-text">{{ settingsStore.indelibleUrl }}</p>
         </div>
         <div class="rounded-md bg-autonomi-dark px-3 py-2">
-          <p class="text-xs text-autonomi-muted">Signed in as</p>
+          <p class="text-xs text-autonomi-muted">{{ $t('settings.indelible.signed_in_as') }}</p>
           <p class="text-xs text-autonomi-text">{{ settingsStore.indelibleOrgName }}</p>
           <p class="text-xs text-autonomi-muted">{{ settingsStore.indelibleUserEmail }}</p>
         </div>
@@ -25,7 +25,7 @@
           class="rounded-md border border-autonomi-border px-2.5 py-1.5 text-xs text-autonomi-muted hover:text-autonomi-text"
           @click="disconnectIndelible"
         >
-          Disconnect
+          {{ $t('settings.indelible.disconnect') }}
         </button>
       </div>
     </div>
@@ -34,19 +34,19 @@
     <div class="rounded-lg border border-autonomi-border p-4">
       <div class="flex items-center justify-between">
         <div class="min-w-0 flex-1">
-          <h3 class="text-sm font-medium">Storage Directory</h3>
-          <p class="text-xs text-autonomi-muted">Where node data is stored on disk</p>
-          <p class="mt-0.5 truncate font-mono text-xs text-autonomi-muted">{{ settingsStore.storageDir ?? 'Default' }}</p>
+          <h3 class="text-sm font-medium">{{ $t('settings.storage.title') }}</h3>
+          <p class="text-xs text-autonomi-muted">{{ $t('settings.storage.description') }}</p>
+          <p class="mt-0.5 truncate font-mono text-xs text-autonomi-muted">{{ settingsStore.storageDir ?? $t('settings.storage.default') }}</p>
         </div>
         <button
           class="ml-3 shrink-0 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted hover:text-autonomi-text"
           @click="pickStorageDir"
         >
-          Browse
+          {{ $t('settings.storage.browse') }}
         </button>
       </div>
       <p class="mt-2 text-xs text-autonomi-warning">
-        Only applies to newly added nodes. Existing nodes keep their current directory.
+        {{ $t('settings.storage.warning') }}
       </p>
       <p v-if="settingsStore.storageDirProbeError" class="mt-2 rounded border border-autonomi-error/40 bg-autonomi-error/10 px-2 py-1.5 text-xs text-autonomi-error">
         {{ settingsStore.storageDirProbeError }}
@@ -56,28 +56,28 @@
     <!-- Downloads Directory -->
     <div class="flex items-center justify-between rounded-lg border border-autonomi-border p-4">
       <div class="min-w-0 flex-1">
-        <h3 class="text-sm font-medium">Downloads Directory</h3>
-        <p class="text-xs text-autonomi-muted">Where downloaded files are saved</p>
-        <p class="mt-0.5 truncate font-mono text-xs text-autonomi-muted">{{ settingsStore.downloadDir ?? 'Not set' }}</p>
+        <h3 class="text-sm font-medium">{{ $t('settings.downloads.title') }}</h3>
+        <p class="text-xs text-autonomi-muted">{{ $t('settings.downloads.description') }}</p>
+        <p class="mt-0.5 truncate font-mono text-xs text-autonomi-muted">{{ settingsStore.downloadDir ?? $t('settings.downloads.not_set') }}</p>
       </div>
       <button
         class="ml-3 shrink-0 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted hover:text-autonomi-text"
         @click="pickDownloadDir"
       >
-        Browse
+        {{ $t('settings.downloads.browse') }}
       </button>
     </div>
 
     <!-- Bell on Critical -->
     <div class="flex items-center justify-between rounded-lg border border-autonomi-border p-4">
       <div>
-        <h3 class="text-sm font-medium">Alert Sound</h3>
-        <p class="text-xs text-autonomi-muted">Play sound on critical node failures</p>
+        <h3 class="text-sm font-medium">{{ $t('settings.alert.title') }}</h3>
+        <p class="text-xs text-autonomi-muted">{{ $t('settings.alert.description') }}</p>
       </div>
       <button
         role="switch"
         :aria-checked="settingsStore.bellOnCritical"
-        aria-label="Toggle alert sound"
+        :aria-label="$t('settings.alert.aria_toggle')"
         class="relative h-6 w-11 rounded-full transition-colors"
         :class="settingsStore.bellOnCritical ? 'bg-autonomi-blue' : 'bg-autonomi-border'"
         @click="settingsStore.toggleBell()"
@@ -92,13 +92,13 @@
     <!-- Appearance -->
     <div class="flex items-center justify-between rounded-lg border border-autonomi-border p-4">
       <div>
-        <h3 class="text-sm font-medium">Light Mode</h3>
-        <p class="text-xs text-autonomi-muted">Switch between dark and light themes</p>
+        <h3 class="text-sm font-medium">{{ $t('settings.theme.title') }}</h3>
+        <p class="text-xs text-autonomi-muted">{{ $t('settings.theme.description') }}</p>
       </div>
       <button
         role="switch"
         :aria-checked="settingsStore.themeMode === 'light'"
-        aria-label="Toggle light mode"
+        :aria-label="$t('settings.theme.aria_toggle')"
         class="relative h-6 w-11 rounded-full transition-colors"
         :class="settingsStore.themeMode === 'light' ? 'bg-autonomi-blue' : 'bg-autonomi-border'"
         @click="settingsStore.setThemeMode(settingsStore.themeMode === 'light' ? 'dark' : 'light')"
@@ -134,7 +134,7 @@
         :aria-expanded="showAdvanced"
         @click="showAdvanced = !showAdvanced"
       >
-        {{ showAdvanced ? '▾ Hide Advanced' : '▸ Show Advanced' }}
+        {{ showAdvanced ? $t('settings.advanced.hide') : $t('settings.advanced.show') }}
       </button>
       <div v-if="showAdvanced" class="mt-2 space-y-4">
 
@@ -142,10 +142,9 @@
         <div class="rounded-lg border border-autonomi-border p-4">
           <div class="flex items-center justify-between gap-3">
             <div class="min-w-0 flex-1">
-              <h3 class="text-sm font-medium">Node daemon</h3>
+              <h3 class="text-sm font-medium">{{ $t('settings.daemon.title') }}</h3>
               <p class="text-xs text-autonomi-muted">
-                Restart the background service that supervises your nodes. Your
-                running nodes keep running — only the supervisor is swapped.
+                {{ $t('settings.daemon.description') }}
               </p>
             </div>
             <button
@@ -153,7 +152,7 @@
               class="ml-3 shrink-0 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted hover:text-autonomi-text disabled:opacity-50"
               @click="restartDaemon"
             >
-              {{ daemonRestarting ? 'Restarting…' : 'Restart daemon' }}
+              {{ daemonRestarting ? $t('settings.daemon.restarting') : $t('settings.daemon.restart') }}
             </button>
           </div>
         </div>
@@ -162,12 +161,12 @@
         <div class="rounded-lg border border-autonomi-border p-4">
           <div class="flex items-center justify-between gap-3">
             <div class="min-w-0 flex-1">
-              <h3 class="text-sm font-medium">Upload concurrency</h3>
+              <h3 class="text-sm font-medium">{{ $t('settings.concurrency.title') }}</h3>
               <p class="mt-1 text-xs text-autonomi-muted">
-                This controls how many quotes/uploads can be running at the same time.
+                {{ $t('settings.concurrency.description_1') }}
               </p>
               <p class="mt-1 text-xs text-autonomi-muted">
-                Note that this has a very large impact on performance.
+                {{ $t('settings.concurrency.description_2') }}
               </p>
             </div>
             <input
@@ -186,23 +185,23 @@
         <div class="rounded-lg border border-autonomi-border p-4">
           <div class="flex items-center justify-between gap-3">
             <div class="min-w-0 flex-1">
-              <h3 class="text-sm font-medium">Pre-release builds</h3>
+              <h3 class="text-sm font-medium">{{ $t('settings.prerelease.title') }}</h3>
               <p class="mt-1 text-xs text-autonomi-muted">
-                Receive auto-updates for pre-release builds (rc / beta) in addition to stable releases. Off by default.
+                {{ $t('settings.prerelease.description') }}
               </p>
               <div
                 v-if="prereleaseChannelRestartRequired"
                 class="mt-1.5 flex items-center gap-2"
               >
                 <p class="text-xs font-medium text-amber-400">
-                  Restart the app to apply this change.
+                  {{ $t('settings.prerelease.restart_required') }}
                 </p>
                 <button
                   type="button"
                   class="rounded-md border border-amber-400/40 px-2 py-0.5 text-xs font-medium text-amber-400 hover:bg-amber-400/10"
                   @click="relaunchApp"
                 >
-                  Restart now
+                  {{ $t('settings.prerelease.restart_now') }}
                 </button>
               </div>
             </div>
@@ -230,25 +229,25 @@
         <div v-if="!settingsStore.indelibleConnected" class="rounded-lg border border-autonomi-border p-4">
           <div class="flex items-center justify-between">
             <div class="min-w-0 flex-1">
-              <h3 class="text-sm font-medium">Indelible Enterprise</h3>
-              <p class="text-xs text-autonomi-muted">Connect to a self-hosted Indelible gateway for managed storage</p>
+              <h3 class="text-sm font-medium">{{ $t('settings.indelible.title') }}</h3>
+              <p class="text-xs text-autonomi-muted">{{ $t('settings.indelible.subtitle_setup') }}</p>
             </div>
             <span
               v-if="settingsStore.indelibleConnected"
               class="ml-3 shrink-0 rounded-full bg-green-500/10 px-2.5 py-0.5 text-xs font-medium text-green-400"
             >
-              Connected
+              {{ $t('settings.indelible.connected_badge') }}
             </span>
           </div>
 
           <!-- Connected state -->
           <div v-if="settingsStore.indelibleConnected" class="mt-3 space-y-2">
             <div class="rounded-md bg-autonomi-dark px-3 py-2">
-              <p class="text-xs text-autonomi-muted">Server</p>
+              <p class="text-xs text-autonomi-muted">{{ $t('settings.indelible.server_label') }}</p>
               <p class="truncate font-mono text-xs text-autonomi-text">{{ settingsStore.indelibleUrl }}</p>
             </div>
             <div class="rounded-md bg-autonomi-dark px-3 py-2">
-              <p class="text-xs text-autonomi-muted">Signed in as</p>
+              <p class="text-xs text-autonomi-muted">{{ $t('settings.indelible.signed_in_as') }}</p>
               <p class="text-xs text-autonomi-text">{{ settingsStore.indelibleOrgName }}</p>
               <p class="text-xs text-autonomi-muted">{{ settingsStore.indelibleUserEmail }}</p>
             </div>
@@ -256,28 +255,28 @@
               class="rounded-md border border-autonomi-border px-2.5 py-1.5 text-xs text-autonomi-muted hover:text-autonomi-text"
               @click="disconnectIndelible"
             >
-              Disconnect
+              {{ $t('settings.indelible.disconnect') }}
             </button>
           </div>
 
           <!-- Setup form -->
           <div v-else-if="editingIndelible" class="mt-3 space-y-3">
             <div>
-              <label class="mb-1 block text-xs text-autonomi-muted">Server URL</label>
+              <label class="mb-1 block text-xs text-autonomi-muted">{{ $t('settings.indelible.server_url_label') }}</label>
               <input
                 v-model="indelibleUrlInput"
                 type="text"
-                placeholder="https://files.acme.com"
+                :placeholder="$t('settings.indelible.server_url_placeholder')"
                 class="w-full rounded-md border border-autonomi-border bg-autonomi-dark px-3 py-1.5 font-mono text-xs text-autonomi-text placeholder-autonomi-muted focus:border-autonomi-blue focus:outline-none"
               />
             </div>
             <div>
-              <label class="mb-1 block text-xs text-autonomi-muted">API Key</label>
+              <label class="mb-1 block text-xs text-autonomi-muted">{{ $t('settings.indelible.api_key_label') }}</label>
               <input
                 v-model="indelibleApiKeyInput"
                 type="password"
                 autocomplete="off"
-                placeholder="Your API token"
+                :placeholder="$t('settings.indelible.api_key_placeholder')"
                 class="w-full rounded-md border border-autonomi-border bg-autonomi-dark px-3 py-1.5 font-mono text-xs text-autonomi-text placeholder-autonomi-muted focus:border-autonomi-blue focus:outline-none"
               />
             </div>
@@ -290,13 +289,13 @@
                 class="rounded-md bg-autonomi-blue px-2.5 py-1.5 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
                 @click="testIndelible"
               >
-                {{ indelibleTesting ? 'Testing...' : 'Test & Connect' }}
+                {{ indelibleTesting ? $t('settings.indelible.testing') : $t('settings.indelible.test_connect') }}
               </button>
               <button
                 class="rounded-md border border-autonomi-border px-2.5 py-1.5 text-xs text-autonomi-muted hover:text-autonomi-text"
                 @click="editingIndelible = false"
               >
-                Cancel
+                {{ $t('common.cancel') }}
               </button>
             </div>
           </div>
@@ -307,7 +306,7 @@
               class="rounded-md border border-autonomi-border px-2.5 py-1.5 text-xs text-autonomi-muted hover:text-autonomi-text"
               @click="startEditIndelible"
             >
-              Configure Connection
+              {{ $t('settings.indelible.configure') }}
             </button>
           </div>
         </div>
@@ -316,60 +315,60 @@
         <div class="rounded-lg border border-autonomi-border p-4">
           <div class="flex items-center justify-between">
             <div class="min-w-0 flex-1">
-              <h3 class="text-sm font-medium">Direct Wallet</h3>
-              <p class="text-xs text-autonomi-muted">Connect with a private key (bypasses WalletConnect)</p>
+              <h3 class="text-sm font-medium">{{ $t('settings.direct_wallet.title') }}</h3>
+              <p class="text-xs text-autonomi-muted">{{ $t('settings.direct_wallet.description') }}</p>
             </div>
             <span
               v-if="walletStore.connected && directWalletActive"
               class="ml-3 shrink-0 rounded-full bg-green-500/10 px-2.5 py-0.5 text-xs font-medium text-green-400"
             >
-              Connected
+              {{ $t('settings.direct_wallet.connected_badge') }}
             </span>
           </div>
 
           <div v-if="walletStore.connected && directWalletActive" class="mt-3 space-y-2">
             <div class="rounded-md bg-autonomi-dark px-3 py-2">
-              <p class="text-xs text-autonomi-muted">Address</p>
+              <p class="text-xs text-autonomi-muted">{{ $t('settings.direct_wallet.address_label') }}</p>
               <p class="truncate font-mono text-xs text-autonomi-text">{{ walletStore.paymentAddress }}</p>
             </div>
             <button
               class="rounded-md border border-autonomi-border px-2.5 py-1.5 text-xs text-autonomi-muted hover:text-autonomi-text"
               @click="disconnectDirectWallet"
             >
-              Disconnect
+              {{ $t('settings.direct_wallet.disconnect') }}
             </button>
           </div>
 
           <div v-else-if="editingDirectWallet" class="mt-3 space-y-3">
             <div>
-              <label class="mb-1 block text-xs text-autonomi-muted">Network</label>
+              <label class="mb-1 block text-xs text-autonomi-muted">{{ $t('settings.direct_wallet.network_label') }}</label>
               <select
                 v-model="directWalletNetwork"
                 class="w-full rounded-md border border-autonomi-border bg-autonomi-dark px-3 py-1.5 text-xs text-autonomi-text focus:border-autonomi-blue focus:outline-none"
               >
-                <option value="arbitrum-sepolia">Arbitrum Sepolia (testnet)</option>
-                <option value="arbitrum">Arbitrum One (mainnet)</option>
+                <option value="arbitrum-sepolia">{{ $t('settings.direct_wallet.network_sepolia_option') }}</option>
+                <option value="arbitrum">{{ $t('settings.direct_wallet.network_arbitrum_option') }}</option>
               </select>
             </div>
             <div>
               <label class="mb-1 block text-xs text-autonomi-muted">
-                RPC URL <span class="text-autonomi-muted/60">(optional)</span>
+                {{ $t('settings.direct_wallet.rpc_url_label') }} <span class="text-autonomi-muted/60">{{ $t('settings.direct_wallet.rpc_url_optional') }}</span>
               </label>
               <input
                 v-model="directWalletRpcInput"
                 type="text"
                 autocomplete="off"
-                placeholder="Defaults to public RPC for the selected chain"
+                :placeholder="$t('settings.direct_wallet.rpc_url_placeholder')"
                 class="w-full rounded-md border border-autonomi-border bg-autonomi-dark px-3 py-1.5 font-mono text-xs text-autonomi-text placeholder-autonomi-muted focus:border-autonomi-blue focus:outline-none"
               />
             </div>
             <div>
-              <label class="mb-1 block text-xs text-autonomi-muted">Private Key</label>
+              <label class="mb-1 block text-xs text-autonomi-muted">{{ $t('settings.direct_wallet.private_key_label') }}</label>
               <input
                 v-model="directWalletKeyInput"
                 type="password"
                 autocomplete="off"
-                placeholder="0x... or raw hex"
+                :placeholder="$t('settings.direct_wallet.private_key_placeholder')"
                 class="w-full rounded-md border border-autonomi-border bg-autonomi-dark px-3 py-1.5 font-mono text-xs text-autonomi-text placeholder-autonomi-muted focus:border-autonomi-blue focus:outline-none"
                 @keyup.enter="connectDirectWallet"
               />
@@ -383,13 +382,13 @@
                 class="rounded-md bg-autonomi-blue px-2.5 py-1.5 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
                 @click="connectDirectWallet"
               >
-                Connect
+                {{ $t('settings.direct_wallet.connect') }}
               </button>
               <button
                 class="rounded-md border border-autonomi-border px-2.5 py-1.5 text-xs text-autonomi-muted hover:text-autonomi-text"
                 @click="editingDirectWallet = false"
               >
-                Cancel
+                {{ $t('common.cancel') }}
               </button>
             </div>
           </div>
@@ -399,7 +398,7 @@
               class="rounded-md border border-autonomi-border px-2.5 py-1.5 text-xs text-autonomi-muted hover:text-autonomi-text"
               @click="editingDirectWallet = true; directWalletError = ''"
             >
-              Import Private Key
+              {{ $t('settings.direct_wallet.import_button') }}
             </button>
           </div>
         </div>
@@ -408,22 +407,22 @@
         <div class="rounded-lg border border-autonomi-border p-4">
           <div class="flex items-center justify-between">
             <div>
-              <h3 class="text-sm font-medium">Diagnostics</h3>
-              <p class="text-xs text-autonomi-muted">{{ errorLogStore.entries.length }} log entries ({{ errorLogStore.errors.length }} errors)</p>
+              <h3 class="text-sm font-medium">{{ $t('settings.diagnostics.title') }}</h3>
+              <p class="text-xs text-autonomi-muted">{{ $t('settings.diagnostics.summary', { entries: errorLogStore.entries.length, errors: errorLogStore.errors.length }) }}</p>
             </div>
             <div class="flex gap-2">
               <button
                 class="shrink-0 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted hover:text-autonomi-text"
                 @click="copyDiagnostics"
               >
-                Copy to Clipboard
+                {{ $t('settings.diagnostics.copy_button') }}
               </button>
               <button
                 v-if="errorLogStore.entries.length > 0"
                 class="shrink-0 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted hover:text-autonomi-text"
                 @click="clearLog"
               >
-                Clear
+                {{ $t('settings.diagnostics.clear_button') }}
               </button>
             </div>
           </div>
@@ -442,13 +441,13 @@
               <span class="ml-1">[{{ entry.source }}]</span>
               <span class="ml-1">{{ entry.message }}</span>
             </div>
-            <p v-if="errorLogStore.entries.length === 0" class="text-xs text-autonomi-muted">No log entries</p>
+            <p v-if="errorLogStore.entries.length === 0" class="text-xs text-autonomi-muted">{{ $t('settings.diagnostics.empty') }}</p>
           </div>
           <button
             class="mt-2 text-xs text-autonomi-muted hover:text-autonomi-text"
             @click="showLog = !showLog"
           >
-            {{ showLog ? '▾ Hide Log' : '▸ Show Log' }}
+            {{ showLog ? $t('settings.diagnostics.hide_log') : $t('settings.diagnostics.show_log') }}
           </button>
         </div>
       </div>
@@ -459,11 +458,11 @@
          the common single-row case. -->
     <div class="flex items-center justify-between rounded-lg border border-autonomi-border p-4">
       <div class="min-w-0 flex-1">
-        <h3 class="text-sm font-medium">Upload history</h3>
+        <h3 class="text-sm font-medium">{{ $t('settings.upload_history.title') }}</h3>
         <p class="mt-0.5 text-xs text-autonomi-muted">
-          {{ settledUploadCount }} settled
-          {{ settledUploadCount === 1 ? 'entry' : 'entries' }} in
-          <span class="font-mono">upload_history.json</span>. DataMaps on disk and chunks on the network are untouched.
+          {{ settledUploadCount === 1
+            ? $t('settings.upload_history.summary_one', { count: settledUploadCount })
+            : $t('settings.upload_history.summary_many', { count: settledUploadCount }) }}
         </p>
       </div>
       <button
@@ -471,7 +470,7 @@
         class="shrink-0 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted hover:text-autonomi-error disabled:opacity-50 disabled:hover:text-autonomi-muted"
         @click="confirmClearUploadHistory"
       >
-        Clear history
+        {{ $t('settings.upload_history.clear_button') }}
       </button>
     </div>
 
@@ -479,13 +478,13 @@
     <div class="rounded-lg border border-autonomi-border p-4">
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0 flex-1">
-          <h3 class="text-sm font-medium">Software</h3>
+          <h3 class="text-sm font-medium">{{ $t('settings.software.title') }}</h3>
           <div class="mt-1 flex items-baseline gap-2 text-xs">
-            <span class="text-autonomi-muted">Version</span>
+            <span class="text-autonomi-muted">{{ $t('settings.software.version_label') }}</span>
             <span class="font-mono">{{ appVersion }}</span>
           </div>
           <p v-if="lastCheckedLabel" class="mt-0.5 text-xs text-autonomi-muted">
-            Last checked {{ lastCheckedLabel }}
+            {{ $t('settings.software.last_checked', { label: lastCheckedLabel }) }}
           </p>
         </div>
         <button
@@ -493,17 +492,17 @@
           class="shrink-0 rounded-md border border-autonomi-border px-2.5 py-1 text-xs text-autonomi-muted hover:text-autonomi-text disabled:opacity-50"
           @click="checkForUpdates"
         >
-          {{ updaterStore.checking ? 'Checking…' : 'Check for Updates' }}
+          {{ updaterStore.checking ? $t('settings.software.checking') : $t('settings.software.check_button') }}
         </button>
       </div>
     </div>
 
     <!-- About -->
     <div class="rounded-lg border border-autonomi-border p-4">
-      <h3 class="text-sm font-medium">About</h3>
+      <h3 class="text-sm font-medium">{{ $t('settings.about.title') }}</h3>
       <div class="mt-3 space-y-1.5 text-xs">
         <div class="flex justify-between">
-          <span class="text-autonomi-muted">Node daemon version</span>
+          <span class="text-autonomi-muted">{{ $t('settings.about.node_version_label') }}</span>
           <span class="font-mono">{{ nodeVersion }}</span>
         </div>
       </div>
@@ -581,12 +580,13 @@ async function confirmClearUploadHistory() {
   // Native window.confirm is enough here — the sheet is already a settings
   // page surface and the action is reversible only via OS-level file
   // restoration on `upload_history.json`.
-  const ok = window.confirm(
-    `Clear ${settledUploadCount.value} upload ${settledUploadCount.value === 1 ? 'entry' : 'entries'} from history?\n\nThis removes the local row + persisted record. The DataMaps on disk and the chunks on the network are unaffected.`,
-  )
+  const message = settledUploadCount.value === 1
+    ? t('settings.upload_history.confirm_one')
+    : t('settings.upload_history.confirm_many', { count: settledUploadCount.value })
+  const ok = window.confirm(message)
   if (!ok) return
   filesStore.clearUploadHistory()
-  toasts.add('Upload history cleared', 'info')
+  toasts.add(t('settings.toast.upload_history_cleared'), 'info')
 }
 
 // Re-compute "Last checked X ago" every 30s so the label stays fresh while
@@ -604,27 +604,27 @@ const lastCheckedLabel = computed(() => {
   const ts = updaterStore.lastCheckedAt
   if (!ts) return ''
   const secs = Math.max(0, Math.round((nowTick.value - ts) / 1000))
-  if (secs < 10) return 'just now'
-  if (secs < 60) return `${secs}s ago`
+  if (secs < 10) return t('settings.relative_time.just_now')
+  if (secs < 60) return t('settings.relative_time.seconds_ago', { n: secs })
   const mins = Math.round(secs / 60)
-  if (mins < 60) return `${mins} min ago`
+  if (mins < 60) return t('settings.relative_time.minutes_ago', { n: mins })
   const hours = Math.round(mins / 60)
-  if (hours < 24) return `${hours}h ago`
+  if (hours < 24) return t('settings.relative_time.hours_ago', { n: hours })
   const days = Math.round(hours / 24)
-  return `${days}d ago`
+  return t('settings.relative_time.days_ago', { n: days })
 })
 
 async function checkForUpdates() {
   const result = await updaterStore.checkForUpdate()
   if (!result.ok) {
-    toasts.add(result.error ?? 'Update check failed', 'error')
+    toasts.add(result.error ?? t('settings.toast.update_check_failed'), 'error')
     return
   }
   if (result.available) {
-    toasts.add(`Update available: v${updaterStore.version}`, 'info')
+    toasts.add(t('settings.toast.update_available', { version: updaterStore.version }), 'info')
     updaterStore.showDialog = true
   } else {
-    toasts.add(`You're on the latest version (v${appVersion.value})`, 'success')
+    toasts.add(t('settings.toast.on_latest_version', { version: appVersion.value }), 'success')
   }
 }
 const nodeVersion = computed(() => {
@@ -650,9 +650,9 @@ const daemonRestarting = computed(() => nodesStore.restarting)
 async function restartDaemon() {
   try {
     await nodesStore.restartDaemon()
-    toasts.add('Daemon restarted', 'info')
+    toasts.add(t('settings.toast.daemon_restarted'), 'info')
   } catch (e: any) {
-    toasts.add(`Failed to restart daemon: ${e?.message ?? e}`, 'error')
+    toasts.add(t('settings.toast.daemon_restart_failed', { error: e?.message ?? e }), 'error')
   }
 }
 
@@ -674,7 +674,7 @@ async function connectDirectWallet() {
     let key = directWalletKeyInput.value.trim()
     if (!key.startsWith('0x')) key = `0x${key}`
     if (!/^0x[0-9a-fA-F]{64}$/.test(key)) {
-      directWalletError.value = 'Invalid private key — must be 64 hex characters'
+      directWalletError.value = t('settings.error.private_key_invalid')
       return
     }
 
@@ -720,14 +720,14 @@ async function connectDirectWallet() {
       console.warn('attach_wallet failed:', e)
       // Non-fatal — uploads will fall back to the JS wagmi path. Surface
       // through the toast so the user sees something didn't go right.
-      toasts.add(`Wallet attach (Rust side) failed: ${e?.message ?? e}`, 'error')
+      toasts.add(t('settings.toast.wallet_attach_failed', { error: e?.message ?? e }), 'error')
     }
 
     directWalletActive.value = true
     editingDirectWallet.value = false
     directWalletKeyInput.value = ''
     directWalletRpcInput.value = ''
-    toasts.add(`Wallet connected: ${walletStore.paymentAddress}`, 'info')
+    toasts.add(t('settings.toast.wallet_connected', { address: walletStore.paymentAddress }), 'info')
   } catch (e: any) {
     directWalletError.value = e.message ?? 'Failed to import key'
   }
@@ -756,7 +756,7 @@ async function disconnectDirectWallet() {
   // rebuild from scratch.
   const { disposeDevnetWallet } = await import('~/composables/useDevnetWallet')
   disposeDevnetWallet()
-  toasts.add('Wallet disconnected', 'info')
+  toasts.add(t('settings.toast.wallet_disconnected'), 'info')
 }
 
 // Indelible connection
@@ -783,7 +783,7 @@ async function testIndelible() {
   indelibleTesting.value = false
   if (result.ok) {
     editingIndelible.value = false
-    toasts.add('Connected to Indelible', 'info')
+    toasts.add(t('settings.toast.indelible_connected'), 'info')
   } else {
     indelibleError.value = result.error ?? 'Connection failed'
   }
@@ -791,7 +791,7 @@ async function testIndelible() {
 
 async function disconnectIndelible() {
   await settingsStore.disconnectIndelible()
-  toasts.add('Disconnected from Indelible', 'info')
+  toasts.add(t('settings.toast.indelible_disconnected'), 'info')
 }
 
 onMounted(async () => {
@@ -802,37 +802,32 @@ onMounted(async () => {
 
 async function pickStorageDir() {
   try {
-    const selected = await open({ directory: true, title: 'Select Storage Directory' })
+    const selected = await open({ directory: true, title: t('settings.picker.storage_title') })
     if (!selected) return
     const path = selected as string
-    // Probe before persist — a path that's writable in Explorer can still be
-    // unwritable to the daemon process (USB read-only volume, OneDrive
-    // placeholder, restrictive ACL on a second drive). Write the failure to
-    // the store-level probe error so the global banner and this card both
-    // reflect the same state.
     const result = await settingsStore.probeStorageDir(path)
     if (!result.ok) {
       settingsStore.storageDirProbeError = result.error
-      toasts.add('Cannot use that folder for node storage', 'error')
+      toasts.add(t('settings.toast.storage_dir_unwritable'), 'error')
       return
     }
     settingsStore.storageDirProbeError = null
     await settingsStore.setStorageDir(path)
-    toasts.add('Storage directory verified', 'success')
+    toasts.add(t('settings.toast.storage_dir_verified'), 'success')
   } catch (e) {
-    toasts.add('Failed to select directory', 'error')
+    toasts.add(t('settings.toast.select_directory_failed'), 'error')
   }
 }
 
 async function pickDownloadDir() {
   try {
-    const selected = await open({ directory: true, title: 'Select Downloads Directory' })
+    const selected = await open({ directory: true, title: t('settings.picker.downloads_title') })
     if (selected) {
       await settingsStore.setDownloadDir(selected as string)
-      toasts.add('Downloads directory updated', 'info')
+      toasts.add(t('settings.toast.downloads_dir_updated'), 'info')
     }
   } catch (e) {
-    toasts.add('Failed to select directory', 'error')
+    toasts.add(t('settings.toast.select_directory_failed'), 'error')
   }
 }
 
@@ -845,12 +840,12 @@ function startEditEarnings() {
 async function saveEarnings() {
   const val = earningsInput.value.trim()
   if (val && !isValidEthAddress(val)) {
-    toasts.add('Invalid EVM address format', 'warning')
+    toasts.add(t('settings.error.invalid_eth_address'), 'warning')
     return
   }
   await settingsStore.setEarningsAddress(val || null)
   editingEarnings.value = false
-  toasts.add('Earnings address updated', 'info')
+  toasts.add(t('settings.toast.earnings_updated'), 'info')
 }
 
 function startEditDaemon() {
@@ -864,7 +859,7 @@ async function saveDaemon() {
   if (!val) return
   await settingsStore.setDaemonUrl(val)
   editingDaemon.value = false
-  toasts.add('Daemon URL updated', 'info')
+  toasts.add(t('settings.toast.daemon_url_updated'), 'info')
 }
 
 async function onConcurrencyChange(raw: string) {
@@ -890,15 +885,15 @@ async function copyDiagnostics() {
   const report = errorLogStore.buildReport()
   try {
     await navigator.clipboard.writeText(report)
-    toasts.add('Diagnostics copied to clipboard', 'info')
+    toasts.add(t('settings.toast.diagnostics_copied'), 'info')
   } catch {
-    toasts.add('Failed to copy to clipboard', 'error')
+    toasts.add(t('settings.toast.diagnostics_copy_failed'), 'error')
   }
 }
 
 function clearLog() {
   errorLogStore.clear()
-  toasts.add('Log cleared', 'info')
+  toasts.add(t('settings.toast.log_cleared'), 'info')
 }
 
 

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -125,6 +125,7 @@
         <option value="en">English</option>
         <option value="ja">日本語</option>
         <option value="nl">Nederlands</option>
+        <option value="fr">Français</option>
       </select>
     </div>
 

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -110,6 +110,23 @@
       </button>
     </div>
 
+    <!-- Language -->
+    <div class="flex items-center justify-between rounded-lg border border-autonomi-border p-4">
+      <div class="min-w-0 flex-1">
+        <h3 class="text-sm font-medium">{{ $t('settings.language.label') }}</h3>
+        <p class="text-xs text-autonomi-muted">{{ $t('settings.language.description') }}</p>
+      </div>
+      <select
+        v-model="localeChoice"
+        :aria-label="$t('settings.language.label')"
+        class="ml-3 shrink-0 rounded-md border border-autonomi-border bg-autonomi-dark px-3 py-1.5 text-xs text-autonomi-text focus:border-autonomi-blue focus:outline-none"
+      >
+        <option value="system">{{ systemDefaultLabel }}</option>
+        <option value="en">English</option>
+        <option value="ja">日本語</option>
+      </select>
+    </div>
+
     <!-- Advanced -->
     <div>
       <button
@@ -509,6 +526,7 @@ import { openUrl as tauriOpenUrl } from '@tauri-apps/plugin-opener'
 import { arbitrum, arbitrumSepolia } from 'viem/chains'
 import { setDevnetWalletKey, UPLOAD_CONCURRENCY_MIN, UPLOAD_CONCURRENCY_MAX } from '~/stores/settings'
 import { useSettingsStore } from '~/stores/settings'
+import { useLocale, SUPPORTED_LOCALES, NATIVE_LOCALE_NAMES, type SupportedLocale } from '~/composables/useLocale'
 import { isValidEthAddress } from '~/utils/validators'
 import { useToastStore } from '~/stores/toasts'
 import { useErrorLogStore } from '~/stores/errorlog'
@@ -516,6 +534,31 @@ import { useUpdaterStore } from '~/stores/updater'
 import { useFilesStore } from '~/stores/files'
 
 const settingsStore = useSettingsStore()
+const { setLocale, osLocale, t } = useLocale()
+
+/** Bound to the Language <select>. `'system'` is the sentinel for "follow
+ *  the OS locale" (persisted as null in config.toml). */
+const localeChoice = computed<'system' | SupportedLocale>({
+  get: () => {
+    const persisted = settingsStore.i18nLocale
+    return persisted && (SUPPORTED_LOCALES as readonly string[]).includes(persisted)
+      ? (persisted as SupportedLocale)
+      : 'system'
+  },
+  set: (value) => {
+    setLocale(value === 'system' ? null : value)
+  },
+})
+
+/** Label for the "Follow system" option. Shows the detected OS-locale's
+ *  native name once detection resolves (e.g. "System default: English"),
+ *  falling back to the bare label during the brief pre-detection window. */
+const systemDefaultLabel = computed(() =>
+  osLocale.value
+    ? t('settings.language.system_default', { name: NATIVE_LOCALE_NAMES[osLocale.value] })
+    : t('settings.language.system_default_pending'),
+)
+
 const walletStore = useWalletStore()
 const nodesStore = useNodesStore()
 const toasts = useToastStore()

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -124,6 +124,7 @@
         <option value="system">{{ systemDefaultLabel }}</option>
         <option value="en">English</option>
         <option value="ja">日本語</option>
+        <option value="nl">Nederlands</option>
       </select>
     </div>
 

--- a/pages/wallet.vue
+++ b/pages/wallet.vue
@@ -3,22 +3,22 @@
     <!-- Earnings Address -->
     <section class="mb-6 rounded-lg border border-autonomi-border p-5">
       <div class="mb-1 flex items-center justify-between">
-        <h2 class="font-medium">Earnings Address</h2>
+        <h2 class="font-medium">{{ $t('wallet.earnings_heading') }}</h2>
         <button
           v-if="!editingEarnings"
           class="text-xs text-autonomi-muted hover:text-autonomi-text"
           @click="startEditEarnings"
         >
-          Edit
+          {{ $t('wallet.edit') }}
         </button>
       </div>
-      <p class="mb-3 text-xs text-autonomi-muted">Where your node earnings are sent</p>
+      <p class="mb-3 text-xs text-autonomi-muted">{{ $t('wallet.earnings_description') }}</p>
 
       <div v-if="!editingEarnings">
         <span v-if="walletStore.earningsAddress" class="font-mono text-sm">
           {{ walletStore.earningsAddress }}
         </span>
-        <span v-else class="text-sm text-autonomi-warning">Not configured</span>
+        <span v-else class="text-sm text-autonomi-warning">{{ $t('wallet.earnings_not_configured') }}</span>
 
         <!-- Suggest using payment wallet address (local mode only) -->
         <div
@@ -26,13 +26,13 @@
           class="mt-3 flex items-center justify-between gap-3 rounded-md border border-autonomi-blue/20 bg-autonomi-blue/5 px-3 py-2"
         >
           <span class="text-xs text-autonomi-muted">
-            Use your connected wallet address for earnings?
+            {{ $t('wallet.earnings_use_payment_prompt') }}
           </span>
           <button
             class="shrink-0 rounded-md bg-autonomi-blue px-2.5 py-1 text-xs font-medium text-white hover:opacity-90"
             @click="usePaymentAsEarnings"
           >
-            Use {{ truncateAddress(walletStore.paymentAddress) }}
+            {{ $t('wallet.earnings_use_payment_button', { address: truncateAddress(walletStore.paymentAddress) }) }}
           </button>
         </div>
       </div>
@@ -42,7 +42,7 @@
           ref="earningsInputEl"
           v-model="earningsInput"
           type="text"
-          placeholder="0x..."
+          :placeholder="$t('wallet.earnings_placeholder')"
           class="flex-1 rounded-md border border-autonomi-border bg-autonomi-dark px-3 py-1.5 font-mono text-sm text-autonomi-text focus:border-autonomi-blue focus:outline-none"
           @keyup.enter="saveEarnings"
           @keyup.escape="editingEarnings = false"
@@ -51,13 +51,13 @@
           class="rounded-md bg-autonomi-blue px-3 py-1.5 text-sm text-white hover:opacity-90"
           @click="saveEarnings"
         >
-          Save
+          {{ $t('wallet.save') }}
         </button>
         <button
           class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted"
           @click="editingEarnings = false"
         >
-          Cancel
+          {{ $t('common.cancel') }}
         </button>
       </div>
     </section>
@@ -67,11 +67,13 @@
       <div class="flex items-center gap-3">
         <span class="flex h-10 w-10 items-center justify-center rounded-full bg-green-500/10 text-lg text-green-400">⬡</span>
         <div>
-          <h2 class="font-medium text-green-400">Managed Storage</h2>
-          <p class="text-sm text-autonomi-muted">
-            Storage managed by <span class="font-medium text-autonomi-text">{{ settingsStore.indelibleOrgName }}</span>
-          </p>
-          <p class="mt-0.5 text-xs text-autonomi-muted">Uploads are routed through your organisation's Indelible gateway. No local wallet required.</p>
+          <h2 class="font-medium text-green-400">{{ $t('wallet.managed_storage_heading') }}</h2>
+          <i18n-t keypath="wallet.managed_storage_org" tag="p" class="text-sm text-autonomi-muted">
+            <template #org>
+              <span class="font-medium text-autonomi-text">{{ settingsStore.indelibleOrgName }}</span>
+            </template>
+          </i18n-t>
+          <p class="mt-0.5 text-xs text-autonomi-muted">{{ $t('wallet.managed_storage_description') }}</p>
         </div>
       </div>
     </section>
@@ -80,43 +82,45 @@
     <section v-if="!settingsStore.indelibleConnected" class="rounded-lg border border-autonomi-border p-5">
       <div class="flex items-center justify-between">
         <div>
-          <h2 class="font-medium">Payment Wallet</h2>
-          <p v-if="!walletStore.connected" class="text-xs text-autonomi-muted">Optional — required for file uploads</p>
+          <h2 class="font-medium">{{ $t('wallet.payment_wallet_heading') }}</h2>
+          <p v-if="!walletStore.connected" class="text-xs text-autonomi-muted">{{ $t('wallet.payment_optional_hint') }}</p>
         </div>
       </div>
 
       <div class="mt-4">
         <div v-if="!walletStore.connected" class="flex flex-col items-center py-4">
-          <p class="mb-3 text-sm text-autonomi-muted">Connect a wallet to pay for file storage</p>
+          <p class="mb-3 text-sm text-autonomi-muted">{{ $t('wallet.connect_prompt') }}</p>
           <button
             class="rounded-md bg-autonomi-blue px-4 py-2 text-sm font-medium text-white hover:opacity-90"
             @click="openModal"
           >
-            Connect Wallet
+            {{ $t('header.connect_wallet') }}
           </button>
           <p class="mt-2 text-xs text-autonomi-muted">
-            {{ settingsStore.devnetChainId === arbitrumSepolia.id ? 'Arbitrum Sepolia testnet' : 'Arbitrum One network required' }}
+            {{ settingsStore.devnetChainId === arbitrumSepolia.id ? $t('wallet.network_arbitrum_sepolia') : $t('wallet.network_arbitrum_one') }}
           </p>
-          <p class="mt-1 text-xs text-autonomi-muted">
-            Or import a private key in <NuxtLink to="/settings" class="text-autonomi-blue hover:underline">Settings &gt; Advanced</NuxtLink>
-          </p>
+          <i18n-t keypath="wallet.import_key_hint" tag="p" class="mt-1 text-xs text-autonomi-muted">
+            <template #link>
+              <NuxtLink to="/settings" class="text-autonomi-blue hover:underline">{{ $t('wallet.import_key_hint_link_text') }}</NuxtLink>
+            </template>
+          </i18n-t>
         </div>
 
         <div v-else class="space-y-3">
           <div class="flex items-center justify-between text-sm">
-            <span class="text-autonomi-muted">Address</span>
+            <span class="text-autonomi-muted">{{ $t('wallet.address_label') }}</span>
             <span class="font-mono text-xs">{{ walletStore.paymentAddress }}</span>
           </div>
           <div class="flex items-center justify-between text-sm">
-            <span class="text-autonomi-muted">ETH Balance</span>
+            <span class="text-autonomi-muted">{{ $t('wallet.eth_balance_label') }}</span>
             <span class="font-mono text-xs">{{ walletStore.ethBalance ?? '...' }}</span>
           </div>
           <div class="flex items-center justify-between text-sm">
-            <span class="text-autonomi-muted">ANT Balance</span>
+            <span class="text-autonomi-muted">{{ $t('wallet.ant_balance_label') }}</span>
             <span class="font-mono text-xs text-autonomi-blue">{{ walletStore.antBalance ?? '...' }}</span>
           </div>
           <div v-if="walletStore.usdcBalance !== ''" class="flex items-center justify-between text-sm">
-            <span class="text-autonomi-muted">USDC Balance</span>
+            <span class="text-autonomi-muted">{{ $t('wallet.usdc_balance_label') }}</span>
             <span class="font-mono text-xs">{{ walletStore.usdcBalance ?? '...' }}</span>
           </div>
           <div class="flex gap-2">
@@ -124,13 +128,13 @@
               class="flex-1 rounded-md border border-autonomi-border py-1.5 text-xs text-autonomi-muted hover:text-autonomi-text"
               @click="refreshBalances"
             >
-              Refresh Balances
+              {{ $t('wallet.refresh_balances') }}
             </button>
             <button
               class="flex-1 rounded-md border border-autonomi-border py-1.5 text-xs text-autonomi-muted hover:text-autonomi-text"
               @click="disconnect"
             >
-              Disconnect
+              {{ $t('wallet.disconnect') }}
             </button>
           </div>
         </div>
@@ -141,11 +145,14 @@
 
 <script setup lang="ts">
 import { arbitrumSepolia } from 'viem/chains'
+import { useI18n } from 'vue-i18n'
 import { useWalletStore } from '~/stores/wallet'
 import { truncateAddress } from '~/utils/formatters'
 import { isValidEthAddress } from '~/utils/validators'
 import { useSettingsStore } from '~/stores/settings'
 import { useToastStore } from '~/stores/toasts'
+
+const { t } = useI18n()
 const walletStore = useWalletStore()
 const settingsStore = useSettingsStore()
 const toastStore = useToastStore()
@@ -173,7 +180,7 @@ function openModal() {
     $appkit.open()
   } else {
     navigateTo('/settings')
-    toastStore.add('Import a private key in Settings > Advanced', 'info')
+    toastStore.add(t('wallet.toast.import_key_in_settings'), 'info')
   }
 }
 
@@ -190,18 +197,18 @@ function startEditEarnings() {
 function saveEarnings() {
   const addr = earningsInput.value.trim()
   if (!isValidEthAddress(addr)) {
-    toastStore.add('Invalid address: must be 0x + 40 hex characters', 'error')
+    toastStore.add(t('wallet.toast.invalid_address'), 'error')
     return
   }
   walletStore.setEarningsAddress(addr)
   editingEarnings.value = false
-  toastStore.add('Earnings address saved', 'info')
+  toastStore.add(t('wallet.toast.earnings_saved'), 'info')
 }
 
 function usePaymentAsEarnings() {
   if (walletStore.paymentAddress) {
     walletStore.setEarningsAddress(walletStore.paymentAddress)
-    toastStore.add('Earnings address set to payment wallet', 'info')
+    toastStore.add(t('wallet.toast.earnings_set_to_payment'), 'info')
   }
 }
 
@@ -214,7 +221,7 @@ async function disconnect() {
     } catch {}
   }
   walletStore.disconnectWallet()
-  toastStore.add('Wallet disconnected', 'info')
+  toastStore.add(t('wallet.toast.wallet_disconnected'), 'info')
 }
 
 </script>

--- a/plugins/i18n.client.ts
+++ b/plugins/i18n.client.ts
@@ -1,0 +1,21 @@
+import { createI18n } from 'vue-i18n'
+import en from '~/locales/en.json'
+import ja from '~/locales/ja.json'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    fallbackLocale: 'en',
+    messages: { en, ja },
+    missingWarn: true,
+    fallbackWarn: false,
+  })
+  nuxtApp.vueApp.use(i18n)
+
+  // Dev-only handle for manual locale-swap testing from DevTools console.
+  // Remove when the Settings picker lands.
+  if (import.meta.dev && typeof window !== 'undefined') {
+    ;(window as unknown as { __i18n: typeof i18n }).__i18n = i18n
+  }
+})

--- a/plugins/i18n.client.ts
+++ b/plugins/i18n.client.ts
@@ -2,15 +2,21 @@ import { createI18n } from 'vue-i18n'
 import en from '~/locales/en.json'
 import ja from '~/locales/ja.json'
 
+/**
+ * Exported so non-component code (Pinia options-API stores, plain utility
+ * modules) can call `i18n.global.t(...)` without a setup context — `useI18n()`
+ * only works inside Vue setup, but options-API store actions don't qualify.
+ */
+export const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: { en, ja },
+  missingWarn: true,
+  fallbackWarn: false,
+})
+
 export default defineNuxtPlugin((nuxtApp) => {
-  const i18n = createI18n({
-    legacy: false,
-    locale: 'en',
-    fallbackLocale: 'en',
-    messages: { en, ja },
-    missingWarn: true,
-    fallbackWarn: false,
-  })
   nuxtApp.vueApp.use(i18n)
 
   // Dev-only handle for manual locale-swap testing from DevTools console.

--- a/plugins/i18n.client.ts
+++ b/plugins/i18n.client.ts
@@ -2,6 +2,7 @@ import { createI18n } from 'vue-i18n'
 import en from '~/locales/en.json'
 import ja from '~/locales/ja.json'
 import nl from '~/locales/nl.json'
+import fr from '~/locales/fr.json'
 
 /**
  * Exported so non-component code (Pinia options-API stores, plain utility
@@ -12,7 +13,7 @@ export const i18n = createI18n({
   legacy: false,
   locale: 'en',
   fallbackLocale: 'en',
-  messages: { en, ja, nl },
+  messages: { en, ja, nl, fr },
   missingWarn: true,
   fallbackWarn: false,
 })

--- a/plugins/i18n.client.ts
+++ b/plugins/i18n.client.ts
@@ -1,6 +1,7 @@
 import { createI18n } from 'vue-i18n'
 import en from '~/locales/en.json'
 import ja from '~/locales/ja.json'
+import nl from '~/locales/nl.json'
 
 /**
  * Exported so non-component code (Pinia options-API stores, plain utility
@@ -11,7 +12,7 @@ export const i18n = createI18n({
   legacy: false,
   locale: 'en',
   fallbackLocale: 'en',
-  messages: { en, ja },
+  messages: { en, ja, nl },
   missingWarn: true,
   fallbackWarn: false,
 })

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -863,6 +863,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-os",
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tokio",
@@ -3352,6 +3353,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4746,6 +4757,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4893,6 +4916,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4914,6 +4958,38 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -4986,8 +5062,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -5112,6 +5207,22 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.30.1",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6711,7 +6822,7 @@ dependencies = [
  "keyring",
  "libc",
  "lru-slab",
- "nix",
+ "nix 0.29.0",
  "once_cell",
  "parking_lot",
  "pin-project-lite",
@@ -7565,6 +7676,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7887,6 +8007,24 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-os"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f08346c8deb39e96f86973da0e2d76cbb933d7ac9b750f6dc4daf955a6f997"
+dependencies = [
+ "gethostname",
+ "log",
+ "os_info",
+ "serde",
+ "serde_json",
+ "serialize-to-javascript",
+ "sys-locale",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-os = "2"
 tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,8 @@
     "dialog:allow-ask",
     "opener:default",
     "opener:allow-reveal-item-in-dir",
+    "os:default",
+    "os:allow-locale",
     "process:default",
     "updater:default",
     "updater:allow-check",

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -30,6 +30,11 @@ pub struct AppConfig {
     /// init from this flag, so toggling requires an app restart to take effect.
     #[serde(default)]
     pub prerelease_channel: bool,
+    /// User-chosen UI locale (e.g. "en", "ja"). `None` means "follow system":
+    /// the frontend reads the OS locale via tauri-plugin-os and falls back to
+    /// English if it doesn't match a shipped locale.
+    #[serde(default)]
+    pub i18n_locale: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -127,6 +132,7 @@ impl Default for AppConfig {
             theme_mode: default_theme_mode(),
             upload_concurrency: default_upload_concurrency(),
             prerelease_channel: false,
+            i18n_locale: None,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -778,6 +778,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(AutonomiState::new())

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -5,6 +5,12 @@ import { useToastStore } from './toasts'
 import { useSettingsStore } from './settings'
 import { payForQuotes, payForMerkleTree, formatNanoTokens, formatGasCost, type RawPayment, type SerializedPoolCommitment } from '~/utils/payment'
 import { indelibleApi } from '~/utils/indelible-api'
+import { i18n } from '~/plugins/i18n.client'
+
+/** Module-scope translator. Options-API store actions can't call useI18n() —
+ *  they run outside Vue's setup context — so we route through the global
+ *  composer the plugin already configured. */
+const t = (key: string, params?: Record<string, unknown>) => i18n.global.t(key, params ?? {})
 
 // ── Lightweight cost estimate (no chunks parked) ──
 // Matches ant_core::data::UploadCostEstimate.
@@ -620,10 +626,10 @@ export const useFilesStore = defineStore('files', {
             stageTotal: undefined,
           })
           await this.persistHistory()
-          toasts.add(`Upload complete: ${entry.name}`, 'info')
+          toasts.add(t('files.toast.upload_complete', { name: entry.name }), 'info')
         } catch (e: any) {
           this.updateEntry(id, { status: 'failed', error: e.message ?? String(e) })
-          toasts.add(`Upload failed: ${entry.name} — ${e.message ?? e}`, 'error')
+          toasts.add(t('files.toast.upload_failed', { name: entry.name, error: e.message ?? e }), 'error')
         }
         return
       }
@@ -706,7 +712,7 @@ export const useFilesStore = defineStore('files', {
             })
           } catch (e: any) {
             this.updateEntry(id, { status: 'failed', error: `Payment failed: ${e.message}` })
-            toasts.add(`Payment failed: ${e.message}`, 'error')
+            toasts.add(t('files.toast.payment_failed', { error: e.message }), 'error')
             return
           }
         } else {
@@ -723,7 +729,7 @@ export const useFilesStore = defineStore('files', {
               this.updateEntry(id, { gas_cost: formatGasCost(payResult.gasSpent.toString()) })
             } catch (e: any) {
               this.updateEntry(id, { status: 'failed', error: `Payment failed: ${e.message}` })
-              toasts.add(`Payment failed: ${e.message}`, 'error')
+              toasts.add(t('files.toast.payment_failed', { error: e.message }), 'error')
               return
             }
           }
@@ -752,10 +758,10 @@ export const useFilesStore = defineStore('files', {
         }
 
         await this.persistHistory()
-        toasts.add(`Upload complete: ${entry.name}`, 'info')
+        toasts.add(t('files.toast.upload_complete', { name: entry.name }), 'info')
       } catch (e: any) {
         this.updateEntry(id, { status: 'failed', error: e.message ?? String(e) })
-        toasts.add(`Upload failed: ${entry.name} — ${e.message ?? e}`, 'error')
+        toasts.add(t('files.toast.upload_failed', { name: entry.name, error: e.message ?? e }), 'error')
       }
     },
 
@@ -790,10 +796,10 @@ export const useFilesStore = defineStore('files', {
         })
 
         await this.persistHistory()
-        toasts.add(`Upload complete: ${entry.name}`, 'info')
+        toasts.add(t('files.toast.upload_complete', { name: entry.name }), 'info')
       } catch (e: any) {
         this.updateEntry(id, { status: 'failed', error: e.message ?? String(e) })
-        toasts.add(`Upload failed: ${entry.name} — ${e.message ?? e}`, 'error')
+        toasts.add(t('files.toast.upload_failed', { name: entry.name, error: e.message ?? e }), 'error')
       }
     },
 
@@ -852,7 +858,7 @@ export const useFilesStore = defineStore('files', {
           this.updateEntry(id, { data_map_json: json })
         } catch (e: any) {
           this.updateEntry(id, { status: 'failed', error: `Failed to read datamap: ${e.message ?? e}` })
-          toasts.add('Cannot download: datamap file missing or unreadable', 'error')
+          toasts.add(t('files.toast.datamap_missing'), 'error')
           return
         }
       }
@@ -894,10 +900,10 @@ export const useFilesStore = defineStore('files', {
           stageDone: undefined,
           stageTotal: undefined,
         })
-        toasts.add(`Download complete: ${entry.name}`, 'info')
+        toasts.add(t('files.toast.download_complete', { name: entry.name }), 'info')
       } catch (e: any) {
         this.updateEntry(id, { status: 'failed', error: e.message ?? String(e) })
-        toasts.add(`Download failed: ${entry.name} — ${e.message ?? e}`, 'error')
+        toasts.add(t('files.toast.download_failed', { name: entry.name, error: e.message ?? e }), 'error')
       }
     },
 
@@ -938,7 +944,7 @@ export const useFilesStore = defineStore('files', {
       try {
         json = await invoke<string>('read_datamap_file', { path: datamapPath })
       } catch (e: any) {
-        toasts.add(`Could not read datamap: ${e.message ?? e}`, 'error')
+        toasts.add(t('files.toast.datamap_read_failed', { error: e.message ?? e }), 'error')
         return null
       }
 

--- a/stores/nodes.ts
+++ b/stores/nodes.ts
@@ -6,6 +6,10 @@ import { daemonApi, connectSSE, disconnectSSE, type NodeEvent } from '~/utils/da
 import type { NodeStatusSummary, ApiNodeStatus, DaemonStatus } from '~/utils/daemon-api'
 import { POLL_INTERVAL, DETAIL_POLL_INTERVAL } from '~/utils/constants'
 import type { UnlistenFn } from '@tauri-apps/api/event'
+import { i18n } from '~/plugins/i18n.client'
+
+/** Module-scope translator — see stores/files.ts for the rationale. */
+const t = (key: string, params?: Record<string, unknown>) => i18n.global.t(key, params ?? {})
 
 // Frontend node status — ant-core values + frontend-only states
 export type NodeStatus = ApiNodeStatus | 'adding'
@@ -444,11 +448,11 @@ export const useNodesStore = defineStore('nodes', {
         this.nodes = this.nodes.filter(n => !placeholderIds.includes(n.id))
         await this.fetchNodes()
         this.enrichNodeDetails() // fire-and-forget — populates data_dir/ports without waiting for the detail poll
-        toasts.add(`Added ${result.nodes_added.length} node(s)`, 'info')
+        toasts.add(t('nodes.toast.added', { count: result.nodes_added.length }), 'info')
       } catch (e: any) {
         // Remove placeholders on failure
         this.nodes = this.nodes.filter(n => !placeholderIds.includes(n.id))
-        toasts.add(`Failed to add nodes: ${e.message}`, 'error')
+        toasts.add(t('nodes.toast.add_failed', { error: e.message }), 'error')
       }
     },
 
@@ -465,11 +469,11 @@ export const useNodesStore = defineStore('nodes', {
           node.pid = result.pid
           node.uptime_secs = 0
         }
-        toasts.add(`Node ${id} started`, 'info')
+        toasts.add(t('nodes.toast.started', { id }), 'info')
       } catch (e: any) {
         const node = this.nodes.find(n => n.id === id)
         if (node) node.status = 'errored'
-        toasts.add(`Failed to start node ${id}: ${e.message}`, 'error')
+        toasts.add(t('nodes.toast.start_failed', { id, error: e.message }), 'error')
       }
     },
 
@@ -485,9 +489,9 @@ export const useNodesStore = defineStore('nodes', {
           node.pid = undefined
           node.uptime_secs = undefined
         }
-        toasts.add(`Node ${id} stopped`, 'info')
+        toasts.add(t('nodes.toast.stopped', { id }), 'info')
       } catch (e: any) {
-        toasts.add(`Failed to stop node ${id}: ${e.message}`, 'error')
+        toasts.add(t('nodes.toast.stop_failed', { id, error: e.message }), 'error')
       }
     },
 
@@ -497,9 +501,9 @@ export const useNodesStore = defineStore('nodes', {
       try {
         await daemonApi.removeNode(id)
         this.nodes = this.nodes.filter(n => n.id !== id)
-        toasts.add(`Node ${id} removed`, 'info')
+        toasts.add(t('nodes.toast.removed', { id }), 'info')
       } catch (e: any) {
-        toasts.add(`Failed to remove node ${id}: ${e.message}`, 'error')
+        toasts.add(t('nodes.toast.remove_failed', { id, error: e.message }), 'error')
       }
     },
 
@@ -507,7 +511,7 @@ export const useNodesStore = defineStore('nodes', {
       const toasts = useToastStore()
       const stoppedNodes = this.nodes.filter(n => n.status === 'stopped')
       if (stoppedNodes.length === 0) {
-        toasts.add('No stopped nodes to start', 'warning')
+        toasts.add(t('nodes.toast.no_stopped'), 'warning')
         return
       }
 
@@ -522,17 +526,17 @@ export const useNodesStore = defineStore('nodes', {
         for (const f of result.failed) {
           const node = this.nodes.find(n => n.id === f.node_id)
           if (node) node.status = 'errored'
-          toasts.add(`Node ${f.node_id} failed: ${f.error}`, 'error')
+          toasts.add(t('nodes.toast.node_failed', { id: f.node_id, error: f.error }), 'error')
         }
         for (const id of result.already_running) {
           const node = this.nodes.find(n => n.id === id)
           if (node) node.status = 'running'
         }
         if (result.started.length > 0) {
-          toasts.add(`Started ${result.started.length} node(s)`, 'info')
+          toasts.add(t('nodes.toast.started_count', { count: result.started.length }), 'info')
         }
       } catch (e: any) {
-        toasts.add(`Failed to start all: ${e.message}`, 'error')
+        toasts.add(t('nodes.toast.start_all_failed', { error: e.message }), 'error')
         await this.fetchNodes() // refresh to get real state
       }
     },
@@ -541,7 +545,7 @@ export const useNodesStore = defineStore('nodes', {
       const toasts = useToastStore()
       const runningNodes = this.nodes.filter(n => n.status === 'running')
       if (runningNodes.length === 0) {
-        toasts.add('No running nodes to stop', 'warning')
+        toasts.add(t('nodes.toast.no_running'), 'warning')
         return
       }
 
@@ -555,13 +559,13 @@ export const useNodesStore = defineStore('nodes', {
         for (const f of result.failed) {
           const node = this.nodes.find(n => n.id === f.node_id)
           if (node) node.status = 'errored'
-          toasts.add(`Node ${f.node_id} failed: ${f.error}`, 'error')
+          toasts.add(t('nodes.toast.node_failed', { id: f.node_id, error: f.error }), 'error')
         }
         if (result.stopped.length > 0) {
-          toasts.add(`Stopped ${result.stopped.length} node(s)`, 'info')
+          toasts.add(t('nodes.toast.stopped_count', { count: result.stopped.length }), 'info')
         }
       } catch (e: any) {
-        toasts.add(`Failed to stop all: ${e.message}`, 'error')
+        toasts.add(t('nodes.toast.stop_all_failed', { error: e.message }), 'error')
         await this.fetchNodes()
       }
     },

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -33,6 +33,7 @@ interface AppConfig {
   theme_mode: string
   upload_concurrency: number
   prerelease_channel: boolean
+  i18n_locale: string | null
 }
 
 /** Allowed range for upload_concurrency (see AppConfig in Rust). */
@@ -67,6 +68,8 @@ export const useSettingsStore = defineStore('settings', {
     /** Snapshot of `prereleaseChannel` at app boot — drives the "restart to
      *  apply" hint banner. Set once during loadConfig. */
     prereleaseChannelBootValue: false,
+    /** Persisted UI locale choice. `null` = follow the OS. */
+    i18nLocale: null as string | null,
     loaded: false,
     /** Set by `revalidateStorageDir()` on startup if the saved storage_dir is
      *  no longer writable (USB unplugged, OneDrive offline, ACL changed).
@@ -105,6 +108,7 @@ export const useSettingsStore = defineStore('settings', {
         this.themeMode = config.theme_mode === 'light' ? 'light' : 'dark'
         this.uploadConcurrency = clampConcurrency(config.upload_concurrency)
         this.prereleaseChannel = config.prerelease_channel ?? false
+        this.i18nLocale = config.i18n_locale ?? null
         // Capture once on first load — represents the value the Rust side
         // resolved its updater endpoint URL from. Subsequent toggles diverge
         // from this until the next app restart.
@@ -128,6 +132,7 @@ export const useSettingsStore = defineStore('settings', {
           theme_mode: this.themeMode,
           upload_concurrency: this.uploadConcurrency,
           prerelease_channel: this.prereleaseChannel,
+          i18n_locale: this.i18nLocale,
         }
         await invoke('save_config', { config })
       } catch (e) {
@@ -204,6 +209,12 @@ export const useSettingsStore = defineStore('settings', {
 
     async setThemeMode(mode: ThemeMode) {
       this.themeMode = mode
+      await this.saveConfig()
+    },
+
+    /** Persist UI-locale choice. `null` means "follow the OS locale". */
+    async setI18nLocale(locale: string | null) {
+      this.i18nLocale = locale
       await this.saveConfig()
     },
 

--- a/stores/updater.ts
+++ b/stores/updater.ts
@@ -2,6 +2,10 @@ import { defineStore } from 'pinia'
 import { invoke } from '@tauri-apps/api/core'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import { useToastStore } from './toasts'
+import { i18n } from '~/plugins/i18n.client'
+
+/** Module-scope translator — see stores/files.ts for the rationale. */
+const t = (key: string, params?: Record<string, unknown>) => i18n.global.t(key, params ?? {})
 
 export interface CheckResult {
   ok: boolean
@@ -119,10 +123,7 @@ export const useUpdaterStore = defineStore('updater', {
 
       this._restartFailedUnlisten = await listen<RestartFailedEvent>('update-restart-failed', (event) => {
         const v = event.payload.version
-        toasts.add(
-          `Update to v${v} installed but the app didn't restart. Quit and reopen Autonomi to finish updating.`,
-          'error',
-        )
+        toasts.add(t('updater.toast.install_no_restart', { version: v }), 'error')
         this.installing = false
         this._cleanupInstallListeners()
       })
@@ -139,7 +140,7 @@ export const useUpdaterStore = defineStore('updater', {
           return
         }
         console.error('Update install failed:', e)
-        toasts.add(`Update install failed: ${raw}`, 'error')
+        toasts.add(t('updater.toast.install_failed', { error: raw }), 'error')
         this.installing = false
         this._cleanupInstallListeners()
       }

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -10,16 +10,20 @@ const RESERVED_FILENAME_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|$)/i
 
 /**
  * Validate a user-typed "Save as" filename against the cross-platform reserved
- * set. Returns an error message for the UI, or null when the name is safe to
- * pass to the OS. An empty/whitespace-only string returns null so the caller
- * can decide whether emptiness is itself an error (most callers gate the
- * submit button on `name.trim().length > 0` separately).
+ * set. Returns a translation key the caller can pass to `$t(...)`, or null
+ * when the name is safe to pass to the OS. An empty/whitespace-only string
+ * returns null so the caller can decide whether emptiness is itself an error
+ * (most callers gate the submit button on `name.trim().length > 0` separately).
+ *
+ * Returns keys instead of pre-translated strings so this module stays usable
+ * outside a Vue setup context — the caller is always rendering in a
+ * component, so it owns translation.
  */
 export function filenameError(name: string): string | null {
   const trimmed = name.trim()
   if (trimmed.length === 0) return null
-  if (RESERVED_FILENAME_CHARS.test(trimmed)) return 'Filename cannot contain special characters'
-  if (/[. ]$/.test(trimmed)) return 'Filename cannot end with a dot or space'
-  if (RESERVED_FILENAME_NAMES.test(trimmed)) return `${trimmed} is a reserved name on Windows`
+  if (RESERVED_FILENAME_CHARS.test(trimmed)) return 'validators.filename.has_special_chars'
+  if (/[. ]$/.test(trimmed)) return 'validators.filename.ends_with_dot_or_space'
+  if (RESERVED_FILENAME_NAMES.test(trimmed)) return 'validators.filename.reserved_on_windows'
   return null
 }


### PR DESCRIPTION
## Summary
Adds French (`fr`) as the fourth supported locale. Machine-translated baseline of all 365 strings, marked via the `_translator_notes` flag at the top of `fr.json`. Community polish welcome.

## Wiring (same surface as Dutch)
- **`locales/fr.json`** — full translation, mirrors `en.json` structure key-for-key (365 keys + `_translator_notes`).
- **`plugins/i18n.client.ts`** — register `fr` in vue-i18n's `messages`.
- **`composables/useLocale.ts`** — add `'fr'` to `SUPPORTED_LOCALES` and `fr: 'Français'` to `NATIVE_LOCALE_NAMES`.
- **`pages/settings.vue`** — add the picker option.

## Translation policy
Per `CONTRIBUTING-i18n.md`, identifiers stay verbatim:
- Product names: Autonomi, Indelible, WalletConnect
- Token tickers: ETH, ANT, USDC
- Network identifiers: Arbitrum One / Sepolia, DEVNET, SEPOLIA
- Technical abbreviations: EVM, RPC, PID
- Placeholder examples: `0x...`, `https://files.acme.com`, `monfichier.dat`

Phase-1 StatusBadge carve-out applies as for the other locales — dynamic backend-produced progress strings stay English until the source emits structured tokens.

## Stacking
Stacked on **i18n/nl-locale** (PR #119) to avoid wiring conflicts on `plugins/i18n.client.ts`, `composables/useLocale.ts`, and `pages/settings.vue`. The dependency chain is:

```
main
 └─ feat/i18n-phase-2-sweep (#103)
      └─ i18n/ja-english-residue (#118)
      └─ i18n/nl-locale (#119)
           └─ i18n/fr-locale (this PR)
```

Base auto-flips as each ancestor merges.

## Test plan
- [ ] `npm run dev` → Settings → Language → "Français" — every screen the i18n sweep touched should switch to French.
- [ ] No `[intlify] Not found '<key>'` warnings in DevTools console after switching.
- [ ] Native speakers (if available) flag awkward translations for follow-up polish.
- [ ] Reload the app with French selected → choice persists.
- [ ] Switch back to "System default" → falls back to OS locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)