### PR TITLE
chore(release): bump version to 0.8.0-rc.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.8.0-rc.2",
+  "version": "0.8.0-rc.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.8.0-rc.2"
+version = "0.8.0-rc.3"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.8.0-rc.2"
+version = "0.8.0-rc.3"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.8.0-rc.2",
+  "version": "0.8.0-rc.3",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Bumps version in 4 files: `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`
- Cuts rc.3 of the 0.8.0 cycle (0.8.0 has not shipped stable yet)

## Contents vs 0.8.0-rc.2

- **New:** CJK font install banner on Linux (#139) — persistent dismissible banner with per-distro install commands and Copy buttons, shown when locale is `ja` on Linux. Extensible to `zh` / `ko` when those locales ship.

## Test plan

- [ ] CI green on this bump PR
- [ ] After tag push: release CI builds installers for Win / Linux (AppImage) / macOS (~22 min)
- [ ] Linux tester pulls the AppImage via the in-app pre-release updater and verifies the CJK banner shows correctly on `ja` locale (no `noto-cjk` installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)