### PR TITLE
ci(release): bump actions/upload-artifact + download-artifact to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,7 +304,7 @@ jobs:
           ls -l "$stage"
 
       - name: upload release assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-assets-${{ matrix.slug }}
           path: release-assets/
@@ -510,7 +510,7 @@ jobs:
           ls -l "$stage"
 
       - name: upload release assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-assets-windows
           path: release-assets/
@@ -519,7 +519,7 @@ jobs:
 
       - name: upload signing logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: signing-logs
           path: ${{ github.workspace }}\smctl-signing.log
@@ -531,7 +531,7 @@ jobs:
     needs: [release-meta, build-linux-macos, build-windows]
     steps:
       - name: download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           # Download every artifact uploaded by the build jobs
           # (release-assets-linux, release-assets-macos-aarch64,


### PR DESCRIPTION
## Summary

- Bump `actions/upload-artifact@v4` (3 uses) and `actions/download-artifact@v4` (1 use) to `@v5` in the release workflow.
- Removes the Node 20 deprecation annotation that fires on every release build (most recently observed on the v0.8.0-rc.1 build).
- Beats the **2026-09-16** runner-side Node 20 removal deadline by a comfortable margin.

## Changelog review

The only meaningful v4 → v5 behaviour change is tighter handling of uploads originating outside `$GITHUB_WORKSPACE`. Every upload step in this workflow stages artifacts to `$GITHUB_WORKSPACE/release-assets/` before calling the action, so we're unaffected.

Note: the `digicert/ssm-code-signing@v1.2.1` action itself still runs on Node 20 (`using: "node20"` in its `action.yml`). That's the maintainer's to address; we can't fix it from here, but it will keep generating one annotation on Windows builds until they cut a Node 24 release.

Closes #107

## Test plan
- [ ] Watch the next release build (RC or merge-driven) — Node 20 annotation for `upload-artifact`/`download-artifact` should be gone.
- [ ] Confirm all four artifacts (`release-assets-linux`, `release-assets-macos-aarch64`, `release-assets-macos-x86_64`, `release-assets-windows`) upload + the publish job downloads + merges them.
- [ ] Confirm `latest.json` composes correctly (integrity check step still passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)