### PR TITLE
fix(theme): make native select popups follow dark theme on Linux

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3,6 +3,18 @@
 @tailwind utilities;
 
 /*
+ * Tell the webview which variant of native controls (select popups,
+ * scrollbars, date pickers) to render. Without this, webkit2gtk on Linux
+ * paints the open <select> popup with the system GTK theme — light on
+ * most distros — even when our app chrome is dark.
+ *
+ * Kept in sync with the `light` class on <html> via the rule below.
+ */
+:root {
+  color-scheme: dark;
+}
+
+/*
  * Light-mode overrides. Dark values live in tailwind.config.cjs as the
  * fallback on each `var(--autonomi-*)`, so the absence of a `.light` class
  * on <html> yields the dark palette without needing a `:root` block here.
@@ -10,6 +22,7 @@
  * Toggle: add/remove `light` class on <html>. See composables/useTheme.ts.
  */
 :root.light {
+  color-scheme: light;
   --autonomi-dark: #F8FAFC;
   --autonomi-surface: #FFFFFF;
   --autonomi-border: #CBD5E1;


### PR DESCRIPTION
## Summary

- Adds `color-scheme: dark` to `:root` (and `color-scheme: light` to `:root.light`) in `assets/css/main.css`
- Fixes the open `<select>` popup rendering as a light GTK panel on Linux even when our app chrome is dark
- Reported against v0.8.0-rc.3 on the language picker in Settings

## Why

On Linux, Tauri renders via webkit2gtk. The closed `<select>` control is styled by our CSS (`bg-autonomi-dark`, etc.) but the **open popup** is painted by GTK, which uses the system theme — and most distros default to a light theme. Our CSS can't reach into the GTK popup; we need to tell the webview which variant of native controls to render. `color-scheme` is the W3C-standard property for exactly this:

> Specifies which color schemes the element is comfortable being rendered in. The user agent then uses an appropriate variant of native controls.

Side effects (all positive):
- Scrollbars also pick up the dark variant on Linux
- Other native controls (date pickers, file inputs) follow the same rule

## Why now

The language picker is the entry point for any future CJK font-banner testing on Linux — testers need to switch to `ja` to see the banner. A jarring light-on-dark dropdown popup right at that entry point reads as broken even though the rest of the UI is fine.

## Test plan

- [ ] Linux: open language dropdown — popup is dark
- [ ] Linux: toggle to light mode — popup is light
- [ ] Windows / macOS: no visual regression (was already correct via OS)
- [x] vue-tsc clean (no JS / TS changes)
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)