### PR TITLE
chore(release): bump version to 0.8.1-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.8.1-rc.1",
+  "version": "0.8.1-rc.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.8.1-rc.1"
+version = "0.8.1-rc.2"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.8.1-rc.1"
+version = "0.8.1-rc.2"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.8.1-rc.1",
+  "version": "0.8.1-rc.2",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Version bump `0.8.1-rc.1 → 0.8.1-rc.2` across the 4 release files. Picks up `ant-core v0.2.6` (merged in #151).

## Test plan

- [x] All 4 versions match across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`
- [x] Commit prefix `chore(release): bump version to ` verbatim (ci.yml skip guard)
- [ ] After merge: tag `v0.8.1-rc.2` and push to trigger `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)