### PR TITLE
ci(release): silence Windows build warnings (digicert inputs + pin runner)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,7 +313,11 @@ jobs:
 
   build-windows:
     name: build windows MSI (signed)
-    runs-on: windows-latest
+    # Pinned to windows-2022 (VS2022) so the auto-migration of `windows-latest`
+    # to a VS2026-based image (announced for 2026-06-15) can't break a release
+    # mid-flight. Revisit windows-2025 in a separate PR with a clean test run
+    # before the eventual VS2022 EOL.
+    runs-on: windows-2022
     needs: [release-meta, resolve-ant-version]
     env:
       SM_HOST: ${{ secrets.SM_HOST }}
@@ -368,7 +372,6 @@ jobs:
           echo "Bootstrap peers refreshed from $ANT_TAG"
 
       - name: create client certificate file
-        id: prepare_cert
         shell: pwsh
         run: |
           $raw = @'
@@ -393,15 +396,15 @@ jobs:
           [System.IO.File]::WriteAllBytes($certPath, $certBytes)
 
           "SM_CLIENT_CERT_FILE=$certPath" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "sm_client_cert_b64=$clean" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: setup DigiCert SSM tools
+        # The action accepts only `force-download-tools` as input — all
+        # credentials are read from env vars: SM_HOST / SM_API_KEY /
+        # SM_CLIENT_CERT_PASSWORD are set at job scope above, and
+        # SM_CLIENT_CERT_FILE is exported by the create-client-certificate
+        # step. Passing the same values via `with:` used to emit a noisy
+        # "Unexpected input(s)" warning on every release build.
         uses: digicert/ssm-code-signing@v1.2.1
-        with:
-          sm_host: ${{ secrets.SM_HOST }}
-          sm_api_key: ${{ secrets.SM_API_KEY }}
-          sm_client_cert_b64: ${{ steps.prepare_cert.outputs.sm_client_cert_b64 }}
-          sm_client_cert_password: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
 
       - name: verify smctl installation
         shell: pwsh


### PR DESCRIPTION
## Summary

Two unrelated annotations fire on every release build's Windows job. This PR addresses both.

### 1. Drop unsupported `digicert/ssm-code-signing` inputs

Warning observed on v0.8.0-rc.1 build:

> Unexpected input(s) 'sm_host', 'sm_api_key', 'sm_client_cert_b64', 'sm_client_cert_password', valid inputs are ['force-download-tools']

Confirmed against the action's [action.yml](https://github.com/digicert/ssm-code-signing/blob/main/action.yml): the only valid input is `force-download-tools`. The action reads everything else from env vars (`SM_HOST`, `SM_API_KEY`, `SM_CLIENT_CERT_FILE`, `SM_CLIENT_CERT_PASSWORD`), all of which we already set — three at job scope, `SM_CLIENT_CERT_FILE` via the preceding `create client certificate file` step. The `with:` block was a no-op.

Also dropped the now-dead `id: prepare_cert` and `sm_client_cert_b64` step output that only existed to feed the `with:` block.

### 2. Pin Windows runner to `windows-2022`

Notice observed on v0.8.0-rc.1 build:

> NOTICE: windows-latest requests are being redirected to windows-2025-vs2026 by June 15, 2026

Pin to `windows-2022` so the auto-migration to a VS2026-based image can't surprise a release mid-flight. VS2026 may affect smctl signing, Tauri MSI bundling, or any of the bash-shell glue we run on the Windows job — none of which we want to debug under tag-push pressure. A separate PR can validate `windows-2025` on its own merits ahead of the eventual VS2022 EOL.

## What's *not* fixed by this PR

`digicert/ssm-code-signing@v1.2.1`'s `action.yml` declares `using: "node20"`, so the Node 20 deprecation annotation will continue to fire on the Windows job until the maintainer cuts a Node 24 release. That's upstream, not actionable here.

## Test plan
- [ ] Watch the next release build — "Unexpected input(s)" warning should be gone from the `setup DigiCert SSM tools` step.
- [ ] Confirm `smctl healthcheck` still passes (i.e. the env-var-only flow works as expected).
- [ ] Confirm MSI Authenticode signature verifies (`verify MSI signature` step still passes).
- [ ] Confirm the Windows runner is reported as `Windows Server 2022` in the job log header.
- [ ] `windows-latest` redirect NOTICE should no longer appear on the Windows job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)