### PR TITLE
chore(deps): bump ant-core to v0.2.6

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -788,7 +788,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -799,13 +799,13 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "ant-core"
-version = "0.2.5"
-source = "git+https://github.com/WithAutonomi/ant-client?tag=ant-core-v0.2.5#76763d686f6e2c27f3a4535146bbab8913190132"
+version = "0.2.6"
+source = "git+https://github.com/WithAutonomi/ant-client?tag=ant-core-v0.2.6#eeba52b997415164421999287d54fce6beae3bd3"
 dependencies = [
  "ant-protocol",
  "async-stream",
@@ -2528,7 +2528,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2834,7 +2834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4800,7 +4800,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4864,7 +4864,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5958,7 +5958,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5971,7 +5971,7 @@ dependencies = [
  "libc",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6521,7 +6521,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6589,7 +6589,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6610,7 +6610,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7447,7 +7447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8181,7 +8181,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8700,7 +8700,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9271,7 +9271,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ toml = "0.8"
 tauri-plugin-updater = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-ant-core = { git = "https://github.com/WithAutonomi/ant-client", tag = "ant-core-v0.2.5" }
+ant-core = { git = "https://github.com/WithAutonomi/ant-client", tag = "ant-core-v0.2.6" }
 evmlib = "0.8"
 hex = "0.4"
 sha2 = "0.10"


### PR DESCRIPTION
## Summary

Bumps `ant-core` pin `v0.2.5 → v0.2.6`. Pure pin bump — `cargo check` clean against current GUI integration, no source-level changes required.

Upstream delivers 36 commits across the data path (`WithAutonomi/ant-client` v0.2.5..v0.2.6):

- **merkle**: retry on quorum shortfall instead of aborting the upload
- **merkle preflight**: trim chunk-selection memory + preserve resume after preflight
- **data**: skip already-stored chunks before merkle payment (resume optimisation)
- **download**: residential-saturation + transient-failure hardening; fetch cap reaches the ceiling on fast-but-lossy links; warm-start keeps slow-start armed
- **download**: throughput hill-climb for fetch concurrency tuning
- **chunk**: all-peer get diagnostics + configurable peer count

Upstream also introduced a new `ant_core::datamap_file` module intended to be shared with this app (per the ant-cli 0.2.5 release notes). Adoption is intentionally **out of scope** for this PR — tracked as a follow-up so this RC stays a pure pin bump.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean
- [ ] Cut `v0.8.1-rc.2` after merge (separate version-bump PR)
- [ ] Tester verification on the produced RC build

🤖 Generated with [Claude Code](https://claude.com/claude-code)