### PR TITLE
feat(i18n): RTL first pass — Arabic + Hebrew locales + dir attribute

### DIFF
--- a/CONTRIBUTING-i18n.md
+++ b/CONTRIBUTING-i18n.md
@@ -39,6 +39,43 @@ see `settings.upload_history.summary_one` / `summary_many` for an example. The
 file does not use vue-i18n's built-in `|` plural syntax; keep the suffix
 convention so call sites can pick the right key explicitly.
 
+## Right-to-left (RTL) locales
+
+Arabic (`ar`) and Hebrew (`he`) ship as RTL baselines. The direction is wired
+through three pieces:
+
+- **`composables/useLocale.ts`** — `RTL_LOCALES` set, and a `dir` computed
+  ref that follows the active locale. Add new RTL locale codes here.
+- **`app.vue`** — `useHead({ htmlAttrs: { dir: localeDir } })` binds the
+  computed dir to the `<html>` element. Tailwind's `rtl:` variant fires off
+  this attribute.
+- **Surgical CSS** — most layout uses gap/flex which mirrors automatically,
+  but anything anchored by physical edge (`left-*`, `right-*`, `ml-*`,
+  `mr-*`, `text-left`, `text-right`, `border-l`, `border-r`) needs the
+  logical equivalent (`start-*`, `end-*`, `ms-*`, `me-*`, `text-start`,
+  `text-end`, `border-s`, `border-e`) or an explicit `rtl:` override.
+  Toggle thumbs use `translate-x-N rtl:-translate-x-N` to flip motion.
+
+Known follow-ups (first pass is intentionally surgical, not exhaustive):
+
+- Several dialogs and detail panels still use `ml-*`/`mr-*` margins that
+  read slightly off in RTL — they're functional but worth migrating to
+  `ms-*`/`me-*` opportunistically.
+- Dynamic StatusBadge strings stay English (see Phase-1 carve-out below);
+  the BiDi handling is fine but the strings themselves don't mirror.
+- **The WalletConnect / Reown AppKit modal stays English + LTR even when
+  the rest of the UI is localized.** Reown AppKit (1.8.19 at time of
+  writing) ships zero i18n or RTL support — no `locale` option on
+  `createAppKit`, no theme variable for direction, all strings are
+  hard-coded in the Shadow-DOM web components. This is an upstream
+  limitation, not a config gap. CSS hacks to force-mirror the Shadow DOM
+  would leave English text reading right-to-left, which is worse than
+  the current state. Revisit when Reown ships localization upstream;
+  don't attempt a workaround locally.
+
+When adding a new RTL locale, register the code in `RTL_LOCALES` and verify
+the toggle thumbs, sidebar border, and toast corner mirror correctly.
+
 ## Adding a new locale
 
 1. **Copy `en.json` to `locales/<lang>.json`.** Use the ISO 639-1 code for the

--- a/app.vue
+++ b/app.vue
@@ -15,8 +15,11 @@ import { useNodesStore } from '~/stores/nodes'
 import { useFilesStore } from '~/stores/files'
 import { useConnectionStore } from '~/stores/connection'
 
+const { init: initLocale, dir: localeDir } = useLocale()
+
 useHead({
   title: 'Autonomi',
+  htmlAttrs: { dir: localeDir },
   bodyAttrs: { class: 'bg-autonomi-dark text-autonomi-text' },
 })
 
@@ -31,8 +34,6 @@ const updaterStore = useUpdaterStore()
 const nodesStore = useNodesStore()
 const filesStore = useFilesStore()
 const connectionStore = useConnectionStore()
