### PR TITLE
ci: opt JS actions onto Node 24 ahead of 2026-06-02 forced-default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Opt JS-based actions onto Node 24 ahead of the 2026-06-02 forced-default
+  # switch (Node 20 fully removed on 2026-09-16). See release.yml for the
+  # same flag.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   frontend:

--- a/.github/workflows/refresh-release-notes.yml
+++ b/.github/workflows/refresh-release-notes.yml
@@ -27,6 +27,12 @@ on:
         required: true
         type: string
 
+env:
+  # Opt JS-based actions onto Node 24 ahead of the 2026-06-02 forced-default
+  # switch (Node 20 fully removed on 2026-09-16). See release.yml for the
+  # same flag.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   refresh:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Opt JS-based actions onto Node 24 ahead of the 2026-06-02 forced-default
+  # switch. Without this, `actions/upload-artifact@v5`, `actions/download-artifact@v5`,
+  # and `digicert/ssm-code-signing@v1.2.1` emit deprecation warnings on every
+  # run and would break outright after Node 20 is removed on 2026-09-16.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Adds \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true\` to the workflow-level \`env:\` block in \`ci.yml\`, \`release.yml\`, and \`refresh-release-notes.yml\`
- Pre-empts the **2026-06-02** GitHub forced Node 24 default (\~12 days from now); avoids the **2026-09-16** Node 20 removal that would otherwise break the release pipeline

## Why

The v0.8.0 release CI run logged this annotation:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: \`actions/upload-artifact@v5\`, \`actions/download-artifact@v5\`, \`digicert/ssm-code-signing@v1.2.1\`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

\`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24\` is the W3C-style escape hatch GitHub documents for early opt-in. It flips every JS-based action on the runner to Node 24 today, so any incompatibility surfaces now rather than mid-release on 2026-06-02.

## Why workflow-level env

Applied at the top of each workflow (not per-job) so every job inherits the flag — including the matrix builds in \`release.yml\` which span 4 OS targets and the code-signing step. No risk of missing a job.

## Verification

- **\`ci.yml\` Node 24 path** — exercised by this PR's CI run. Green = no incompatibility with the existing action versions.
- **\`release.yml\` Node 24 path** — first real verification will be the next release tag push. Fallback if the worst happens: revert the env line or set \`ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true\` (insecure but valid until 2026-09-16).
- **\`refresh-release-notes.yml\`** — only uses \`gh\` CLI; the flag is a no-op but kept for consistency.

## Test plan

- [ ] CI green on this PR (validates ci.yml Node 24 path)
- [ ] No Node 20 deprecation annotation in this PR's run logs
- [ ] After merge: next release tag push completes the full release workflow green
- [ ] Closes the work tracked in V2-349

🤖 Generated with [Claude Code](https://claude.com/claude-code)