### PR TITLE
chore(release): bump version to 0.8.2-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.8.2-rc.1",
+  "version": "0.8.2-rc.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.8.2-rc.1"
+version = "0.8.2-rc.2"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.8.2-rc.1"
+version = "0.8.2-rc.2"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.8.2-rc.1",
+  "version": "0.8.2-rc.2",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bumps version 0.8.2-rc.1 → 0.8.2-rc.2 in the 4 release files (package.json, src-tauri/Cargo.toml, src-tauri/Cargo.lock, src-tauri/tauri.conf.json).

rc.2 includes everything merged since the rc.1 tag:
- #158 wallet chain-mismatch fix (consistent ETH balance)
- #161 datamap backup — Settings export/import (closes #110)
- #159 wrap long error status labels
- #155 Russian locale polish

Tag `v0.8.2-rc.2` will be pushed after this merges.