### PR TITLE
chore(release): bump version to 0.8.1-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.8.0",
+  "version": "0.8.1-rc.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.8.0",
+  "version": "0.8.1-rc.1",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
First RC in the 0.8.1 line. For internal-tester verification of the new locales — none of the maintainers speak the languages in scope.

## Contents vs 0.8.0 stable

**i18n — RTL first pass** (#147 merged today)
- Arabic (\`ar\`) and Hebrew (\`he\`) locale baselines, machine-translated.
- \`<html dir>\` attribute now binds to the active locale via \`useHead\` — Tailwind \`rtl:\` variants flip automatically.
- Surgical logical-property migration on the most visible LTR-only constructs: toggle thumbs, sidebar border, toast corner, files-table alignment, NodeTile status dot, default-layout banner.
- Side fix: \`formatDate\` / \`formatShortDate\` now use the active vue-i18n locale instead of OS locale (was leaking English month names in non-English UIs).
- Known follow-ups documented in \`CONTRIBUTING-i18n.md\` — \`ml-*\`/\`mr-*\` margins in dialogs/detail panels stay LTR-anchored, dynamic StatusBadge strings stay English (Phase-1 carve-out), Reown AppKit modal is English+LTR-only (upstream limitation, not fixable locally).

**i18n — locale expansion** (#148 merged today)
- 9 new LTR locale baselines: Russian (\`ru\`), Ukrainian (\`uk\`), Simplified Chinese (\`zh-CN\`), Traditional Chinese (\`zh-TW\`), Brazilian Portuguese (\`pt-BR\`), Turkish (\`tr\`), Vietnamese (\`vi\`), Indonesian (\`id\`), German (\`de\`).
- All machine-translated baselines flagged with \`_translator_notes\`. Community polish via PR welcome.
- \`normalizeLocale()\` patched to try the full IETF tag (\`zh-CN\`) before stripping to bare lang — without this, OS locale \`zh-CN\` would degrade to \`zh\` and fall back to English. \`fr-CA\`, \`en-GB\` etc. still fall through to bare lang.
- **Total locales after this RC: 18** (en, ja, ko, nl, fr, bg, es, ar, he, ru, uk, zh-CN, zh-TW, pt-BR, tr, vi, id, de).

## Test plan

- [ ] \`npm run test:run\` — 30/30 pass (verified locally).
- [ ] CI green on this PR.
- [ ] Tester sweep: open Settings → Language picker, walk through every native script in order. Verify the picker labels render correctly. Verify switching to each locale flips nav / sidebar / settings text. Identifiers (Autonomi, Indelible, WalletConnect, ANT, ETH, 0x… addresses) stay verbatim in all locales — that's by design.
- [ ] RTL specifically (ar / he): confirm sidebar moves to right side of window, toggle thumbs slide from right edge, toasts appear in bottom-left.
- [ ] Spot-check date rendering — month name should localize in every locale (e.g. \`14 May\` → \`14 мая\` / \`14 трав.\` / \`14 May\` → \`5月14日\` / etc).

## After merge

Tag \`v0.8.1-rc.1\` to trigger the release build (~22 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)