### PR TITLE
fix(wallet): enforce active chain on connect so balances are consistent

### DIFF
--- a/composables/useWallet.ts
+++ b/composables/useWallet.ts
@@ -1,4 +1,4 @@
-import { getBalance, readContract } from '@wagmi/core'
+import { getBalance, readContract, getAccount, switchChain } from '@wagmi/core'
 import { formatEther, formatUnits, erc20Abi } from 'viem'
 import { useWalletStore } from '~/stores/wallet'
 import { useSettingsStore } from '~/stores/settings'
@@ -11,6 +11,45 @@ import { getTokenAddress, getUsdcAddress, getActiveChainId, USDC_DECIMALS } from
 // briefly nulled walletStore.connected/balances — visible in the UI as a
 // "wallet disconnected" flicker on Refresh Balances.
 let syncStarted = false
+
+/**
+ * Make sure the connected AppKit/WalletConnect wallet is on the chain we read
+ * balances from and pay on (`getActiveChainId()` — Arbitrum One on mainnet, or
+ * the manifest's chain on devnet). Mirrors `ensureActiveChain` in
+ * `utils/payment.ts`, but runs at *connect* time rather than only at payment
+ * time — that gap was the root cause of GH #85 / V2-474, where our balance
+ * panel (pinned to Arbitrum One) disagreed with the AppKit account modal
+ * (which shows the wallet's actually-connected chain).
+ *
+ * Returns `true` if the wallet is on the target chain (already, or after a
+ * successful switch), `false` if a mismatch persists (wallet declined the
+ * `wallet_switchEthereumChain` request, or the target chain isn't one AppKit
+ * knows about). Never throws — a `false` return drives the "wrong network"
+ * banner instead of breaking the connect flow.
+ *
+ * The direct-key devnet wallet always sits on the manifest's chain, so it's
+ * skipped via the same `_devnetWalletKeySet` guard the watcher uses.
+ */
+export async function ensureActiveChain(): Promise<boolean> {
+  const { $appkitReady, $wagmiAdapter } = useNuxtApp()
+  if (!$appkitReady || !$wagmiAdapter?.wagmiConfig) return true
+
+  const settingsStore = useSettingsStore()
+  if (settingsStore._devnetWalletKeySet) return true
+
+  const config = $wagmiAdapter.wagmiConfig
+  const target = getActiveChainId()
+  const account = getAccount(config)
+  if (account.chainId === target) return true
+
+  try {
+    await switchChain(config, { chainId: target })
+    return true
+  } catch (err) {
+    console.warn('Wallet is on the wrong network; switch was not completed:', err)
+    return false
+  }
+}
 
 /**
  * Fetch wallet balances and update the store. Safe to call repeatedly from
@@ -103,17 +142,22 @@ async function syncFromAppKit() {
 
   watch(
     [isConnected, address],
-    ([connected, addr]) => {
+    async ([connected, addr]) => {
       if (settingsStore._devnetWalletKeySet) return
       walletStore.connected = !!connected
       walletStore.paymentAddress = addr ?? null
       if (connected && addr) {
+        // Move the wallet onto our target chain before reading balances, so
+        // our panel and the AppKit modal agree (GH #85 / V2-474). If the
+        // switch doesn't complete, flag it for the "wrong network" banner.
+        walletStore.wrongNetwork = !(await ensureActiveChain())
         refreshBalances()
       } else {
         walletStore.balance = null
         walletStore.ethBalance = null
         walletStore.antBalance = null
         walletStore.usdcBalance = null
+        walletStore.wrongNetwork = false
       }
     },
     { immediate: true },

--- a/locales/en.json
+++ b/locales/en.json
@@ -401,12 +401,15 @@
     "usdc_balance_label": "USDC Balance",
     "refresh_balances": "Refresh Balances",
     "disconnect": "Disconnect",
+    "wrong_network_warning": "Your wallet is on a different network. Switch to {network} to see your correct balance and pay for uploads.",
+    "switch_network_button": "Switch network",
     "toast": {
       "import_key_in_settings": "Import a private key in Settings > Advanced",
       "invalid_address": "Invalid address: must be 0x + 40 hex characters",
       "earnings_saved": "Earnings address saved",
       "earnings_set_to_payment": "Earnings address set to payment wallet",
-      "wallet_disconnected": "Wallet disconnected"
+      "wallet_disconnected": "Wallet disconnected",
+      "switch_network_failed": "Couldn't switch your wallet to {network}. Change the network in your wallet, then refresh."
     }
   },
   "updater": {

--- a/pages/wallet.vue
+++ b/pages/wallet.vue
@@ -107,6 +107,23 @@
         </div>
 
         <div v-else class="space-y-3">
+          <!-- Wrong-network banner: the connected wallet is on a different
+               chain than the one we read balances from / pay on, so our figure
+               below disagrees with the wallet's own balance (GH #85 / V2-474). -->
+          <div
+            v-if="walletStore.wrongNetwork"
+            class="flex items-center justify-between gap-3 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2"
+          >
+            <span class="text-xs text-amber-400">
+              {{ $t('wallet.wrong_network_warning', { network: activeNetworkLabel }) }}
+            </span>
+            <button
+              class="shrink-0 rounded-md bg-amber-500 px-2.5 py-1 text-xs font-medium text-autonomi-dark hover:opacity-90"
+              @click="switchNetwork"
+            >
+              {{ $t('wallet.switch_network_button') }}
+            </button>
+          </div>
           <div class="flex items-center justify-between text-sm">
             <span class="text-autonomi-muted">{{ $t('wallet.address_label') }}</span>
             <span class="font-mono text-xs">{{ walletStore.paymentAddress }}</span>
@@ -151,6 +168,7 @@ import { truncateAddress } from '~/utils/formatters'
 import { isValidEthAddress } from '~/utils/validators'
 import { useSettingsStore } from '~/stores/settings'
 import { useToastStore } from '~/stores/toasts'
+import { getActiveChainId } from '~/utils/wallet-config'
 
 const { t } = useI18n()
 const walletStore = useWalletStore()
@@ -172,6 +190,23 @@ async function refreshBalances() {
   if ($appkitReady) {
     const { refreshBalances: refresh } = await import('~/composables/useWallet')
     await refresh()
+  }
+}
+
+// Short, untranslated proper-noun label for the chain we require — used in the
+// wrong-network banner. Network names aren't localized.
+const activeNetworkLabel = computed(() =>
+  getActiveChainId() === arbitrumSepolia.id ? 'Arbitrum Sepolia' : 'Arbitrum One',
+)
+
+async function switchNetwork() {
+  const { ensureActiveChain } = await import('~/composables/useWallet')
+  const ok = await ensureActiveChain()
+  walletStore.wrongNetwork = !ok
+  if (ok) {
+    await refreshBalances()
+  } else {
+    toastStore.add(t('wallet.toast.switch_network_failed', { network: activeNetworkLabel.value }), 'error')
   }
 }
 

--- a/stores/wallet.ts
+++ b/stores/wallet.ts
@@ -12,6 +12,13 @@ export const useWalletStore = defineStore('wallet', {
      *  (e.g. Anvil devnet) so the UI can hide the row instead of showing 0. */
     usdcBalance: null as string | null,
     connected: false,
