### PR TITLE
fix(files): wrap long error status labels instead of truncating

### DIFF
--- a/components/StatusBadge.vue
+++ b/components/StatusBadge.vue
@@ -1,16 +1,18 @@
 <template>
   <!-- Non-error labels render at their natural width (whitespace-nowrap so
        they never break to two lines). Error labels — which can be a wall of
-       viem stacktrace — keep `max-w-xs truncate` so they don't blow out the
-       table. The full error text is always available via the title tooltip. -->
+       viem stacktrace — wrap onto multiple lines (whitespace-normal + break
+       so long, unspaced strings still break) and stay capped at max-w-xs so
+       they don't blow out the table width. align-top keeps the dot pinned to
+       the first line. The full error text is also available via the tooltip. -->
   <span
-    class="inline-flex items-center gap-1 align-middle text-xs font-medium"
-    :class="[colorClass, isError ? 'max-w-xs' : 'whitespace-nowrap']"
+    class="inline-flex gap-1 text-xs font-medium"
+    :class="[colorClass, isError ? 'max-w-xs items-start align-top' : 'items-center align-middle whitespace-nowrap']"
     role="status"
     :title="label"
   >
     <span aria-hidden="true" class="shrink-0">{{ dot }}</span>
-    <span :class="isError ? 'truncate' : ''">{{ label }}</span>
+    <span :class="isError ? 'whitespace-normal break-words' : ''">{{ label }}</span>
   </span>
 </template>
 


### PR DESCRIPTION
## Problem

On the Files page, failed uploads/downloads surface their full error string through `StatusBadge` (`Failed: <error>`). But error labels were capped at `max-w-xs truncate`, so anything past one line's width was clipped to an ellipsis — the full message was only reachable via the title tooltip. viem/network errors are often a wall of text, making the visible portion useless.

## Fix

Error labels now use `whitespace-normal break-words` so they wrap onto multiple lines and the whole message is visible inline in the table. They're still capped at `max-w-xs` so a long stacktrace doesn't blow out the column width, and `align-top` keeps the status dot pinned to the first line. The tooltip is retained.

Non-error statuses are unchanged (single-line, `whitespace-nowrap`).

Scope: single template-class change in `components/StatusBadge.vue`. Covers both render sites on the Files page since both go through `StatusBadge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)