### PR TITLE
chore(ci): also skip ci.yml when bump PR title matches version-bump prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     # safely — on push events `pull_request.title` is null and vice versa.
     if: >-
       !startsWith(github.event.head_commit.message, 'chore(release): bump version to ')
+      && !startsWith(github.event.pull_request.title, 'chore(release): bump version to ')
       && !startsWith(github.event.head_commit.message, 'docs:')
       && !startsWith(github.event.head_commit.message, 'docs(')
       && !startsWith(github.event.pull_request.title, 'docs:')
@@ -46,6 +47,7 @@ jobs:
     name: rust (${{ matrix.check }})
     if: >-
       !startsWith(github.event.head_commit.message, 'chore(release): bump version to ')
+      && !startsWith(github.event.pull_request.title, 'chore(release): bump version to ')
       && !startsWith(github.event.head_commit.message, 'docs:')
       && !startsWith(github.event.head_commit.message, 'docs(')
       && !startsWith(github.event.pull_request.title, 'docs:')


### PR DESCRIPTION
## Summary
The version-bump skip from #111 only checks \`github.event.head_commit.message\` — that's null on \`pull_request\` events, so the bump PR's own ci run still triggers the full suite. The docs guard from #117 already checks both \`head_commit\` and \`pull_request.title\`; this brings the version-bump guard up to the same shape.

Adds one new alternation per job:

\`\`\`yaml
&& !startsWith(github.event.pull_request.title, 'chore(release): bump version to ')
\`\`\`

## Evidence
Run [26033686223](https://github.com/WithAutonomi/ant-ui/actions/runs/26033686223) fired on the v0.8.0-rc.1 bump PR (#128) on \`pull_request\` open, even though the push-event run for the same head_sha was correctly skipped.

## Test plan
- [ ] This PR's own ci run fires (title is \`chore(ci):\`, not \`chore(release):\` — guard doesn't over-skip).
- [ ] Next release bump PR — ci.yml jobs show as \`Skipped\` on the PR's Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)