### PR TITLE
i18n: polish FR/JP header + JP upload-confirm strings

### DIFF
--- a/locales/fr.json
+++ b/locales/fr.json
@@ -160,9 +160,9 @@
   "header": {
     "title": "Autonomi",
     "active_transfers": "{count} actif(s)",
-    "connecting": "Connexion au réseau",
+    "connecting": "Connexion",
     "connecting_tooltip": "Connexion au réseau Autonomi",
-    "connected": "Connecté au réseau",
+    "connected": "Connecté",
     "connected_tooltip": "Connecté au réseau Autonomi",
     "offline": "Hors ligne · Réessayer",
     "offline_tooltip": "Échec de la connexion — cliquez pour réessayer",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -162,7 +162,7 @@
     "active_transfers": "{count} actif(s)",
     "connecting": "Connexion au réseau",
     "connecting_tooltip": "Connexion au réseau Autonomi",
-    "connected": "Réseau",
+    "connected": "Connecté au réseau",
     "connected_tooltip": "Connecté au réseau Autonomi",
     "offline": "Hors ligne · Réessayer",
     "offline_tooltip": "Échec de la connexion — cliquez pour réessayer",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -160,7 +160,7 @@
   "header": {
     "title": "Autonomi",
     "active_transfers": "{count} actif(s)",
-    "connecting": "Connexion",
+    "connecting": "Connexion au réseau",
     "connecting_tooltip": "Connexion au réseau Autonomi",
     "connected": "Réseau",
     "connected_tooltip": "Connecté au réseau Autonomi",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -159,7 +159,7 @@
   },
   "header": {
     "title": "Autonomi",
-    "active_transfers": "{count} 件処理中",
+    "active_transfers": "{count} 処理中",
     "connecting": "接続中",
     "connecting_tooltip": "Autonomi ネットワークに接続中",
     "connected": "ネットワーク",
@@ -350,7 +350,7 @@
     },
     "upload_confirm": {
       "title": "アップロードを確認",
-      "info_banner": "このウィンドウは閉じても見積もりが届いたら戻ってこれます。承認またはキャンセルするまでアップロードは保留されます。",
+      "info_banner": "このウィンドウは閉じても見積もりが届いたら戻ってこられます。承認またはキャンセルするまでアップロードは保留されます。",
       "already_stored_badge": "保存済み",
       "payment_label": "支払い",
       "payment_mixed": "混在",


### PR DESCRIPTION
Small targeted polish on the FR and JP locales, reviewed against how the strings actually render (`components/AppHeader.vue`, upload-confirm dialog), not just the JSON. Both files remain machine-translated baselines so `_translator_notes` is left as-is.

The header connecting/connected/offline strings render as **compact icon + label status pills** (spinner / green dot / red dot) in a fixed 48px header. EN is deliberately short and asymmetric — `Connecting` (verb) then `Network` (noun) — and nl/bg/ja follow that. Kept the FR labels short for the same reason.

### French
- `header.connected`: `Réseau` → `Connecté`. The bare "Réseau" noun didn't convey connection state sitting next to its green status dot. `Connecté` is the compact stateful parallel to `Connexion` and doesn't widen the fixed pill. (`header.connecting` left as the original `Connexion` — already correct and matches the one-word pattern.)

### Japanese
- `files.upload_confirm.info_banner`: fixed ら-抜き言葉 — `戻ってこれます` → `戻ってこられます`. Body text in the upload-confirm dialog, so the colloquial contraction stood out; standard potential form is correct here.
- `header.active_transfers`: `{count} 件処理中` → `{count} 処理中` — drops the `件` counter so it matches `nodes.running_count` (`{count} 実行中`) and the other counters. Consistency only.

Net: 3 string changes. No key paths or placeholders changed, JSON validated, structural check vs `en.json` still clean (0 missing / 0 extra / 0 placeholder mismatches).