### PR TITLE
fix(settings): move "Node version" row into Software, rename "Version" → "App version"

### DIFF
--- a/locales/bg.json
+++ b/locales/bg.json
@@ -103,14 +103,14 @@
     },
     "software": {
       "title": "Софтуер",
-      "version_label": "Версия",
+      "app_version_label": "Версия на приложението",
+      "node_version_label": "Версия на нод",
       "last_checked": "Последна проверка {label}",
       "check_button": "Проверка за актуализации",
       "checking": "Проверяване…"
     },
     "about": {
-      "title": "Информация",
-      "node_version_label": "Версия на демона на нод"
+      "title": "Информация"
     },
     "relative_time": {
       "just_now": "току-що",

--- a/locales/en.json
+++ b/locales/en.json
@@ -102,14 +102,14 @@
     },
     "software": {
       "title": "Software",
-      "version_label": "Version",
+      "app_version_label": "App version",
+      "node_version_label": "Node version",
       "last_checked": "Last checked {label}",
       "check_button": "Check for Updates",
       "checking": "Checking…"
     },
     "about": {
-      "title": "About",
-      "node_version_label": "Node daemon version"
+      "title": "About"
     },
     "relative_time": {
       "just_now": "just now",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -103,14 +103,14 @@
     },
     "software": {
       "title": "Logiciel",
-      "version_label": "Version",
+      "app_version_label": "Version de l'application",
+      "node_version_label": "Version du nœud",
       "last_checked": "Dernière vérification {label}",
       "check_button": "Vérifier les mises à jour",
       "checking": "Vérification…"
     },
     "about": {
-      "title": "À propos",
-      "node_version_label": "Version du démon de nœud"
+      "title": "À propos"
     },
     "relative_time": {
       "just_now": "à l'instant",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -103,14 +103,14 @@
     },
     "software": {
       "title": "ソフトウェア",
-      "version_label": "バージョン",
+      "app_version_label": "アプリバージョン",
+      "node_version_label": "ノードバージョン",
       "last_checked": "最終確認 {label}",
       "check_button": "アップデートを確認",
       "checking": "確認中…"
     },
     "about": {
-      "title": "情報",
-      "node_version_label": "ノードデーモンバージョン"
+      "title": "情報"
     },
     "relative_time": {
       "just_now": "たった今",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -103,14 +103,14 @@
     },
     "software": {
       "title": "Software",
-      "version_label": "Versie",
+      "app_version_label": "App-versie",
+      "node_version_label": "Node-versie",
       "last_checked": "Laatst gecontroleerd {label}",
       "check_button": "Op updates controleren",
       "checking": "Controleren…"
     },
     "about": {
-      "title": "Over",
-      "node_version_label": "Node-daemon-versie"
+      "title": "Over"
     },
     "relative_time": {
       "just_now": "zojuist",

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -483,8 +483,12 @@
         <div class="min-w-0 flex-1">
           <h3 class="text-sm font-medium">{{ $t('settings.software.title') }}</h3>
           <div class="mt-1 flex items-baseline gap-2 text-xs">
-            <span class="text-autonomi-muted">{{ $t('settings.software.version_label') }}</span>
+            <span class="text-autonomi-muted">{{ $t('settings.software.app_version_label') }}</span>
             <span class="font-mono">{{ appVersion }}</span>
+          </div>
+          <div class="mt-0.5 flex items-baseline gap-2 text-xs">
+            <span class="text-autonomi-muted">{{ $t('settings.software.node_version_label') }}</span>
+            <span class="font-mono">{{ nodeVersion }}</span>
           </div>
           <p v-if="lastCheckedLabel" class="mt-0.5 text-xs text-autonomi-muted">
             {{ $t('settings.software.last_checked', { label: lastCheckedLabel }) }}
@@ -503,12 +507,6 @@
     <!-- About -->
     <div class="rounded-lg border border-autonomi-border p-4">
       <h3 class="text-sm font-medium">{{ $t('settings.about.title') }}</h3>
-      <div class="mt-3 space-y-1.5 text-xs">
-        <div class="flex justify-between">
-          <span class="text-autonomi-muted">{{ $t('settings.about.node_version_label') }}</span>
-          <span class="font-mono">{{ nodeVersion }}</span>
-        </div>
-      </div>
       <div class="mt-3 flex gap-3">
         <button class="text-xs text-autonomi-blue hover:underline" @click="tauriOpenUrl('https://autonomi.com')">
           autonomi.com


### PR DESCRIPTION
## Summary
Three related Settings-page changes that were getting confusing:

1. **Move** the version-of-something row out of About → into Software. The user is already looking at versions in Software (next to "Check for Updates") — that's where another version row belongs.
2. **Rename** Software's existing "Version" row to "App version". Once a node version sits next to it, the bare "Version" is ambiguous.
3. **Drop "daemon" from "Node daemon version"** — the field has always shown `nodesStore.nodes[0].version` (the first running node's binary version), not the daemon's version. The daemon doesn't actually expose its own version on `/api/v1/status` — `DaemonStatus` has no `version` field. Honest fix: relabel to match what the binding shows. Surfacing the daemon's actual version requires upstream work in ant-client (separate ticket).

## Before / after

**Before** — Software card: "Version: 0.7.1". About card: "Node daemon version: 0.1.4" (wrong label, value is the node binary).

**After** — Software card: "App version: 0.7.1" + "Node version: 0.1.4". About card: just the autonomi.com / GitHub links.

## Locale keys touched (all 5 locales: en, ja, nl, fr, bg)
- `settings.software.version_label` → `settings.software.app_version_label` (value: `"Version"` → `"App version"`)
- `settings.about.node_version_label` → `settings.software.node_version_label` (value: `"Node daemon version"` → `"Node version"`)

Parity confirmed: 365 keys in every locale, no missing/extra.

## Closes
GitHub #93 (reported the same mislabel 2026-05-06).

## Test plan
- [ ] `npm run dev` → Settings → confirm Software card has both rows, About card has just the links.
- [ ] Switch each of 5 locales — both labels render correctly.
- [ ] No `[intlify] Not found` warnings in DevTools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)