### PR TITLE
chore(release): bump version to 0.9.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.8.0-rc.1",
+  "version": "0.9.0-rc.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.8.0-rc.1"
+version = "0.9.0-rc.1"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.8.0-rc.1"
+version = "0.9.0-rc.1"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.8.0-rc.1",
+  "version": "0.9.0-rc.1",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
Mechanical version bump 0.8.0-rc.1 → 0.9.0-rc.1 across the four files (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`).

## What's in 0.9.0
- **ant-core 0.2.3 → 0.2.5** (#136) — merkle batch PUT timeout alignment + spill-dir leak fix
- **Spanish (es) locale** (#135) — full 365-key machine-translated baseline
- 0.8.0-rc.1 carries forward (Phase 1 i18n with en/ja/nl/fr/bg, Settings version-row reshuffle from GH #93, dev-env hygiene). The 0.8.0 line is being rolled into 0.9.0 without an intermediate stable promote — the ant-core behavioural changes (timeout, cleanup) warrant the minor bump.

## Test plan
- [ ] PR CI green (fmt / clippy / build / typecheck)
- [ ] After merge: `git tag v0.9.0-rc.1 && git push origin v0.9.0-rc.1` triggers `release.yml`
- [ ] Confirm pre-release build appears on github.com/WithAutonomi/ant-ui/releases (~22min)
- [ ] Edit auto-generated release notes, then `gh workflow run refresh-release-notes.yml -f tag=v0.9.0-rc.1` to populate the in-app updater dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)