### PR TITLE
chore(release): bump version to 0.8.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.7.1",
+  "version": "0.8.0-rc.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.7.1"
+version = "0.8.0-rc.1"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.7.1"
+version = "0.8.0-rc.1"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.7.1",
+  "version": "0.8.0-rc.1",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump for the v0.8.0 RC. Standalone PR (no feature changes bundled).

The CI skip from #111 catches this commit message prefix, so this PR's own ci.yml run is skipped. release.yml fires on the tag push after merge.

See commit message for full changelog vs 0.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)