### PR TITLE
chore(release): bump version to 0.8.0-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.9.0-rc.1",
+  "version": "0.8.0-rc.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.9.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.9.0-rc.1"
+version = "0.8.0-rc.2"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.9.0-rc.1",
+  "version": "0.8.0-rc.2",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
Corrects the version after #137 mistakenly bumped to `0.9.0-rc.1`. Since `0.8.0` was never promoted to stable, this RC continues the 0.8.0 cycle as `0.8.0-rc.2`.

Same four files: `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`.

The previous `v0.9.0-rc.1` tag has been deleted (locally + remote) and its release build cancelled before any platform installers were published.

## What's in 0.8.0-rc.2
- ant-core 0.2.3 → 0.2.5 (#136) — merkle PUT timeout alignment + spill-dir leak fix
- Spanish (es) locale (#135) — full 365-key machine-translated baseline
- Everything from 0.8.0-rc.1 (Phase 1 i18n, Settings reshuffle, dev-env hygiene)
- ja/nl/fr polish (#132, #133), CI hygiene (#129–#131), Linux build docs (#134)

## Test plan
- [ ] After merge: `git tag v0.8.0-rc.2 && git push origin v0.8.0-rc.2` triggers `release.yml`
- [ ] Confirm pre-release on github.com/WithAutonomi/ant-ui/releases (~22min)
- [ ] Edit release notes, then `gh workflow run refresh-release-notes.yml -f tag=v0.8.0-rc.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)