### PR TITLE
i18n(nl): "Download op adres" → "Download via adres"

### DIFF
--- a/locales/nl.json
+++ b/locales/nl.json
@@ -248,7 +248,7 @@
   "files": {
     "upload_button": "Bestand(en) uploaden",
     "estimate_button": "Kosten schatten",
-    "download_by_address": "Download op adres",
+    "download_by_address": "Download via adres",
     "download_by_datamap": "Download via DataMap",
     "uploads_heading": "Uploads",
     "downloads_heading": "Downloads",
@@ -257,7 +257,7 @@
     "uploads_empty_title": "Nog geen uploads",
     "uploads_empty_hint": "Sleep bestanden hierheen, of gebruik de knoppen hierboven",
     "downloads_empty_title": "Nog geen downloads",
-    "downloads_empty_hint": "Gebruik \"Download op adres\" of \"Download via DataMap\"",
+    "downloads_empty_hint": "Gebruik \"Download via adres\" of \"Download via DataMap\"",
     "table": {
       "name": "Naam",
       "status": "Status",


### PR DESCRIPTION
## Summary

Native-speaker nit from a Dutch tester on v0.8.0-rc.1: "Download op adres" is awkward Dutch; "Download via adres" reads naturally.

Bonus: this makes the two download buttons grammatically parallel — **"Download via adres"** + **"Download via DataMap"** — which also makes it clearer they're two routes to the same action.

Two strings updated in `locales/nl.json`:

- `files.download_by_address` (the button label)
- `files.downloads_empty_hint` (the empty-state hint that quotes the button label verbatim)

No other locales touched.

## Test plan
- [ ] Switch app language to Dutch
- [ ] Files tab — confirm the second download button reads "Download via adres"
- [ ] Files tab with no downloads — confirm the empty-state hint reads `Gebruik "Download via adres" of "Download via DataMap"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)