### PR TITLE
chore(release): bump version to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.8.0-rc.3",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.8.0-rc.3"
+version = "0.8.0"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.8.0-rc.3"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.8.0-rc.3",
+  "version": "0.8.0",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Promotes `0.8.0-rc.3` to stable `0.8.0`
- Bumps version in 4 files: `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`

## Contents vs 0.7.1 (last stable)

- **i18n Phase 1** (vue-i18n framework, EN + JA baseline, six locales total: en/ja/nl/fr/bg/es)
- **CJK font install banner on Linux** (#139) — persistent dismissible banner with per-distro install commands and Copy buttons, shown when locale is `ja` on Linux
- **Theme: native select popups follow dark mode on Linux** (#141) — `color-scheme: dark` on `:root` so the open `<select>` popup is painted dark by webkit2gtk
- **ant-core 0.2.3 → 0.2.5** — merkle PUT timeout alignment + spill-dir leak fix on SIGKILL/OOM
- Plus the rc.1/rc.2/rc.3 cycle's docs and CI hygiene

## Test plan

- [x] Linux tester verified CJK font banner on `ja` locale (rc.3)
- [x] Dropdown dark-mode fix merged to address rc.3 finding
- [ ] CI green on this bump PR
- [ ] After tag push: release CI builds stable installers for Win / Linux (AppImage / .deb / .rpm) / macOS (~22 min)
- [ ] Stable installer pulled via the in-app updater (without pre-release toggle) and verified to install cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)