### PR TITLE
chore(deps): bump ant-core to v0.2.5

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -804,12 +804,13 @@ dependencies = [
 
 [[package]]
 name = "ant-core"
-version = "0.2.3"
-source = "git+https://github.com/WithAutonomi/ant-client?tag=ant-core-v0.2.3#6cada1d6b318a93e52ea6c34aa4b68fc2782c946"
+version = "0.2.5"
+source = "git+https://github.com/WithAutonomi/ant-client?tag=ant-core-v0.2.5#76763d686f6e2c27f3a4535146bbab8913190132"
 dependencies = [
  "ant-protocol",
  "async-stream",
  "axum",
+ "blake3",
  "bytes",
  "flate2",
  "fs2",
@@ -883,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.0.3"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaf05019466da9ff9055dbbc1428db3414440a8f0a1ac929febcf4fb0608a6d"
+checksum = "a4d0ba3f671c08a1d52291b601ec35a7353f4f4e10f221b5f0ee372d154636dd"
 dependencies = [
  "blake3",
  "bytes",
@@ -2527,7 +2528,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2833,7 +2834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3894,7 +3895,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4799,7 +4800,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4863,7 +4864,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5957,7 +5958,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5970,7 +5971,7 @@ dependencies = [
  "libc",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6520,7 +6521,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6588,7 +6589,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6609,7 +6610,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6685,9 +6686,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.24.2"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e194874b524ad2a50d0976eb4ebcb81aea326dfb475373de9a2942a90cb2cc"
+checksum = "0c1267928da1bcc91748c314f95f7952bc01c0359a4ac70a0b111b0386898934"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6800,9 +6801,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ebc09fb51e2c325e61ff09892f1256c60ef4f3beb881fd2980befe3e53e9bc"
+checksum = "852400712537856ab6fec5293be4290daf0130df0dbcb249a6e8280f9257665f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7033,9 +7034,9 @@ dependencies = [
 
 [[package]]
 name = "self_encryption"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11020d59e8e663ba591026c2b45a08caa74a3a654ac12b2532d5a7c5b97e510"
+checksum = "47ab904569f88dcbde4f0feadb693c184577dc81e8243f96bb725e72a779c637"
 dependencies = [
  "bincode",
  "blake3",
@@ -8180,7 +8181,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9270,7 +9271,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9372,19 +9373,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ toml = "0.8"
 tauri-plugin-updater = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-ant-core = { git = "https://github.com/WithAutonomi/ant-client", tag = "ant-core-v0.2.3" }
+ant-core = { git = "https://github.com/WithAutonomi/ant-client", tag = "ant-core-v0.2.5" }
 evmlib = "0.8"
 hex = "0.4"
 sha2 = "0.10"


### PR DESCRIPTION
## Summary
Bumps the embedded ant-core data client from `ant-core-v0.2.3` to `ant-core-v0.2.5`.

### Headline fixes
- **Merkle batch PUT timeout alignment** — `DEFAULT_STORE_TIMEOUT_SECS` 10s → 270s so the client matches the storer-side `CLOSENESS_LOOKUP_TIMEOUT` (240s, post ant-node PR #89) plus a 30s padding. Cross-region close-K membership (sgp1/syd1 storers serving lon1 clients) was firing the old 10s timeout on virtually every merkle PUT, causing re-targeting and double-stores.
- **Spill-dir leak on non-graceful exits** — `cleanup_stale` now reaps on lockfile-release rather than the 24h age guard. Prevents disk-fill from `~/.local/share/ant/spill/` under SIGKILL / OOM / panic-abort + systemd restart loops. The 24h policy was masking a real leak.

### Transitive bumps
- ant-protocol 2.0.3 → 2.1.1
- saorsa-core 0.24.2 → 0.24.4
- saorsa-transport 0.34.1 → 0.34.2
- self_encryption 0.35.0 → 0.36.0

### Verification
- `cargo check` clean — no API breakage on the GUI side.
- Headline behaviour is upstream/transparent; nothing in this repo had to adapt.

## Test plan
- [ ] CI green (fmt / clippy / build)
- [ ] Smoke a merkle upload (≥64 chunks) in `npm run tauri:dev` — confirm no 10s timeout abandonment
- [ ] Kill the app mid-upload and confirm the next launch reaps the orphan `spill_*` dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)