### PR TITLE
ci: bump JS actions to Node-24-native manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
       && !startsWith(github.event.pull_request.title, 'docs(')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: npm
@@ -68,9 +68,9 @@ jobs:
           - check: build
             command: cargo check --manifest-path src-tauri/Cargo.toml
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Opt JS-based actions onto Node 24 ahead of the 2026-06-02 forced-default
-  # switch. Without this, `actions/upload-artifact@v5`, `actions/download-artifact@v5`,
-  # and `digicert/ssm-code-signing@v1.2.1` emit deprecation warnings on every
-  # run and would break outright after Node 20 is removed on 2026-09-16.
+  # switch (Node 20 fully removed on 2026-09-16). All actions/* are now on
+  # Node-24-native manifests (checkout@v6, setup-node@v6, upload-artifact@v7,
+  # download-artifact@v8); the override remains load-bearing for
+  # `digicert/ssm-code-signing@v1.2.1`, which still declares `using: node20`
+  # in its manifest. Remove once digicert ships a Node-24-native release.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
@@ -51,7 +53,7 @@ jobs:
       ant_tag: ${{ steps.resolve.outputs.ant_tag }}
       ant_version: ${{ steps.resolve.outputs.ant_version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: resolve version
         id: resolve
@@ -94,9 +96,9 @@ jobs:
             args: "--target x86_64-apple-darwin"
             slug: macos-x86_64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: npm
@@ -309,7 +311,7 @@ jobs:
           ls -l "$stage"
 
       - name: upload release assets
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: release-assets-${{ matrix.slug }}
           path: release-assets/
@@ -332,9 +334,9 @@ jobs:
       SM_LOG_LEVEL: trace
       SM_LOG_FILE: ${{ github.workspace }}\smctl-signing.log
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: npm
@@ -518,7 +520,7 @@ jobs:
           ls -l "$stage"
 
       - name: upload release assets
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: release-assets-windows
           path: release-assets/
@@ -527,7 +529,7 @@ jobs:
 
       - name: upload signing logs on failure
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: signing-logs
           path: ${{ github.workspace }}\smctl-signing.log
@@ -539,7 +541,7 @@ jobs:
     needs: [release-meta, build-linux-macos, build-windows]
     steps:
       - name: download all build artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           # Download every artifact uploaded by the build jobs
           # (release-assets-linux, release-assets-macos-aarch64,


### PR DESCRIPTION
## Why

GitHub removes Node 20 from the Actions runner on **2026-09-16**. Action manifests still declaring \`using: node20\` will break outright after that — the \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24\` runtime override (PR #146) only kept them limping along on Node 24 today, with deprecation warnings on every run.

This bumps the affected \`actions/*\` to versions that natively declare \`using: node24\` in their manifests.

## Diff

| Action | Before | After | Manifest |
|---|---|---|---|
| \`actions/checkout\` | v5 | **v6** (v6.0.2) | \`node24\` |
| \`actions/setup-node\` | v5 | **v6** (v6.4.0) | \`node24\` |
| \`actions/upload-artifact\` | v5 | **v7** (v7.0.1) | \`node24\` |
| \`actions/download-artifact\` | v5 | **v8** (v8.0.1) | \`node24\` |

## Unchanged

| Action | Why kept |
|---|---|
| \`swatinem/rust-cache@v2\` | Floats to v2.9.1 which already uses \`node24\` |
| \`tauri-apps/tauri-action@v0\` | action-v0.6.2 uses \`node24\` |
| \`dtolnay/rust-toolchain@stable\` | Rust action, no Node runtime |
| \`digicert/ssm-code-signing@v1.2.1\` | Vendor has not shipped a Node-24-native release yet. \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24\` keeps it working until they do. Comment in \`release.yml\` updated to reflect this. |

## Test plan

- [ ] CI green on this PR (frontend + rust matrix all pass).
- [ ] After merge, next \`main\` push triggers ci.yml — confirm no Node 20 warnings on \`upload-artifact\` / \`download-artifact\` / \`checkout\` / \`setup-node\` jobs.
- [ ] Next release cuts cleanly (release.yml builds + signs + publishes installers as before).
- [ ] The only Node 20 deprecation warning remaining should be on the \`setup DigiCert SSM tools\` step — that's expected and tracked separately.

## Notes

The \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24\` env override stays in both workflows. With digicert still on a node20-declaring manifest, removing the override would have it crash hard on 2026-09-16. Once digicert ships a v2 (or whatever) that declares \`using: node24\`, the override can come out in a followup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)