### PR TITLE
feat(i18n): add CJK font install banner for Linux

### DIFF
--- a/components/CjkFontBanner.vue
+++ b/components/CjkFontBanner.vue
@@ -1,0 +1,77 @@
+<template>
+  <div
+    v-if="shouldShow"
+    class="border-b border-autonomi-blue/40 bg-autonomi-blue/10 px-6 py-3 text-xs text-autonomi-text"
+    role="status"
+  >
+    <div class="flex items-start justify-between gap-4">
+      <div class="min-w-0 flex-1">
+        <p class="font-medium">
+          <span class="mr-1">{{ scriptLabel }} /</span>
+          <span>{{ $t('banners.cjk_font_missing.message') }}</span>
+        </p>
+        <div class="mt-2 space-y-1">
+          <div
+            v-for="row in distroRows"
+            :key="row.id"
+            class="flex items-center gap-3"
+          >
+            <span class="w-28 shrink-0 text-autonomi-muted">{{ row.label }}</span>
+            <code class="min-w-0 flex-1 truncate font-mono text-[11px] text-autonomi-text">{{ row.cmd }}</code>
+            <button
+              type="button"
+              class="rounded p-0.5 text-autonomi-muted/60 hover:bg-autonomi-surface hover:text-autonomi-blue"
+              :title="$t('banners.cjk_font_missing.copy')"
+              :aria-label="$t('banners.cjk_font_missing.copy')"
+              @click="copyCommand(row.cmd)"
+            >
+              <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
+                <path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      <button
+        type="button"
+        class="shrink-0 rounded px-1.5 py-0.5 text-autonomi-muted hover:bg-autonomi-surface hover:text-autonomi-text"
+        :title="$t('banners.cjk_font_missing.dismiss')"
+        :aria-label="$t('banners.cjk_font_missing.dismiss')"
+        @click="dismiss"
+      >
+        ✕
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useCjkFontBanner } from '~/composables/useCjkFontBanner'
+import { useToastStore } from '~/stores/toasts'
+
+const { t } = useI18n()
+const { shouldShow, dismiss } = useCjkFontBanner()
+const toastStore = useToastStore()
+
+const scriptLabel = computed(() => t('banners.cjk_font_missing.script_label'))
+
+interface DistroRow {
+  id: string
+  label: string
+  cmd: string
+}
+
+const distroRows = computed<DistroRow[]>(() => [
+  { id: 'arch', label: t('banners.cjk_font_missing.distro_arch'), cmd: 'sudo pacman -S noto-fonts-cjk' },
+  { id: 'debian', label: t('banners.cjk_font_missing.distro_debian'), cmd: 'sudo apt install fonts-noto-cjk' },
+  { id: 'fedora', label: t('banners.cjk_font_missing.distro_fedora'), cmd: 'sudo dnf install google-noto-sans-cjk-fonts' },
+])
+
+function copyCommand(cmd: string) {
+  navigator.clipboard.writeText(cmd)
+  toastStore.add(t('banners.cjk_font_missing.copied'), 'info')
+}
+</script>

