### PR TITLE
chore(release): bump version to 0.8.0-rc.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.8.0-rc.3",
+  "version": "0.8.0-rc.4",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.8.0-rc.3",
+  "version": "0.8.0-rc.4",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Bumps version in 4 files: \`package.json\`, \`src-tauri/Cargo.toml\`, \`src-tauri/Cargo.lock\`, \`src-tauri/tauri.conf.json\`
- Continues the 0.8.0 RC cycle (0.8.0 has not shipped stable yet)

## Contents vs 0.8.0-rc.3

- **Korean (ko) locale** (#143) — machine-translated baseline, seventh supported language (en/ja/ko/nl/fr/bg/es)
- **CJK font banner extended to ko** — \`한국어\` prefix, same noto-cjk install commands

## Test plan

- [ ] CI green on this bump PR
- [ ] After tag push: release CI builds installers (~22 min)
- [ ] Korean reviewer pulls rc.4 via in-app pre-release updater and verifies:
  - Settings → Language → \`한국어\` switches the UI
  - Strings render correctly across pages
  - On Linux: CJK banner shows with \`한국어 /\` prefix when noto-cjk is absent
- [ ] Existing rc.3 verification (CJK banner for ja, dropdown dark theme) remains valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)