-
-const { init: initLocale } = useLocale()
 
 onMounted(async () => {
   // Config first — useLocale.init() reads the persisted choice from

--- a/components/AppSidebar.vue
+++ b/components/AppSidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="flex h-full w-56 flex-col border-r border-autonomi-border bg-autonomi-surface">
+  <aside class="flex h-full w-56 flex-col border-e border-autonomi-border bg-autonomi-surface">
     <!-- Logo / Brand -->
     <div class="flex items-center gap-3 px-4 py-5">
       <IconsAutonomiLogo :size="28" />
@@ -31,7 +31,7 @@
       <!-- Update banner -->
       <button
         v-if="updaterStore.available"
-        class="mb-2 flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-left text-sm font-semibold text-gray-900 shadow-md transition-all active:scale-[0.98]"
+        class="mb-2 flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-start text-sm font-semibold text-gray-900 shadow-md transition-all active:scale-[0.98]"
         :class="updaterStore.isPrerelease
           ? 'bg-teal-400 shadow-teal-400/25 hover:bg-teal-300'
           : 'bg-amber-400 shadow-amber-400/25 hover:bg-amber-300'"

--- a/components/ToastContainer.vue
+++ b/components/ToastContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col gap-2" aria-live="polite" aria-atomic="false">
+  <div class="pointer-events-none fixed bottom-4 end-4 z-50 flex flex-col gap-2" aria-live="polite" aria-atomic="false">
     <TransitionGroup name="toast">
       <div
         v-for="toast in toasts"

--- a/components/files/DownloadByDatamapDialog.vue
+++ b/components/files/DownloadByDatamapDialog.vue
@@ -56,7 +56,10 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { formatBytes } from '~/utils/formatters'
+
+const { locale } = useI18n()
 
 defineProps<{
   open: boolean
@@ -85,7 +88,7 @@ function basename(path: string): string {
 
 function formatShortDate(iso: string): string {
   try {
-    return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+    return new Date(iso).toLocaleDateString(locale.value, { month: 'short', day: 'numeric' })
   } catch {
     return iso
   }

--- a/components/nodes/NodeTile.vue
+++ b/components/nodes/NodeTile.vue
@@ -8,7 +8,7 @@
     @click="$emit('select', node.id)"
   >
     <!-- Status indicator dot -->
-    <div class="absolute left-3 top-3" :aria-label="$t('nodes.field.status_aria', { status: node.status })" role="img">
+    <div class="absolute start-3 top-3" :aria-label="$t('nodes.field.status_aria', { status: node.status })" role="img">
       <span class="relative flex h-2.5 w-2.5">
         <span
           v-if="node.status === 'running' || node.status === 'adding' || node.status === 'upgrade_scheduled'"
@@ -20,7 +20,7 @@
     </div>
 
     <!-- Node name / ID -->
-    <div class="mb-3 mt-1 pl-5">
+    <div class="mb-3 mt-1 ps-5">
       <p class="text-sm font-medium text-autonomi-text">{{ node.name || $t('nodes.node_fallback_name', { id: node.id }) }}</p>
       <p v-if="node.version" class="text-[10px] text-autonomi-muted">
         v{{ node.version }}<span

--- a/composables/useLocale.ts
+++ b/composables/useLocale.ts
@@ -1,14 +1,24 @@
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { locale as osLocaleApi } from '@tauri-apps/plugin-os'
 import { useI18n } from 'vue-i18n'
 import { useSettingsStore } from '~/stores/settings'
 
-export const SUPPORTED_LOCALES = ['en', 'ja', 'ko', 'nl', 'fr', 'bg', 'es'] as const
+export const SUPPORTED_LOCALES = ['en', 'ja', 'ko', 'nl', 'fr', 'bg', 'es', 'ar', 'he'] as const
 export type SupportedLocale = typeof SUPPORTED_LOCALES[number]
 const DEFAULT_LOCALE: SupportedLocale = 'en'
 
+/** Locales whose script flows right-to-left. The active value is applied as
+ *  `dir="rtl"` on the <html> element via useHead() in app.vue, which lets
+ *  Tailwind's `rtl:` variant flip individual classes that aren't already on
+ *  logical properties. */
+export const RTL_LOCALES: ReadonlySet<SupportedLocale> = new Set(['ar', 'he'])
+
+export function isRtlLocale(value: string): boolean {
+  return RTL_LOCALES.has(value as SupportedLocale)
+}
+
 /** Each locale's name in its own script. Used in the Settings picker so the
- *  user sees "English" / "日本語" / "한국어" / "Nederlands" / "Français" / "Български" / "Español"
+ *  user sees "English" / "日本語" / "한국어" / "Nederlands" / "Français" / "Български" / "Español" / "العربية" / "עברית"
  *  regardless of the currently-active UI locale. */
 export const NATIVE_LOCALE_NAMES: Record<SupportedLocale, string> = {
   en: 'English',
@@ -18,6 +28,8 @@ export const NATIVE_LOCALE_NAMES: Record<SupportedLocale, string> = {
   fr: 'Français',
   bg: 'Български',
   es: 'Español',
+  ar: 'العربية',
+  he: 'עברית',
 }
 
 /** Module-scoped cache of the OS-resolved locale. Warmed on the first
@@ -82,5 +94,10 @@ export function useLocale() {
     locale.value = next
   }
 
-  return { locale, setLocale, init, t, osLocale: osLocaleRef }
+  /** Reactive `ltr`/`rtl` flag tracking the active locale. Bound into the
+   *  <html dir=...> attribute by app.vue so Tailwind `rtl:` variants flip
+   *  in lockstep with the locale picker. */
+  const dir = computed<'ltr' | 'rtl'>(() => (isRtlLocale(locale.value) ? 'rtl' : 'ltr'))
+
+  return { locale, dir, setLocale, init, t, osLocale: osLocaleRef }
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -12,7 +12,7 @@
         <span class="font-medium">Storage directory unwritable.</span>
         Adding a node will fail until you pick a working folder in
         <NuxtLink to="/settings" class="underline hover:text-autonomi-error/80">Settings</NuxtLink>.
-        <span class="ml-2 font-mono text-autonomi-error/80">{{ settingsStore.storageDirProbeError }}</span>
+        <span class="ms-2 font-mono text-autonomi-error/80">{{ settingsStore.storageDirProbeError }}</span>
       </div>
       <main class="flex-1 overflow-auto p-6">
         <slot />

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -1,0 +1,482 @@
+{
+  "_translator_notes": "Machine-translated baseline. Community polish via PR welcome. RTL script — see CONTRIBUTING-i18n.md for the dir-attribute hookup.",
+  "settings": {
+    "language": {
+      "label": "اللغة",
+      "description": "لغة عرض واجهة المستخدم",
+      "system_default": "افتراضي النظام: {name}",
+      "system_default_pending": "افتراضي النظام"
+    },
+    "indelible": {
+      "title": "Indelible Enterprise",
+      "subtitle_connected": "متصل ببوابة التخزين المُدارة",
+      "subtitle_setup": "اتصل ببوابة Indelible مُستضافة ذاتيًا لتخزين مُدار",
+      "connected_badge": "متصل",
+      "server_label": "الخادم",
+      "signed_in_as": "تم تسجيل الدخول باسم",
+      "disconnect": "قطع الاتصال",
+      "server_url_label": "عنوان URL للخادم",
+      "server_url_placeholder": "https://files.acme.com",
+      "api_key_label": "مفتاح API",
+      "api_key_placeholder": "رمز API الخاص بك",
+      "test_connect": "اختبار واتصال",
+      "testing": "جارٍ الاختبار…",
+      "configure": "تكوين الاتصال"
+    },
+    "storage": {
+      "title": "دليل التخزين",
+      "description": "مكان تخزين بيانات العقدة على القرص",
+      "default": "افتراضي",
+      "browse": "تصفّح",
+      "warning": "ينطبق فقط على العقد المُضافة حديثًا. تحتفظ العقد الحالية بدليلها الحالي."
+    },
+    "downloads": {
+      "title": "دليل التنزيلات",
+      "description": "مكان حفظ الملفات المُنزَّلة",
+      "not_set": "غير محدد",
+      "browse": "تصفّح"
+    },
+    "alert": {
+      "title": "صوت التنبيه",
+      "description": "تشغيل صوت عند الأعطال الحرجة للعقدة",
+      "aria_toggle": "تبديل صوت التنبيه"
+    },
+    "theme": {
+      "title": "الوضع الفاتح",
+      "description": "التبديل بين السمتين الفاتحة والداكنة",
+      "aria_toggle": "تبديل الوضع الفاتح"
+    },
+    "advanced": {
+      "hide": "▾ إخفاء الإعدادات المتقدمة",
+      "show": "▸ إظهار الإعدادات المتقدمة"
+    },
+    "daemon": {
+      "title": "خدمة العقدة",
+      "description": "أعد تشغيل الخدمة الخلفية التي تُشرف على العقد. تظل العقد قيد التشغيل — يتم تبديل المُشرف فقط.",
+      "restart": "إعادة تشغيل الخدمة",
+      "restarting": "جارٍ إعادة التشغيل…"
+    },
+    "concurrency": {
+      "title": "تزامن الرفع",
+      "description_1": "يتحكم هذا في عدد عمليات التسعير/الرفع التي يمكن تشغيلها في نفس الوقت.",
+      "description_2": "لاحظ أن لهذا تأثيرًا كبيرًا جدًا على الأداء."
+    },
+    "prerelease": {
+      "title": "إصدارات ما قبل الإطلاق",
+      "description": "احصل على تحديثات تلقائية لإصدارات ما قبل الإطلاق (rc / beta) بالإضافة إلى الإصدارات المستقرة. مُعطّل افتراضيًا.",
+      "restart_required": "أعد تشغيل التطبيق لتطبيق هذا التغيير.",
+      "restart_now": "إعادة التشغيل الآن"
+    },
+    "direct_wallet": {
+      "title": "محفظة مباشرة",
+      "description": "الاتصال باستخدام مفتاح خاص (يتجاوز WalletConnect)",
+      "connected_badge": "متصل",
+      "address_label": "العنوان",
+      "disconnect": "قطع الاتصال",
+      "network_label": "الشبكة",
+      "network_sepolia_option": "Arbitrum Sepolia (شبكة اختبار)",
+      "network_arbitrum_option": "Arbitrum One (الشبكة الرئيسية)",
+      "rpc_url_label": "عنوان RPC",
+      "rpc_url_optional": "(اختياري)",
+      "rpc_url_placeholder": "افتراضي إلى RPC العام للسلسلة المختارة",
+      "private_key_label": "المفتاح الخاص",
+      "private_key_placeholder": "0x... أو سداسي عشري خام",
+      "connect": "اتصال",
+      "import_button": "استيراد مفتاح خاص"
+    },
+    "diagnostics": {
+      "title": "التشخيصات",
+      "summary": "{entries} إدخالات سجل ({errors} أخطاء)",
+      "copy_button": "نسخ إلى الحافظة",
+      "clear_button": "مسح",
+      "empty": "لا توجد إدخالات سجل",
+      "hide_log": "▾ إخفاء السجل",
+      "show_log": "▸ إظهار السجل"
+    },
+    "upload_history": {
+      "title": "سجل الرفع",
+      "summary_one": "{count} إدخال مستقر في upload_history.json. ملفات DataMaps على القرص والمقاطع على الشبكة لم تُمَس.",
+      "summary_many": "{count} إدخالات مستقرة في upload_history.json. ملفات DataMaps على القرص والمقاطع على الشبكة لم تُمَس.",
+      "clear_button": "مسح السجل",
+      "confirm_one": "مسح إدخال رفع واحد من السجل؟\n\nيؤدي هذا إلى إزالة الصف المحلي + السجل المحفوظ. لا تتأثر ملفات DataMaps على القرص ولا المقاطع على الشبكة.",
+      "confirm_many": "مسح {count} إدخالات رفع من السجل؟\n\nيؤدي هذا إلى إزالة الصف المحلي + السجل المحفوظ. لا تتأثر ملفات DataMaps على القرص ولا المقاطع على الشبكة."
+    },
+    "software": {
+      "title": "البرنامج",
+      "app_version_label": "إصدار التطبيق",
+      "node_version_label": "إصدار العقدة",
+      "last_checked": "آخر تحقق {label}",
+      "check_button": "التحقق من التحديثات",
+      "checking": "جارٍ التحقق…"
+    },
+    "about": {
+      "title": "حول"
+    },
+    "relative_time": {
+      "just_now": "الآن",
+      "seconds_ago": "{n} ث مضت",
+      "minutes_ago": "{n} د مضت",
+      "hours_ago": "{n} س مضت",
+      "days_ago": "{n} ي مضت"
+    },
+    "picker": {
+      "storage_title": "اختر دليل التخزين",
+      "downloads_title": "اختر دليل التنزيلات"
+    },
+    "error": {
+      "private_key_invalid": "مفتاح خاص غير صالح — يجب أن يكون 64 حرفًا سداسيًا عشريًا",
+      "invalid_eth_address": "تنسيق عنوان EVM غير صالح"
+    },
+    "toast": {
+      "upload_history_cleared": "تم مسح سجل الرفع",
+      "update_check_failed": "فشل التحقق من التحديث",
+      "update_available": "تحديث متاح: v{version}",
+      "on_latest_version": "أنت على أحدث إصدار (v{version})",
+      "daemon_restarted": "تم إعادة تشغيل الخدمة",
+      "daemon_restart_failed": "فشل في إعادة تشغيل الخدمة: {error}",
+      "storage_dir_updated": "تم تحديث دليل التخزين",
+      "storage_dir_verified": "تم التحقق من دليل التخزين",
+      "storage_dir_unwritable": "لا يمكن استخدام هذا المجلد لتخزين العقدة",
+      "select_directory_failed": "فشل في اختيار الدليل",
+      "downloads_dir_updated": "تم تحديث دليل التنزيلات",
+      "earnings_updated": "تم تحديث عنوان الأرباح",
+      "daemon_url_updated": "تم تحديث عنوان URL للخدمة",
+      "diagnostics_copied": "تم نسخ التشخيصات إلى الحافظة",
+      "diagnostics_copy_failed": "فشل النسخ إلى الحافظة",
+      "log_cleared": "تم مسح السجل",
+      "indelible_connected": "تم الاتصال بـ Indelible",
+      "indelible_disconnected": "تم قطع الاتصال بـ Indelible",
+      "wallet_connected": "تم توصيل المحفظة: {address}",
+      "wallet_disconnected": "تم فصل المحفظة",
+      "wallet_attach_failed": "فشل إرفاق المحفظة (جانب Rust): {error}"
+    }
+  },
+  "nav": {
+    "nodes": "العقد",
+    "files": "الملفات",
+    "wallet": "المحفظة",
+    "settings": "الإعدادات"
+  },
+  "header": {
+    "title": "Autonomi",
+    "active_transfers": "{count} نشطة",
+    "connecting": "جارٍ الاتصال",
+    "connecting_tooltip": "جارٍ الاتصال بشبكة Autonomi",
+    "connected": "الشبكة",
+    "connected_tooltip": "متصل بشبكة Autonomi",
+    "offline": "غير متصل · إعادة المحاولة",
+    "offline_tooltip": "فشل الاتصال — انقر لإعادة المحاولة",
+    "connect_wallet": "توصيل المحفظة"
+  },
+  "sidebar": {
+    "pre_release": "ما قبل الإطلاق",
+    "update_available": "تحديث متاح",
+    "update_pre_release_tag": "ما قبل الإطلاق",
+    "network_devnet": "DEVNET",
+    "network_sepolia": "SEPOLIA TESTNET"
+  },
+  "common": {
+    "cancel": "إلغاء",
+    "confirm": "تأكيد",
+    "close": "إغلاق",
+    "download": "تنزيل",
+    "start": "بدء",
+    "stop": "إيقاف",
+    "remove": "إزالة",
+    "close_panel": "إغلاق اللوحة"
+  },
+  "nodes": {
+    "add_button": "+ إضافة عقد",
+    "start_all": "بدء الكل",
+    "stop_all": "إيقاف الكل",
+    "running_count": "{count} قيد التشغيل",
+    "stopped_count": "{count} متوقفة",
+    "errored_count": "{count} أخطأت",
+    "filter_placeholder": "تصفية...",
+    "filter_aria_label": "تصفية العقد",
+    "starting_daemon": "جارٍ بدء خدمة العقدة…",
+    "restarting_daemon": "جارٍ إعادة تشغيل خدمة العقدة…",
+    "nodes_keep_running": "تظل عقدك قيد التشغيل.",
+    "daemon_disconnected": "تعذّر الاتصال بخدمة العقدة",
+    "daemon_retrying": "جارٍ إعادة المحاولة تلقائيًا…",
+    "empty_title": "لا توجد عقد بعد",
+    "empty_hint": "انقر على \"+ إضافة عقد\" للبدء",
+    "confirm_action": "تأكيد الإجراء",
+    "remove_node_message": "إزالة العقدة {id}؟ سيحذف هذا جميع بياناتها.",
+    "stop_all_message": "إيقاف جميع العقد {count} قيد التشغيل؟",
+    "node_fallback_name": "العقدة {id}",
+    "field": {
+      "node_id": "معرّف العقدة",
+      "status": "الحالة",
+      "version": "الإصدار",
+      "pid": "PID",
+      "uptime": "وقت التشغيل",
+      "storage": "التخزين",
+      "data_directory": "دليل البيانات",
+      "log_directory": "دليل السجل",
+      "port": "المنفذ",
+      "binary": "الملف الثنائي",
+      "rewards_address": "عنوان المكافآت",
+      "status_aria": "الحالة: {status}"
+    },
+    "add_dialog": {
+      "title": "إضافة عقد",
+      "number_label": "عدد العقد",
+      "range_hint": "بين 1 و 50",
+      "no_earnings_warning": "لم يتم تكوين عنوان أرباح. عيّن واحدًا في صفحة المحفظة قبل إضافة العقد.",
+      "submit_one": "إضافة عقدة واحدة",
+      "submit_many": "إضافة {count} عقد"
+    },
+    "toast": {
+      "added": "تمت إضافة {count} عقدة/عقد",
+      "add_failed": "فشل في إضافة العقد: {error}",
+      "started": "تم بدء العقدة {id}",
+      "start_failed": "فشل في بدء العقدة {id}: {error}",
+      "stopped": "تم إيقاف العقدة {id}",
+      "stop_failed": "فشل في إيقاف العقدة {id}: {error}",
+      "removed": "تمت إزالة العقدة {id}",
+      "remove_failed": "فشل في إزالة العقدة {id}: {error}",
+      "no_stopped": "لا توجد عقد متوقفة لبدئها",
+      "no_running": "لا توجد عقد قيد التشغيل لإيقافها",
+      "node_failed": "فشلت العقدة {id}: {error}",
+      "started_count": "تم بدء {count} عقدة/عقد",
+      "stopped_count": "تم إيقاف {count} عقدة/عقد",
+      "start_all_failed": "فشل في بدء الكل: {error}",
+      "stop_all_failed": "فشل في إيقاف الكل: {error}"
+    }
+  },
+  "files": {
+    "upload_button": "رفع ملف/ملفات",
+    "estimate_button": "تقدير التكلفة",
+    "download_by_address": "تنزيل بالعنوان",
+    "download_by_datamap": "تنزيل بـ Datamap",
+    "uploads_heading": "عمليات الرفع",
+    "downloads_heading": "عمليات التنزيل",
+    "clear": "مسح",
+    "drop_files": "أفلت الملفات للرفع",
+    "uploads_empty_title": "لا توجد عمليات رفع بعد",
+    "uploads_empty_hint": "اسحب الملفات هنا، أو استخدم الأزرار أعلاه",
+    "downloads_empty_title": "لا توجد عمليات تنزيل بعد",
+    "downloads_empty_hint": "استخدم \"تنزيل بالعنوان\" أو \"تنزيل بـ Datamap\"",
+    "table": {
+      "name": "الاسم",
+      "status": "الحالة",
+      "size": "الحجم",
+      "cost": "التكلفة",
+      "date": "التاريخ",
+      "address": "العنوان",
+      "saved_to": "محفوظ في",
+      "actions": "الإجراءات"
+    },
+    "row": {
+      "free_already_stored": "مجاني — مُخزّن بالفعل",
+      "gas_suffix": "+ {gas} غاز",
+      "public_badge": "عام",
+      "retry": "↻ إعادة المحاولة",
+      "public_tooltip": "رفع عام — انقر لنسخ عنوان الشبكة القابل للمشاركة",
+      "reveal_datamap_tooltip": "إظهار ملف datamap في Finder/Explorer",
+      "copy_datamap_tooltip": "نسخ مسار ملف datamap",
+      "copy_address_tooltip": "نسخ عنوان الشبكة",
+      "retry_tooltip": "إعادة محاولة الرفع",
+      "remove_tooltip": "إزالة من القائمة"
+    },
+    "stage": {
+      "encrypting": "جارٍ التشفير…",
+      "quoting_pct": "تسعير · {pct}%",
+      "quoting_indeterminate": "جارٍ التسعير…",
+      "storing_pct": "تخزين · {pct}%",
+      "storing_indeterminate": "جارٍ التخزين…",
+      "resolving_pct": "جارٍ تحليل datamap · {pct}%",
+      "resolving_indeterminate": "جارٍ تحليل datamap…",
+      "downloading_pct": "تنزيل · {pct}%",
+      "downloading_indeterminate": "جارٍ التنزيل…"
+    },
+    "picker": {
+      "upload_title": "اختر الملفات للرفع",
+      "datamap_title": "اختر ملف datamap للتنزيل",
+      "estimate_title": "اختر الملفات لتقدير التكلفة",
+      "datamap_filter": "Datamap"
+    },
+    "toast": {
+      "upload_requires_wallet": "الرفع يتطلب محفظة",
+      "download_requires_network": "التنزيل يتطلب اتصال شبكة",
+      "open_folder_failed": "تعذّر فتح المجلد",
+      "address_copied": "تم نسخ العنوان إلى الحافظة",
+      "public_address_copied": "تم نسخ العنوان العام — شاركه ليتمكن الآخرون من تنزيل هذا الملف",
+      "datamap_path_copied": "تم نسخ مسار datamap إلى الحافظة",
+      "already_stored_one": "ملف واحد مُخزّن بالفعل — جارٍ حفظ datamap",
+      "already_stored_many": "{count} ملفات مُخزّنة بالفعل — جارٍ حفظ datamap",
+      "upload_complete": "اكتمل الرفع: {name}",
+      "upload_failed": "فشل الرفع: {name} — {error}",
+      "payment_failed": "فشل الدفع: {error}",
+      "download_complete": "اكتمل التنزيل: {name}",
+      "download_failed": "فشل التنزيل: {name} — {error}",
+      "datamap_missing": "تعذّر التنزيل: ملف datamap مفقود أو غير قابل للقراءة",
+      "datamap_read_failed": "تعذّر قراءة datamap: {error}"
+    },
+    "error": {
+      "wallet_not_connected": "المحفظة غير متصلة",
+      "not_connected_to_network": "غير متصل بالشبكة"
+    },
+    "network": {
+      "unavailable": "غير متصل بشبكة Autonomi — تقدير التكلفة غير متاح.",
+      "retry_connection": "إعادة محاولة الاتصال",
+      "connecting": "جارٍ الاتصال بشبكة Autonomi…",
+      "obtaining_quote": "الحصول على عرض سعر من الشبكة…",
+      "obtaining_quotes": "الحصول على عروض الأسعار من الشبكة…"
+    },
+    "datamap_saveas": {
+      "title": "حفظ الملف المُنزَّل باسم",
+      "filename_label": "اسم الملف",
+      "filename_placeholder": "myfile.dat"
+    },
+    "download_dialog": {
+      "title": "تنزيل ملف",
+      "address_label": "عنوان الملف",
+      "address_placeholder": "عنوان الملف (سداسي عشري)",
+      "filename_label": "حفظ باسم",
+      "filename_placeholder": "myfile.dat"
+    },
+    "datamap_picker": {
+      "description": "اختر رفعًا سابقًا لإعادة تنزيله، أو تصفّح بحثًا عن ملف datamap تلقيته من مكان آخر.",
+      "empty": "لا توجد عمليات رفع سابقة مع datamap محفوظ بعد.",
+      "browse_button": "تصفّح بحثًا عن ملف datamap…"
+    },
+    "cost_estimate": {
+      "title": "تقدير تكلفة الرفع",
+      "loading": "جارٍ تقدير التكلفة…",
+      "no_files": "لا توجد ملفات مُختارة",
+      "footnote": "تم الاستعلام عن التكاليف من شبكة Autonomi. رسوم الغاز (ETH) تنطبق فوق تكاليف التخزين."
+    },
+    "upload_confirm": {
+      "title": "تأكيد الرفع",
+      "info_banner": "يمكنك إغلاق هذه النافذة والعودة عندما يصل العرض. يبقى الرفع معلقًا حتى تُوافق عليه أو تُلغيه.",
+      "already_stored_badge": "مُخزّن بالفعل",
+      "payment_label": "الدفع",
+      "payment_mixed": "مختلط",
+      "payment_mixed_detail": "{regular} عادي، {merkle} merkle — دفع لكل ملف.",
+      "payment_merkle": "شجرة Merkle",
+      "payment_regular": "عادي",
+      "payment_merkle_detail": "معاملة واحدة لـ {count} مقاطع — غاز أقل.",
+      "payment_regular_detail_one": "دفع لكل دفعة لمقطع واحد.",
+      "payment_regular_detail_many": "دفع لكل دفعة لـ {count} مقاطع.",
+      "free_title": "مُخزّن بالفعل على الشبكة — مجاني",
+      "free_detail": "كل مقطع موجود بالفعل. لن يتم إنفاق ANT أو غاز.",
+      "cost_label": "تكلفة تخزين الشبكة",
+      "gas_label": "الغاز المُقدَّر",
+      "some_already_stored": "بعض الملفات مُخزّنة بالفعل — لا يكلّف هذا الجزء شيئًا.",
+      "visibility_label": "الرؤية",
+      "visibility_private": "خاص",
+      "visibility_private_desc": "مشفّر ولا يمكن الوصول إليه إلا بخريطة البيانات الخاصة بك. أنت فقط من يمكنه استرجاع الملف.",
+      "visibility_public": "عام",
+      "visibility_public_desc": "تُنشَر خريطة البيانات على الشبكة. شارك عنوانًا واحدًا حتى يتمكن أي شخص من استرجاع الملف.",
+      "regular_footnote": "تم التقدير من عرض سعر شبكة واحد — قد تتفاوت التكلفة النهائية قليلًا. رسوم الغاز تنطبق فوق ذلك.",
+      "cancel_upload": "إلغاء الرفع",
+      "ready_count": "جاهز: {ready} من {total}",
+      "approve_button_one": "الموافقة على الرفع",
+      "approve_button_many": "الموافقة على {count} عمليات رفع"
+    }
+  },
+  "wallet": {
+    "earnings_heading": "عنوان الأرباح",
+    "earnings_description": "حيث تُرسل أرباح عقدتك",
+    "earnings_not_configured": "غير مُكوَّن",
+    "edit": "تعديل",
+    "save": "حفظ",
+    "earnings_use_payment_prompt": "استخدام عنوان محفظتك المتصلة للأرباح؟",
+    "earnings_use_payment_button": "استخدم {address}",
+    "earnings_placeholder": "0x...",
+    "managed_storage_heading": "تخزين مُدار",
+    "managed_storage_org": "تخزين مُدار بواسطة {org}",
+    "managed_storage_description": "تُوجَّه عمليات الرفع عبر بوابة Indelible الخاصة بمؤسستك. لا حاجة لمحفظة محلية.",
+    "payment_wallet_heading": "محفظة الدفع",
+    "payment_optional_hint": "اختياري — مطلوب لرفع الملفات",
+    "connect_prompt": "اتصل بمحفظة للدفع لتخزين الملفات",
+    "network_arbitrum_sepolia": "Arbitrum Sepolia testnet",
+    "network_arbitrum_one": "شبكة Arbitrum One مطلوبة",
+    "import_key_hint": "أو استورد مفتاحًا خاصًا في {link}",
+    "import_key_hint_link_text": "الإعدادات > متقدم",
+    "address_label": "العنوان",
+    "eth_balance_label": "رصيد ETH",
+    "ant_balance_label": "رصيد ANT",
+    "usdc_balance_label": "رصيد USDC",
+    "refresh_balances": "تحديث الأرصدة",
+    "disconnect": "قطع الاتصال",
+    "toast": {
+      "import_key_in_settings": "استورد مفتاحًا خاصًا في الإعدادات > متقدم",
+      "invalid_address": "عنوان غير صالح: يجب أن يكون 0x + 40 حرفًا سداسيًا عشريًا",
+      "earnings_saved": "تم حفظ عنوان الأرباح",
+      "earnings_set_to_payment": "تم تعيين عنوان الأرباح إلى محفظة الدفع",
+      "wallet_disconnected": "تم فصل المحفظة"
+    }
+  },
+  "updater": {
+    "dialog": {
+      "title": "تحديث متاح",
+      "version_ready": "v{version} جاهز للتثبيت",
+      "pre_release_badge": "ما قبل الإطلاق",
+      "download_size": "حجم التنزيل: {size}",
+      "release_notes": "ملاحظات الإصدار",
+      "no_release_notes": "لا توجد ملاحظات إصدار لهذه النسخة.",
+      "downloading": "جارٍ التنزيل…",
+      "download_complete": "نجح التنزيل، سيُعيد التطبيق التشغيل قريبًا",
+      "auto_restart_hint": "سيُعيد التطبيق التشغيل تلقائيًا عند الاكتمال.",
+      "cancel_download": "إلغاء التنزيل",
+      "installing_tooltip": "جارٍ التثبيت — يُرجى الانتظار",
+      "not_now": "ليس الآن",
+      "update_restart": "تحديث وإعادة تشغيل"
+    },
+    "toast": {
+      "install_no_restart": "تم تثبيت التحديث إلى v{version} لكن التطبيق لم يُعِد التشغيل. أغلق Autonomi وأعد فتحه لإنهاء التحديث.",
+      "install_failed": "فشل تثبيت التحديث: {error}"
+    }
+  },
+  "validators": {
+    "filename": {
+      "has_special_chars": "لا يمكن أن يحتوي اسم الملف على أحرف خاصة",
+      "ends_with_dot_or_space": "لا يمكن أن ينتهي اسم الملف بنقطة أو مسافة",
+      "reserved_on_windows": "هذا الاسم محجوز على Windows"
+    }
+  },
+  "status": {
+    "node": {
+      "running": "قيد التشغيل",
+      "stopped": "متوقفة",
+      "starting": "جارٍ البدء",
+      "stopping": "جارٍ الإيقاف",
+      "adding": "جارٍ الإضافة…",
+      "errored": "خطأ",
+      "upgrade_scheduled": "جارٍ الترقية"
+    },
+    "file": {
+      "pending": "قيد الانتظار",
+      "quoting": "جارٍ التسعير",
+      "encrypting": "جارٍ التشفير…",
+      "resolving_datamap": "جارٍ تحليل datamap",
+      "queued_quoting": "في الطابور: تسعير",
+      "queued_uploading": "في الطابور: رفع",
+      "connecting_to_network": "جارٍ الاتصال بالشبكة…",
+      "obtaining_quote": "الحصول على عرض سعر…",
+      "saving_datamap": "جارٍ حفظ datamap…",
+      "network_unavailable": "الشبكة غير متاحة",
+      "ready_to_approve": "جاهز للموافقة",
+      "awaiting_approval": "بانتظار الموافقة",
+      "uploading": "جارٍ الرفع",
+      "downloading": "جارٍ التنزيل",
+      "done": "تم",
+      "downloaded": "تم التنزيل — انقر للفتح"
+    }
+  },
+  "banners": {
+    "cjk_font_missing": {
+      "script_label": "日本語",
+      "message": "قد لا تُعرض النصوص اليابانية بشكل صحيح على هذا النظام. للإصلاح، ثبّت خطوط Noto CJK وأعد تشغيل التطبيق:",
+      "distro_arch": "Arch",
+      "distro_debian": "Debian / Ubuntu",
+      "distro_fedora": "Fedora",
+      "copy": "نسخ الأمر",
+      "copied": "تم نسخ الأمر إلى الحافظة",
+      "dismiss": "تجاهل"
+    }
+  }
+}

--- a/locales/he.json
+++ b/locales/he.json
@@ -1,0 +1,482 @@
+{
+  "_translator_notes": "Machine-translated baseline. Community polish via PR welcome. RTL script — see CONTRIBUTING-i18n.md for the dir-attribute hookup.",
+  "settings": {
+    "language": {
+      "label": "שפה",
+      "description": "שפת תצוגת הממשק",
+      "system_default": "ברירת מחדל של המערכת: {name}",
+      "system_default_pending": "ברירת מחדל של המערכת"
+    },
+    "indelible": {
+      "title": "Indelible Enterprise",
+      "subtitle_connected": "מחובר לשער אחסון מנוהל",
+      "subtitle_setup": "התחבר לשער Indelible מאוחסן עצמית עבור אחסון מנוהל",
+      "connected_badge": "מחובר",
+      "server_label": "שרת",
+      "signed_in_as": "מחובר בתור",
+      "disconnect": "התנתק",
+      "server_url_label": "כתובת URL של השרת",
+      "server_url_placeholder": "https://files.acme.com",
+      "api_key_label": "מפתח API",
+      "api_key_placeholder": "אסימון ה-API שלך",
+      "test_connect": "בדיקה והתחברות",
+      "testing": "בודק…",
+      "configure": "הגדרת חיבור"
+    },
+    "storage": {
+      "title": "תיקיית אחסון",
+      "description": "היכן נתוני הצומת מאוחסנים בדיסק",
+      "default": "ברירת מחדל",
+      "browse": "עיון",
+      "warning": "חל רק על צמתים חדשים שנוספים. צמתים קיימים שומרים על התיקייה הנוכחית שלהם."
+    },
+    "downloads": {
+      "title": "תיקיית הורדות",
+      "description": "היכן קבצים שהורדו נשמרים",
+      "not_set": "לא הוגדר",
+      "browse": "עיון"
+    },
+    "alert": {
+      "title": "צליל התראה",
+      "description": "השמע צליל בעת כשלים קריטיים של צומת",
+      "aria_toggle": "החלף צליל התראה"
+    },
+    "theme": {
+      "title": "מצב בהיר",
+      "description": "החלף בין ערכות נושא כהות ובהירות",
+      "aria_toggle": "החלף מצב בהיר"
+    },
+    "advanced": {
+      "hide": "▾ הסתר מתקדם",
+      "show": "▸ הצג מתקדם"
+    },
+    "daemon": {
+      "title": "שירות צמתים",
+      "description": "הפעל מחדש את שירות הרקע שמפקח על הצמתים שלך. הצמתים הפועלים שלך ממשיכים לפעול — רק המפקח מוחלף.",
+      "restart": "הפעל מחדש את השירות",
+      "restarting": "מפעיל מחדש…"
+    },
+    "concurrency": {
+      "title": "מקביליות העלאה",
+      "description_1": "פעולה זו שולטת בכמה הצעות מחיר/העלאות יכולות לפעול בו-זמנית.",
+      "description_2": "שים לב שיש לכך השפעה גדולה מאוד על הביצועים."
+    },
+    "prerelease": {
+      "title": "גרסאות טרום שחרור",
+      "description": "קבל עדכונים אוטומטיים עבור גרסאות טרום שחרור (rc / beta) בנוסף לגרסאות יציבות. כבוי כברירת מחדל.",
+      "restart_required": "הפעל מחדש את האפליקציה כדי להחיל את השינוי.",
+      "restart_now": "הפעל מחדש עכשיו"
+    },
+    "direct_wallet": {
+      "title": "ארנק ישיר",
+      "description": "התחבר עם מפתח פרטי (עוקף את WalletConnect)",
+      "connected_badge": "מחובר",
+      "address_label": "כתובת",
+      "disconnect": "התנתק",
+      "network_label": "רשת",
+      "network_sepolia_option": "Arbitrum Sepolia (רשת בדיקה)",
+      "network_arbitrum_option": "Arbitrum One (רשת ראשית)",
+      "rpc_url_label": "כתובת RPC",
+      "rpc_url_optional": "(אופציונלי)",
+      "rpc_url_placeholder": "ברירת מחדל ל-RPC ציבורי של השרשרת שנבחרה",
+      "private_key_label": "מפתח פרטי",
+      "private_key_placeholder": "0x... או hex גולמי",
+      "connect": "התחבר",
+      "import_button": "ייבוא מפתח פרטי"
+    },
+    "diagnostics": {
+      "title": "אבחון",
+      "summary": "{entries} ערכי יומן ({errors} שגיאות)",
+      "copy_button": "העתק ללוח",
+      "clear_button": "נקה",
+      "empty": "אין ערכי יומן",
+      "hide_log": "▾ הסתר יומן",
+      "show_log": "▸ הצג יומן"
+    },
+    "upload_history": {
+      "title": "היסטוריית העלאות",
+      "summary_one": "{count} ערך מסודר ב-upload_history.json. קבצי DataMaps בדיסק והמקטעים ברשת אינם נפגעים.",
+      "summary_many": "{count} ערכים מסודרים ב-upload_history.json. קבצי DataMaps בדיסק והמקטעים ברשת אינם נפגעים.",
+      "clear_button": "נקה היסטוריה",
+      "confirm_one": "לנקות ערך העלאה אחד מההיסטוריה?\n\nפעולה זו מסירה את השורה המקומית + הרישום השמור. קבצי DataMaps בדיסק והמקטעים ברשת אינם מושפעים.",
+      "confirm_many": "לנקות {count} ערכי העלאה מההיסטוריה?\n\nפעולה זו מסירה את השורה המקומית + הרישום השמור. קבצי DataMaps בדיסק והמקטעים ברשת אינם מושפעים."
+    },
+    "software": {
+      "title": "תוכנה",
+      "app_version_label": "גרסת אפליקציה",
+      "node_version_label": "גרסת צומת",
+      "last_checked": "נבדק לאחרונה {label}",
+      "check_button": "בדוק עדכונים",
+      "checking": "בודק…"
+    },
+    "about": {
+      "title": "אודות"
+    },
+    "relative_time": {
+      "just_now": "הרגע",
+      "seconds_ago": "לפני {n} שנ׳",
+      "minutes_ago": "לפני {n} דק׳",
+      "hours_ago": "לפני {n} שע׳",
+      "days_ago": "לפני {n} יום"
+    },
+    "picker": {
+      "storage_title": "בחר תיקיית אחסון",
+      "downloads_title": "בחר תיקיית הורדות"
+    },
+    "error": {
+      "private_key_invalid": "מפתח פרטי לא חוקי — חייב להיות 64 תווי hex",
+      "invalid_eth_address": "פורמט כתובת EVM לא חוקי"
+    },
+    "toast": {
+      "upload_history_cleared": "היסטוריית העלאות נוקתה",
+      "update_check_failed": "בדיקת עדכון נכשלה",
+      "update_available": "עדכון זמין: v{version}",
+      "on_latest_version": "אתה בגרסה האחרונה (v{version})",
+      "daemon_restarted": "השירות הופעל מחדש",
+      "daemon_restart_failed": "נכשלה הפעלת השירות מחדש: {error}",
+      "storage_dir_updated": "תיקיית האחסון עודכנה",
+      "storage_dir_verified": "תיקיית האחסון אומתה",
+      "storage_dir_unwritable": "לא ניתן להשתמש בתיקייה זו לאחסון צמתים",
+      "select_directory_failed": "נכשלה בחירת תיקייה",
+      "downloads_dir_updated": "תיקיית ההורדות עודכנה",
+      "earnings_updated": "כתובת הרווחים עודכנה",
+      "daemon_url_updated": "כתובת ה-URL של השירות עודכנה",
+      "diagnostics_copied": "האבחון הועתק ללוח",
+      "diagnostics_copy_failed": "ההעתקה ללוח נכשלה",
+      "log_cleared": "היומן נוקה",
+      "indelible_connected": "מחובר ל-Indelible",
+      "indelible_disconnected": "מנותק מ-Indelible",
+      "wallet_connected": "ארנק מחובר: {address}",
+      "wallet_disconnected": "ארנק התנתק",
+      "wallet_attach_failed": "צירוף ארנק (צד Rust) נכשל: {error}"
+    }
+  },
+  "nav": {
+    "nodes": "צמתים",
+    "files": "קבצים",
+    "wallet": "ארנק",
+    "settings": "הגדרות"
+  },
+  "header": {
+    "title": "Autonomi",
+    "active_transfers": "{count} פעילים",
+    "connecting": "מתחבר",
+    "connecting_tooltip": "מתחבר לרשת Autonomi",
+    "connected": "רשת",
+    "connected_tooltip": "מחובר לרשת Autonomi",
+    "offline": "לא מקוון · נסה שוב",
+    "offline_tooltip": "החיבור נכשל — לחץ לנסות שוב",
+    "connect_wallet": "התחבר לארנק"
+  },
+  "sidebar": {
+    "pre_release": "טרום שחרור",
+    "update_available": "עדכון זמין",
+    "update_pre_release_tag": "טרום שחרור",
+    "network_devnet": "DEVNET",
+    "network_sepolia": "SEPOLIA TESTNET"
+  },
+  "common": {
+    "cancel": "ביטול",
+    "confirm": "אישור",
+    "close": "סגור",
+    "download": "הורד",
+    "start": "הפעל",
+    "stop": "עצור",
+    "remove": "הסר",
+    "close_panel": "סגור חלונית"
+  },
+  "nodes": {
+    "add_button": "+ הוסף צמתים",
+    "start_all": "הפעל הכל",
+    "stop_all": "עצור הכל",
+    "running_count": "{count} פועלים",
+    "stopped_count": "{count} עצורים",
+    "errored_count": "{count} בשגיאה",
+    "filter_placeholder": "סינון...",
+    "filter_aria_label": "סינון צמתים",
+    "starting_daemon": "מפעיל שירות צמתים…",
+    "restarting_daemon": "מפעיל מחדש שירות צמתים…",
+    "nodes_keep_running": "הצמתים שלך ממשיכים לפעול.",
+    "daemon_disconnected": "לא ניתן להתחבר לשירות הצמתים",
+    "daemon_retrying": "מנסה שוב אוטומטית…",
+    "empty_title": "אין צמתים עדיין",
+    "empty_hint": "לחץ \"+ הוסף צמתים\" כדי להתחיל",
+    "confirm_action": "אישור פעולה",
+    "remove_node_message": "להסיר את הצומת {id}? פעולה זו תמחק את כל הנתונים שלו.",
+    "stop_all_message": "לעצור את כל {count} הצמתים הפועלים?",
+    "node_fallback_name": "צומת {id}",
+    "field": {
+      "node_id": "מזהה צומת",
+      "status": "סטטוס",
+      "version": "גרסה",
+      "pid": "PID",
+      "uptime": "זמן פעולה",
+      "storage": "אחסון",
+      "data_directory": "תיקיית נתונים",
+      "log_directory": "תיקיית יומן",
+      "port": "פורט",
+      "binary": "קובץ הפעלה",
+      "rewards_address": "כתובת תגמולים",
+      "status_aria": "סטטוס: {status}"
+    },
+    "add_dialog": {
+      "title": "הוסף צמתים",
+      "number_label": "מספר צמתים",
+      "range_hint": "בין 1 ל-50",
+      "no_earnings_warning": "לא הוגדרה כתובת רווחים. הגדר אחת בדף הארנק לפני הוספת צמתים.",
+      "submit_one": "הוסף צומת אחד",
+      "submit_many": "הוסף {count} צמתים"
+    },
+    "toast": {
+      "added": "נוספו {count} צמתים",
+      "add_failed": "הוספת הצמתים נכשלה: {error}",
+      "started": "צומת {id} הופעל",
+      "start_failed": "הפעלת צומת {id} נכשלה: {error}",
+      "stopped": "צומת {id} נעצר",
+      "stop_failed": "עצירת צומת {id} נכשלה: {error}",
+      "removed": "צומת {id} הוסר",
+      "remove_failed": "הסרת צומת {id} נכשלה: {error}",
+      "no_stopped": "אין צמתים עצורים להפעלה",
+      "no_running": "אין צמתים פועלים לעצירה",
+      "node_failed": "צומת {id} נכשל: {error}",
+      "started_count": "הופעלו {count} צמתים",
+      "stopped_count": "נעצרו {count} צמתים",
+      "start_all_failed": "הפעלת הכל נכשלה: {error}",
+      "stop_all_failed": "עצירת הכל נכשלה: {error}"
+    }
+  },
+  "files": {
+    "upload_button": "העלה קבצים",
+    "estimate_button": "אמוד עלות",
+    "download_by_address": "הורד לפי כתובת",
+    "download_by_datamap": "הורד לפי Datamap",
+    "uploads_heading": "העלאות",
+    "downloads_heading": "הורדות",
+    "clear": "נקה",
+    "drop_files": "שחרר קבצים להעלאה",
+    "uploads_empty_title": "אין העלאות עדיין",
+    "uploads_empty_hint": "גרור קבצים לכאן, או השתמש בכפתורים למעלה",
+    "downloads_empty_title": "אין הורדות עדיין",
+    "downloads_empty_hint": "השתמש ב-\"הורד לפי כתובת\" או \"הורד לפי Datamap\"",
+    "table": {
+      "name": "שם",
+      "status": "סטטוס",
+      "size": "גודל",
+      "cost": "עלות",
+      "date": "תאריך",
+      "address": "כתובת",
+      "saved_to": "נשמר ב",
+      "actions": "פעולות"
+    },
+    "row": {
+      "free_already_stored": "חינם — כבר מאוחסן",
+      "gas_suffix": "+ {gas} גז",
+      "public_badge": "ציבורי",
+      "retry": "↻ נסה שוב",
+      "public_tooltip": "העלאה ציבורית — לחץ להעתיק את כתובת הרשת לשיתוף",
+      "reveal_datamap_tooltip": "הצג קובץ datamap ב-Finder/Explorer",
+      "copy_datamap_tooltip": "העתק נתיב קובץ datamap",
+      "copy_address_tooltip": "העתק כתובת רשת",
+      "retry_tooltip": "נסה שוב העלאה",
+      "remove_tooltip": "הסר מהרשימה"
+    },
+    "stage": {
+      "encrypting": "מצפין…",
+      "quoting_pct": "מתמחר · {pct}%",
+      "quoting_indeterminate": "מתמחר…",
+      "storing_pct": "מאחסן · {pct}%",
+      "storing_indeterminate": "מאחסן…",
+      "resolving_pct": "פותר datamap · {pct}%",
+      "resolving_indeterminate": "פותר datamap…",
+      "downloading_pct": "מוריד · {pct}%",
+      "downloading_indeterminate": "מוריד…"
+    },
+    "picker": {
+      "upload_title": "בחר קבצים להעלאה",
+      "datamap_title": "בחר קובץ datamap להורדה",
+      "estimate_title": "בחר קבצים לאמידת עלות",
+      "datamap_filter": "Datamap"
+    },
+    "toast": {
+      "upload_requires_wallet": "ההעלאה דורשת ארנק",
+      "download_requires_network": "ההורדה דורשת חיבור רשת",
+      "open_folder_failed": "לא ניתן לפתוח את התיקייה",
+      "address_copied": "הכתובת הועתקה ללוח",
+      "public_address_copied": "כתובת ציבורית הועתקה — שתף כדי שאחרים יוכלו להוריד את הקובץ",
+      "datamap_path_copied": "נתיב datamap הועתק ללוח",
+      "already_stored_one": "קובץ אחד כבר מאוחסן — שומר datamap",
+      "already_stored_many": "{count} קבצים כבר מאוחסנים — שומר datamap",
+      "upload_complete": "ההעלאה הושלמה: {name}",
+      "upload_failed": "ההעלאה נכשלה: {name} — {error}",
+      "payment_failed": "התשלום נכשל: {error}",
+      "download_complete": "ההורדה הושלמה: {name}",
+      "download_failed": "ההורדה נכשלה: {name} — {error}",
+      "datamap_missing": "לא ניתן להוריד: קובץ datamap חסר או לא קריא",
+      "datamap_read_failed": "לא ניתן לקרוא את datamap: {error}"
+    },
+    "error": {
+      "wallet_not_connected": "הארנק לא מחובר",
+      "not_connected_to_network": "לא מחובר לרשת"
+    },
+    "network": {
+      "unavailable": "לא מחובר לרשת Autonomi — אמידת עלות לא זמינה.",
+      "retry_connection": "נסה לחבר שוב",
+      "connecting": "מתחבר לרשת Autonomi…",
+      "obtaining_quote": "מקבל הצעת מחיר מהרשת…",
+      "obtaining_quotes": "מקבל הצעות מחיר מהרשת…"
+    },
+    "datamap_saveas": {
+      "title": "שמור את הקובץ שהורד בשם",
+      "filename_label": "שם קובץ",
+      "filename_placeholder": "myfile.dat"
+    },
+    "download_dialog": {
+      "title": "הורד קובץ",
+      "address_label": "כתובת קובץ",
+      "address_placeholder": "כתובת קובץ (hex)",
+      "filename_label": "שמור בשם",
+      "filename_placeholder": "myfile.dat"
+    },
+    "datamap_picker": {
+      "description": "בחר העלאה קודמת להורדה מחדש, או חפש קובץ datamap שקיבלת ממקור אחר.",
+      "empty": "אין העלאות קודמות עם datamap שמור עדיין.",
+      "browse_button": "חפש קובץ datamap…"
+    },
+    "cost_estimate": {
+      "title": "אמדן עלות העלאה",
+      "loading": "אומד עלות…",
+      "no_files": "לא נבחרו קבצים",
+      "footnote": "העלויות מתקבלות מרשת Autonomi. דמי גז (ETH) חלים בנוסף לעלויות האחסון."
+    },
+    "upload_confirm": {
+      "title": "אישור העלאה",
+      "info_banner": "אתה יכול לסגור את החלון ולחזור כשהצעת המחיר תגיע. ההעלאה ממתינה עד שתאשר או תבטל אותה.",
+      "already_stored_badge": "כבר מאוחסן",
+      "payment_label": "תשלום",
+      "payment_mixed": "מעורב",
+      "payment_mixed_detail": "{regular} רגיל, {merkle} merkle — תשלום לכל קובץ.",
+      "payment_merkle": "עץ Merkle",
+      "payment_regular": "רגיל",
+      "payment_merkle_detail": "עסקה אחת ל-{count} מקטעים — פחות גז.",
+      "payment_regular_detail_one": "תשלום לכל אצווה עבור מקטע אחד.",
+      "payment_regular_detail_many": "תשלום לכל אצווה עבור {count} מקטעים.",
+      "free_title": "כבר מאוחסן ברשת — חינם",
+      "free_detail": "כל מקטע כבר קיים. לא יושקעו ANT או גז.",
+      "cost_label": "עלות אחסון רשת",
+      "gas_label": "גז משוער",
+      "some_already_stored": "חלק מהקבצים כבר מאוחסנים — אותו חלק לא עולה דבר.",
+      "visibility_label": "נראות",
+      "visibility_private": "פרטי",
+      "visibility_private_desc": "מוצפן ונגיש רק עם מפת הנתונים שלך. רק אתה יכול לאחזר את הקובץ.",
+      "visibility_public": "ציבורי",
+      "visibility_public_desc": "מפת הנתונים מתפרסמת לרשת. שתף כתובת אחת כדי שכל אחד יוכל לאחזר את הקובץ.",
+      "regular_footnote": "אמדן מהצעת מחיר רשת אחת — העלות הסופית עשויה להשתנות מעט. דמי גז חלים בנוסף.",
+      "cancel_upload": "בטל העלאה",
+      "ready_count": "מוכן: {ready} מתוך {total}",
+      "approve_button_one": "אשר העלאה",
+      "approve_button_many": "אשר {count} העלאות"
+    }
+  },
+  "wallet": {
+    "earnings_heading": "כתובת רווחים",
+    "earnings_description": "לאן רווחי הצמתים שלך נשלחים",
+    "earnings_not_configured": "לא הוגדר",
+    "edit": "ערוך",
+    "save": "שמור",
+    "earnings_use_payment_prompt": "להשתמש בכתובת הארנק המחובר שלך עבור רווחים?",
+    "earnings_use_payment_button": "השתמש ב-{address}",
+    "earnings_placeholder": "0x...",
+    "managed_storage_heading": "אחסון מנוהל",
+    "managed_storage_org": "אחסון מנוהל על ידי {org}",
+    "managed_storage_description": "ההעלאות מנותבות דרך שער Indelible של הארגון שלך. אין צורך בארנק מקומי.",
+    "payment_wallet_heading": "ארנק תשלומים",
+    "payment_optional_hint": "אופציונלי — נדרש להעלאת קבצים",
+    "connect_prompt": "חבר ארנק כדי לשלם עבור אחסון קבצים",
+    "network_arbitrum_sepolia": "Arbitrum Sepolia testnet",
+    "network_arbitrum_one": "נדרשת רשת Arbitrum One",
+    "import_key_hint": "או ייבא מפתח פרטי ב-{link}",
+    "import_key_hint_link_text": "הגדרות > מתקדם",
+    "address_label": "כתובת",
+    "eth_balance_label": "יתרת ETH",
+    "ant_balance_label": "יתרת ANT",
+    "usdc_balance_label": "יתרת USDC",
+    "refresh_balances": "רענן יתרות",
+    "disconnect": "התנתק",
+    "toast": {
+      "import_key_in_settings": "ייבא מפתח פרטי בהגדרות > מתקדם",
+      "invalid_address": "כתובת לא חוקית: חייבת להיות 0x + 40 תווי hex",
+      "earnings_saved": "כתובת הרווחים נשמרה",
+      "earnings_set_to_payment": "כתובת הרווחים הוגדרה לארנק התשלומים",
+      "wallet_disconnected": "הארנק התנתק"
+    }
+  },
+  "updater": {
+    "dialog": {
+      "title": "עדכון זמין",
+      "version_ready": "v{version} מוכן להתקנה",
+      "pre_release_badge": "טרום שחרור",
+      "download_size": "גודל הורדה: {size}",
+      "release_notes": "הערות שחרור",
+      "no_release_notes": "אין הערות שחרור עבור גרסה זו.",
+      "downloading": "מוריד…",
+      "download_complete": "ההורדה הצליחה, האפליקציה תופעל מחדש בקרוב",
+      "auto_restart_hint": "האפליקציה תופעל מחדש אוטומטית עם השלמת הפעולה.",
+      "cancel_download": "בטל הורדה",
+      "installing_tooltip": "מתקין — אנא המתן",
+      "not_now": "לא עכשיו",
+      "update_restart": "עדכן והפעל מחדש"
+    },
+    "toast": {
+      "install_no_restart": "העדכון ל-v{version} הותקן אבל האפליקציה לא הופעלה מחדש. צא מ-Autonomi ופתח שוב כדי לסיים את העדכון.",
+      "install_failed": "התקנת העדכון נכשלה: {error}"
+    }
+  },
+  "validators": {
+    "filename": {
+      "has_special_chars": "שם הקובץ לא יכול להכיל תווים מיוחדים",
+      "ends_with_dot_or_space": "שם הקובץ לא יכול להסתיים בנקודה או רווח",
+      "reserved_on_windows": "שם זה שמור ב-Windows"
+    }
+  },
+  "status": {
+    "node": {
+      "running": "פועל",
+      "stopped": "עצור",
+      "starting": "מפעיל",
+      "stopping": "עוצר",
+      "adding": "מוסיף…",
+      "errored": "שגיאה",
+      "upgrade_scheduled": "משדרג"
+    },
+    "file": {
+      "pending": "ממתין",
+      "quoting": "מתמחר",
+      "encrypting": "מצפין…",
+      "resolving_datamap": "פותר datamap",
+      "queued_quoting": "בתור: מתמחר",
+      "queued_uploading": "בתור: מעלה",
+      "connecting_to_network": "מתחבר לרשת…",
+      "obtaining_quote": "מקבל הצעת מחיר…",
+      "saving_datamap": "שומר datamap…",
+      "network_unavailable": "הרשת לא זמינה",
+      "ready_to_approve": "מוכן לאישור",
+      "awaiting_approval": "ממתין לאישור",
+      "uploading": "מעלה",
+      "downloading": "מוריד",
+      "done": "הושלם",
+      "downloaded": "הורד — לחץ לפתיחה"
+    }
+  },
+  "banners": {
+    "cjk_font_missing": {
+      "script_label": "日本語",
+      "message": "טקסט יפני עשוי שלא להופיע נכון במערכת זו. לתיקון, התקן את גופני Noto CJK והפעל את האפליקציה מחדש:",
+      "distro_arch": "Arch",
+      "distro_debian": "Debian / Ubuntu",
+      "distro_fedora": "Fedora",
+      "copy": "העתק פקודה",
+      "copied": "הפקודה הועתקה ללוח",
+      "dismiss": "סגור"
+    }
+  }
+}

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -80,7 +80,7 @@
         <div v-else class="overflow-hidden rounded-lg border border-autonomi-border">
           <table class="w-full text-sm">
             <thead class="bg-autonomi-surface">
-              <tr class="text-left text-xs uppercase tracking-wider text-autonomi-muted">
+              <tr class="text-start text-xs uppercase tracking-wider text-autonomi-muted">
                 <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleUploadSort('name')">
                   {{ $t('files.table.name') }} {{ uploadSortIndicator('name') }}
                 </th>
@@ -181,7 +181,7 @@
                   </span>
                   <span v-else class="text-autonomi-muted">-</span>
                 </td>
-                <td class="px-2 py-2.5 text-right whitespace-nowrap">
+                <td class="px-2 py-2.5 text-end whitespace-nowrap">
                   <span v-if="isSettled(file)" class="inline-flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
                     <button
                       v-if="canRetry(file)"
@@ -234,7 +234,7 @@
       <div v-else class="overflow-hidden rounded-lg border border-autonomi-border">
         <table class="w-full text-sm">
           <thead class="bg-autonomi-surface">
-            <tr class="text-left text-xs uppercase tracking-wider text-autonomi-muted">
+            <tr class="text-start text-xs uppercase tracking-wider text-autonomi-muted">
               <th class="cursor-pointer px-4 py-2.5 hover:text-autonomi-text" @click="toggleDownloadSort('name')">
                 {{ $t('files.table.name') }} {{ downloadSortIndicator('name') }}
               </th>
@@ -282,7 +282,7 @@
                 {{ file.dest_path ? basenameOf(file.dest_path) : '-' }}
               </td>
               <td class="px-4 py-2.5 text-autonomi-muted">{{ formatDate(file.date) }}</td>
-              <td class="px-2 py-2.5 text-right whitespace-nowrap">
+              <td class="px-2 py-2.5 text-end whitespace-nowrap">
                 <span v-if="isSettled(file)" class="inline-flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
                   <button
                     class="rounded px-1.5 py-0.5 text-[11px] text-autonomi-muted hover:bg-autonomi-surface hover:text-autonomi-error"
@@ -352,7 +352,7 @@ import { useSettingsStore } from '~/stores/settings'
 import { useToastStore } from '~/stores/toasts'
 import { useConnectionStore } from '~/stores/connection'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 interface FileMeta {
   path: string
@@ -1085,7 +1085,7 @@ function datamapBasename(path: string): string {
 function formatDate(iso: string): string {
   try {
     const d = new Date(iso)
-    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+    return d.toLocaleDateString(locale.value, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
   } catch {
     return iso
   }

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -83,8 +83,8 @@
         @click="settingsStore.toggleBell()"
       >
         <span
-          class="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white transition-transform"
-          :class="settingsStore.bellOnCritical ? 'translate-x-5' : ''"
+          class="absolute start-0.5 top-0.5 h-5 w-5 rounded-full bg-white transition-transform"
+          :class="settingsStore.bellOnCritical ? 'translate-x-5 rtl:-translate-x-5' : ''"
         />
       </button>
     </div>
@@ -104,8 +104,8 @@
         @click="settingsStore.setThemeMode(settingsStore.themeMode === 'light' ? 'dark' : 'light')"
       >
         <span
-          class="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white transition-transform"
-          :class="settingsStore.themeMode === 'light' ? 'translate-x-5' : ''"
+          class="absolute start-0.5 top-0.5 h-5 w-5 rounded-full bg-white transition-transform"
+          :class="settingsStore.themeMode === 'light' ? 'translate-x-5 rtl:-translate-x-5' : ''"
         />
       </button>
     </div>
@@ -129,6 +129,8 @@
         <option value="fr">Français</option>
         <option value="bg">Български</option>
         <option value="es">Español</option>
+        <option value="ar">العربية</option>
+        <option value="he">עברית</option>
       </select>
     </div>
 
@@ -223,7 +225,7 @@
               <span
                 :class="[
                   'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
-                  settingsStore.prereleaseChannel ? 'translate-x-6' : 'translate-x-1',
+                  settingsStore.prereleaseChannel ? 'translate-x-6 rtl:-translate-x-6' : 'translate-x-1 rtl:-translate-x-1',
                 ]"
               />
             </button>

--- a/plugins/i18n.client.ts
+++ b/plugins/i18n.client.ts
@@ -6,6 +6,8 @@ import nl from '~/locales/nl.json'
 import fr from '~/locales/fr.json'
 import bg from '~/locales/bg.json'
 import es from '~/locales/es.json'
+import ar from '~/locales/ar.json'
+import he from '~/locales/he.json'
 
 /**
  * Exported so non-component code (Pinia options-API stores, plain utility
@@ -16,7 +18,7 @@ export const i18n = createI18n({
   legacy: false,
   locale: 'en',
   fallbackLocale: 'en',
-  messages: { en, ja, ko, nl, fr, bg, es },
+  messages: { en, ja, ko, nl, fr, bg, es, ar, he },
   missingWarn: true,
   fallbackWarn: false,
 })


### PR DESCRIPTION
## Summary

- Adds the RTL infrastructure (\`RTL_LOCALES\` set, \`dir\` computed ref, \`<html dir>\` binding via \`useHead\`) so any RTL locale flips layout direction automatically.
- Ships Arabic (\`ar\`) and Hebrew (\`he\`) baselines, machine-translated, mirroring \`en.json\`.
- Surgical Tailwind logical-property migration on the most visible LTR-only constructs (toggle thumbs, sidebar border, toast corner, files table alignment, NodeTile status dot, default-layout banner). Many dialog-internal \`ml-*\`/\`mr-*\` spots intentionally left for follow-up.
- Side fix: \`formatDate\` / \`formatShortDate\` now pass the active vue-i18n locale to \`toLocaleDateString\` instead of relying on the OS locale (was leaking English month names in non-English UIs).

## Why this matters

Direction is the load-bearing piece — anything else (more RTL locales, narrower CSS sweep) can land later without revisiting infra. Doing this first means future RTL additions (Persian, Urdu) are pure additive.

## What's NOT in this PR (documented as follow-ups in \`CONTRIBUTING-i18n.md\`)

- \`ml-*\`/\`mr-*\` margins in dialogs and detail panels — functional but read slightly off in RTL.
- Dynamic StatusBadge strings (\"Uploading 45%\", \"Failed: <err>\") stay English; backend pre-renders them as strings the frontend can't round-trip through \`t()\`.
- Reown AppKit modal stays English + LTR — upstream limitation, no \`locale\` option in AppKit 1.8.19. CSS hacks against the Shadow DOM would leave English text reading right-to-left, which is worse than current. Documented; not fixable locally.

## Test plan

- [ ] \`npm run test:run\` — 30/30 pass (verified locally).
- [ ] Settings → Language → العربية → confirm \`<html dir=\"rtl\">\` and sidebar / toast / toggle thumbs mirror.
- [ ] Settings → Language → עברית → same checks.
- [ ] Switch back to English → layout returns to LTR, dates back to English month names.
- [ ] Smoke-test other locales (ja, ko, fr, etc.) confirm date formatter localization didn't regress them.

## Notes for the merger

If this lands after the sibling \`i18n/locale-expansion\` PR, expect trivial conflicts in:
- \`composables/useLocale.ts\` — combine \`SUPPORTED_LOCALES\` and \`NATIVE_LOCALE_NAMES\` entries
- \`plugins/i18n.client.ts\` — combine imports + messages map
- \`pages/settings.vue\` — combine \`<option>\` entries in the language picker

Resolution is mechanical; both branches add to the same arrays/maps without overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)