--- a/composables/useCjkFontBanner.ts
+++ b/composables/useCjkFontBanner.ts
@@ -1,0 +1,57 @@
+import { ref, computed, type ComputedRef } from 'vue'
+import { platform } from '@tauri-apps/plugin-os'
+import { useI18n } from 'vue-i18n'
+
+// Locales whose script is not in the base Linux font fallback chain and
+// therefore renders as tofu/mojibake without a CJK font (noto-cjk).
+// Add 'zh', 'ko' when those locales ship — same package on every distro.
+const CJK_LOCALES = new Set<string>(['ja'])
+
+// Module-scoped: probe once at first call, share the result across all
+// component instances that mount the banner.
+const isLinux = ref(false)
+let platformProbed = false
+
+async function probePlatformOnce(): Promise<void> {
+  if (platformProbed) return
+  platformProbed = true
+  try {
+    isLinux.value = (await platform()) === 'linux'
+  } catch {
+    isLinux.value = false
+  }
+}
+
+// Bumped by dismiss() to invalidate the shouldShow computed, since
+// localStorage reads aren't reactive on their own.
+const dismissedVersion = ref(0)
+
+function dismissedKeyFor(loc: string): string {
+  return `cjk-font-banner-dismissed-${loc}`
+}
+
+function isDismissed(loc: string): boolean {
+  if (typeof localStorage === 'undefined') return false
+  return localStorage.getItem(dismissedKeyFor(loc)) === '1'
+}
+
+export function useCjkFontBanner() {
+  const { locale } = useI18n()
+  probePlatformOnce()
+
+  const shouldShow: ComputedRef<boolean> = computed(() => {
+    // Touch the version ref so the computed re-runs after dismiss().
+    void dismissedVersion.value
+    if (!isLinux.value) return false
+    if (!CJK_LOCALES.has(locale.value)) return false
+    return !isDismissed(locale.value)
+  })
+
+  function dismiss(): void {
+    if (typeof localStorage === 'undefined') return
+    localStorage.setItem(dismissedKeyFor(locale.value), '1')
+    dismissedVersion.value++
+  }
+
+  return { shouldShow, dismiss }
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,6 +3,7 @@
     <AppSidebar />
     <div class="flex flex-1 flex-col overflow-hidden">
       <AppHeader />
+      <CjkFontBanner />
       <div
         v-if="settingsStore.storageDirProbeError"
         class="border-b border-autonomi-error/40 bg-autonomi-error/10 px-6 py-2 text-xs text-autonomi-error"

--- a/locales/bg.json
+++ b/locales/bg.json
@@ -466,5 +466,17 @@
       "done": "Готово",
       "downloaded": "Изтеглено — щракнете за отваряне"
     }
+  },
+  "banners": {
+    "cjk_font_missing": {
+      "script_label": "日本語",
+      "message": "Japanese text may not render correctly on this system. To fix, install the Noto CJK fonts and restart the app:",
+      "distro_arch": "Arch",
+      "distro_debian": "Debian / Ubuntu",
+      "distro_fedora": "Fedora",
+      "copy": "Copy command",
+      "copied": "Command copied to clipboard",
+      "dismiss": "Dismiss"
+    }
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -465,5 +465,17 @@
       "done": "Done",
       "downloaded": "Downloaded — click to open"
     }
+  },
+  "banners": {
+    "cjk_font_missing": {
+      "script_label": "日本語",
+      "message": "Japanese text may not render correctly on this system. To fix, install the Noto CJK fonts and restart the app:",
+      "distro_arch": "Arch",
+      "distro_debian": "Debian / Ubuntu",
+      "distro_fedora": "Fedora",
+      "copy": "Copy command",
+      "copied": "Command copied to clipboard",
+      "dismiss": "Dismiss"
+    }
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -466,5 +466,17 @@
       "done": "Hecho",
       "downloaded": "Descargado — haz clic para abrir"
     }
+  },
+  "banners": {
+    "cjk_font_missing": {
+      "script_label": "日本語",
+      "message": "Japanese text may not render correctly on this system. To fix, install the Noto CJK fonts and restart the app:",
+      "distro_arch": "Arch",
+      "distro_debian": "Debian / Ubuntu",
+      "distro_fedora": "Fedora",
+      "copy": "Copy command",
+      "copied": "Command copied to clipboard",
+      "dismiss": "Dismiss"
+    }
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -466,5 +466,17 @@
       "done": "Terminé",
       "downloaded": "Téléchargé — cliquez pour ouvrir"
     }