+    /** True when the connected wallet is on a different chain than the one we
+     *  read balances from / pay on (see `getActiveChainId`). The balance panel
+     *  shows a "wrong network" banner so the user isn't confused by a figure
+     *  that disagrees with their wallet's own (active-chain) balance — the
+     *  root cause of GH #85 / V2-474. Only the AppKit/WalletConnect path sets
+     *  this; the direct-key devnet wallet is always on the manifest chain. */
+    wrongNetwork: false,
   }),
 
   getters: {
@@ -34,6 +41,7 @@ export const useWalletStore = defineStore('wallet', {
       this.antBalance = null
       this.usdcBalance = null
       this.connected = false
+      this.wrongNetwork = false
     },
   },
 })


### PR DESCRIPTION
Fixes the inconsistent ETH balance reported in GH #85.

## Root cause
The **Payment Wallet** panel reads balances on a fixed chain (`getActiveChainId()` — Arbitrum One on mainnet, the manifest chain on devnet), while the **Reown AppKit account modal** shows the balance on the wallet's *actually-connected* chain. When a wallet connected on a different chain, the two disagreed — our panel showed the Arbitrum One balance (e.g. `0.1200 ETH`) while AppKit showed `0.000 ETH` on the wallet's real chain. The chain was only reconciled **at payment time** (`ensureActiveChain` in `utils/payment.ts`), never at connect.

## Fix
Move the reconciliation to **connect time**. The AppKit watcher (`composables/useWallet.ts::syncFromAppKit`) now switches the wallet onto `getActiveChainId()` before reading balances. If the switch doesn't complete (wallet declines, or the target chain isn't one AppKit knows), it **fails soft** and raises a "wrong network" banner with a **Switch network** button — never breaks connect.

## Devnet-safe (no impact on manifest testing)
- `VITE_DEVNET=1` local-Anvil builds skip AppKit entirely → the watcher (and this code) never runs.
- The direct-key devnet wallet is skipped via the existing `_devnetWalletKeySet` guard — it always sits on the manifest chain.
- The one path it touches — custom manifest **without** a key + WalletConnect wallet — targets `getActiveChainId()` (= the manifest chain, e.g. Sepolia), which is correct.

## Changes
- `composables/useWallet.ts` — new `ensureActiveChain()` (mirrors `payment.ts`), wired into the connect watcher.
- `stores/wallet.ts` — `wrongNetwork` flag, reset on disconnect.
- `pages/wallet.vue` — wrong-network banner + Switch button.
- `locales/en.json` — two new strings (other locales fall back to EN, `fallbackWarn: false`).

## Verification
- `vitest run` — 30/30 pass.
- `nuxi typecheck` — clean.
- Manual: connect a wallet sitting on a non-target chain that holds ETH on Arbitrum One; confirm the connect-time switch fires and both surfaces then match; decline the switch and confirm the banner + Switch button.

## Release note
> **Not for the v0.8.2-rc.1 line** — this is post-soak / next-cycle work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)