+  },
+  "banners": {
+    "cjk_font_missing": {
+      "script_label": "日本語",
+      "message": "Japanese text may not render correctly on this system. To fix, install the Noto CJK fonts and restart the app:",
+      "distro_arch": "Arch",
+      "distro_debian": "Debian / Ubuntu",
+      "distro_fedora": "Fedora",
+      "copy": "Copy command",
+      "copied": "Command copied to clipboard",
+      "dismiss": "Dismiss"
+    }
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -466,5 +466,17 @@
       "done": "完了",
       "downloaded": "ダウンロード完了 — クリックして開く"
     }
+  },
+  "banners": {
+    "cjk_font_missing": {
+      "script_label": "日本語",
+      "message": "Japanese text may not render correctly on this system. To fix, install the Noto CJK fonts and restart the app:",
+      "distro_arch": "Arch",
+      "distro_debian": "Debian / Ubuntu",
+      "distro_fedora": "Fedora",
+      "copy": "Copy command",
+      "copied": "Command copied to clipboard",
+      "dismiss": "Dismiss"
+    }
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -466,5 +466,17 @@
       "done": "Klaar",
       "downloaded": "Gedownload — klik om te openen"
     }
+  },
+  "banners": {
+    "cjk_font_missing": {
+      "script_label": "日本語",
+      "message": "Japanese text may not render correctly on this system. To fix, install the Noto CJK fonts and restart the app:",
+      "distro_arch": "Arch",
+      "distro_debian": "Debian / Ubuntu",
+      "distro_fedora": "Fedora",
+      "copy": "Copy command",
+      "copied": "Command copied to clipboard",
+      "dismiss": "Dismiss"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds a persistent, dismissible banner shown when running on Linux with a CJK locale active (today: `ja`)
- Tells the user the Noto CJK font is missing and provides per-distro install commands (Arch / Debian / Fedora) with per-row Copy buttons
- Locale-keyed dismissal via `localStorage` — one click, gone forever for that locale
- Designed for trivial `zh` / `ko` extension: add to `CJK_LOCALES` set + add a `script_label` translation key per locale, no component changes

## Why now

The base Linux font stack doesn't include CJK glyphs, and we deliberately don't bundle the ~80 MB Noto CJK font in the AppImage / `.deb`. Users who switch the app to Japanese (or auto-detect from OS locale) on a clean Linux install currently see tofu boxes with no in-app guidance. This was promised in the i18n phase 1 plan but didn't make the cut.

## Design notes

- **No canvas glyph probe.** We deliberately don't try to detect whether the font is actually missing. Canvas-width font detection is brittle, and a false positive (banner shown to a user who already has `noto-cjk`) costs them one dismiss click — much cheaper than the probe missing a real font gap.
- **Persistent banner, not a toast.** User needs time to read the commands, identify their distro, and act. Banner sits in the layout banner stack alongside the storage-dir warning, styled blue (info, not error).
- **English-only message body** with a bilingual `日本語 /` prefix. If the font is present, the prefix renders correctly and confirms the message is about Japanese. If the font is absent, the prefix tofus and the English half still carries the meaning.
- **Linux-only.** Windows and macOS ship CJK fonts by default.
- **Bulgarian / future Cyrillic locales — no banner.** Cyrillic is part of the base Linux font fallback chain. `bg` was deliberately added as a Cyrillic stress test in v0.8.0-rc.1 and shipped working without any extra package.

## Test plan

- [ ] **Needs Linux tester** — verify on a clean Arch (no `noto-cjk`) with locale switched to JA: banner appears, English half + install commands readable, Copy buttons work
- [ ] Same Arch after `pacman -S noto-fonts-cjk` and restart: banner still appears (we don't probe), Dismiss click hides it permanently for `ja`
- [ ] Ubuntu / Fedora spot-checks with their respective install commands
- [x] macOS / Windows in JA: banner never shows (verified by Linux-only platform check)
- [ ] Linux + BG locale: banner never shows (verified by `CJK_LOCALES` set membership)
- [ ] Switching JA → EN mid-session hides the banner; switching back shows it again (unless dismissed)
- [x] `vue-tsc --noEmit` clean
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)