### PR TITLE
feat(deep-link): handle autonomi:// URLs to trigger downloads

### DIFF
--- a/components/files/DownloadDialog.vue
+++ b/components/files/DownloadDialog.vue
@@ -15,7 +15,7 @@
             v-model="address"
             type="text"
             :placeholder="$t('files.download_dialog.address_placeholder')"
-            class="w-full rounded-md border border-autonomi-border bg-autonomi-surface px-3 py-2 font-mono text-sm text-autonomi-text focus:border-autonomi-blue focus:outline-none"
+            class="w-full rounded-md border border-autonomi-border bg-autonomi-surface px-3 py-2 font-mono text-sm text-autonomi-text placeholder-autonomi-muted placeholder:opacity-70 focus:border-autonomi-blue focus:outline-none"
             @keyup.enter="confirm"
             @keyup.escape="$emit('close')"
           />
@@ -28,7 +28,7 @@
             type="text"
             :placeholder="$t('files.download_dialog.filename_placeholder')"
             :class="[
-              'w-full rounded-md border bg-autonomi-surface px-3 py-2 text-sm text-autonomi-text focus:outline-none',
+              'w-full rounded-md border bg-autonomi-surface px-3 py-2 text-sm text-autonomi-text placeholder-autonomi-muted placeholder:opacity-70 focus:outline-none',
               filenameError ? 'border-red-500 focus:border-red-500' : 'border-autonomi-border focus:border-autonomi-blue',
             ]"
             @input="onFilenameInput"

--- a/components/files/DownloadDialog.vue
+++ b/components/files/DownloadDialog.vue
@@ -66,6 +66,8 @@ const props = defineProps<{
   /** When the dialog is opened via a deep link, the address arrives prefilled.
    *  Empty/undefined for the manual "Download by address" button. */
   prefillAddress?: string
+  /** Optional filename prefill from the deep link's `?name=`. */
+  prefillFilename?: string
 }>()
 const emit = defineEmits<{
   close: []
@@ -97,14 +99,24 @@ const matchedEntry = computed(() => {
   return filesStore.findUploadByAddress(addr)
 })
 
-watch(() => props.open, (val) => {
-  if (val) {
+// `immediate` so the prefill applies even when the dialog mounts already-open
+// (deep-link first-attempt: the Files page navigates in with the dialog open
+// from the start, so there's no false→true transition to catch). Also watch
+// `prefillAddress` so a deep link arriving while the dialog is already open
+// refreshes the fields.
+watch(
+  [() => props.open, () => props.prefillAddress],
+  ([val]) => {
+    if (!val) return
     address.value = props.prefillAddress ?? ''
-    filename.value = ''
-    filenameDirty.value = false
+    filename.value = props.prefillFilename ?? ''
+    // Treat a deep-link-provided name as user-set so the history-match
+    // auto-prefill doesn't clobber it.
+    filenameDirty.value = !!props.prefillFilename
     nextTick(() => inputEl.value?.focus())
-  }
-})
+  },
+  { immediate: true },
+)
 
 watch(matchedEntry, (match) => {
   if (!match) return

--- a/components/files/DownloadDialog.vue
+++ b/components/files/DownloadDialog.vue
@@ -61,7 +61,12 @@
 import { useFilesStore } from '~/stores/files'
 import { filenameError as checkFilename } from '~/utils/validators'
 
-const props = defineProps<{ open: boolean }>()
+const props = defineProps<{
+  open: boolean
+  /** When the dialog is opened via a deep link, the address arrives prefilled.
+   *  Empty/undefined for the manual "Download by address" button. */
+  prefillAddress?: string
+}>()
 const emit = defineEmits<{
   close: []
   download: [address: string, filename: string]
@@ -94,7 +99,7 @@ const matchedEntry = computed(() => {
 
 watch(() => props.open, (val) => {
   if (val) {
-    address.value = ''
+    address.value = props.prefillAddress ?? ''
     filename.value = ''
     filenameDirty.value = false
     nextTick(() => inputEl.value?.focus())

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -303,7 +303,8 @@
     <FilesDownloadDialog
       :open="showDownloadDialog"
       :prefill-address="downloadPrefillAddress"
-      @close="showDownloadDialog = false; downloadPrefillAddress = ''"
+      :prefill-filename="downloadPrefillFilename"
+      @close="showDownloadDialog = false; downloadPrefillAddress = ''; downloadPrefillFilename = ''"
       @download="handleDownload"
     />
 
@@ -844,23 +845,28 @@ const showDownloadDialog = ref(false)
 /** Address to prefill the Download dialog with — set when opened via an
  *  `autonomi://` deep link, empty for the manual button. */
 const downloadPrefillAddress = ref('')
+const downloadPrefillFilename = ref('')
 
 /** Manual "Download by address" — always opens a blank dialog. */
 function openDownloadByAddress() {
   downloadPrefillAddress.value = ''
+  downloadPrefillFilename.value = ''
   showDownloadDialog.value = true
 }
 
-// Deep link (autonomi://<address>): the handler stashes the parsed address on
-// the store; open the Download dialog prefilled with it, then clear the signal.
-// `immediate` so an address set before this page mounted (cold start) is caught.
+// Deep link (autonomi://<address>?name=…): the handler stashes the parsed
+// address (+ optional name) on the store; open the Download dialog prefilled,
+// then clear the signal. `immediate` so an address set before this page mounted
+// (cold start) is caught.
 watch(
   () => filesStore.pendingDownloadAddress,
   (addr) => {
     if (!addr) return
     downloadPrefillAddress.value = addr
+    downloadPrefillFilename.value = filesStore.pendingDownloadName ?? ''
     showDownloadDialog.value = true
     filesStore.pendingDownloadAddress = null
+    filesStore.pendingDownloadName = null
   },
   { immediate: true },
 )

--- a/pages/files.vue
+++ b/pages/files.vue
@@ -20,7 +20,7 @@
       <div class="flex items-center gap-2">
         <button
           class="rounded-md border border-autonomi-border px-3 py-1.5 text-sm text-autonomi-muted hover:text-autonomi-text"
-          @click="showDownloadDialog = true"
+          @click="openDownloadByAddress"
         >
           {{ $t('files.download_by_address') }}
         </button>
@@ -302,7 +302,8 @@
     <!-- Dialogs -->
     <FilesDownloadDialog
       :open="showDownloadDialog"
-      @close="showDownloadDialog = false"
+      :prefill-address="downloadPrefillAddress"
+      @close="showDownloadDialog = false; downloadPrefillAddress = ''"
       @download="handleDownload"
     />
 
@@ -840,6 +841,29 @@ function closeUploadDialog() {
 // ── Download flow ──
 
 const showDownloadDialog = ref(false)
+/** Address to prefill the Download dialog with — set when opened via an
+ *  `autonomi://` deep link, empty for the manual button. */
+const downloadPrefillAddress = ref('')
+
+/** Manual "Download by address" — always opens a blank dialog. */
+function openDownloadByAddress() {
+  downloadPrefillAddress.value = ''
+  showDownloadDialog.value = true
+}
+
+// Deep link (autonomi://<address>): the handler stashes the parsed address on
+// the store; open the Download dialog prefilled with it, then clear the signal.
+// `immediate` so an address set before this page mounted (cold start) is caught.
+watch(
+  () => filesStore.pendingDownloadAddress,
+  (addr) => {
+    if (!addr) return
+    downloadPrefillAddress.value = addr
+    showDownloadDialog.value = true
+    filesStore.pendingDownloadAddress = null
+  },
+  { immediate: true },
+)
 
 /**
  * Resolve once the embedded ant-core client is connected, or returns false

--- a/plugins/deep-link.client.ts
+++ b/plugins/deep-link.client.ts
@@ -4,46 +4,48 @@ import { parseAutonomiDeepLink } from '~/utils/validators'
 import { useFilesStore } from '~/stores/files'
 
 /**
- * Handles `autonomi://<public_address>` deep links (V2-505).
+ * Handles `autonomi://<public_address>?name=<file>` deep links (V2-505).
  *
- * The Rust side (`src-tauri/src/lib.rs`) delivers URLs two ways:
- *  - a `deep-link` event for warm/live opens (app already running), and
- *  - a `take_pending_deep_links` command holding any URL the app was cold-started
- *    with, before this listener existed.
- *
- * Both funnel through `handle()`, which validates the address and asks the Files
- * page (via the store) to open the Download dialog prefilled with it. The dialog
- * is the confirmation + filename step — we never download silently, since a web
- * page is what triggered the action.
+ * The Rust side (`src-tauri/src/lib.rs`) delivers URLs two ways: a `deep-link`
+ * event for warm/live opens, and a `take_pending_deep_links` command for any
+ * URL the app was cold-started with. Both funnel through `handle()`, which
+ * validates the address and asks the Files page (via the store) to open the
+ * Download dialog prefilled with it — the dialog is the confirm + filename
+ * step, so a web-triggered link never downloads silently.
  */
 export default defineNuxtPlugin(() => {
   // Only in the Tauri desktop runtime — no-op in a plain browser dev session.
   if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) return
 
+  // Capture composables now, while the Nuxt instance context is available — the
+  // listen/invoke callbacks below run outside it, where calling
+  // useFilesStore()/navigateTo() directly is unreliable.
+  const files = useFilesStore()
+  const router = useRouter()
+
   let lastUrl = ''
   let lastTs = 0
 
   const handle = (url: string) => {
-    const address = parseAutonomiDeepLink(url)
-    if (!address) return
-    // Dedupe the brief cold-start overlap (the pending drain and the live event
-    // can both deliver the launch URL), while still allowing a deliberate
-    // re-click of the same link later.
+    const link = parseAutonomiDeepLink(url)
+    if (!link) return
+    // Dedupe the brief overlap where the same URL arrives via both the pending
+    // drain and the live event (the Rust side emits from two paths), while
+    // still allowing a deliberate re-click of the same link later.
     const now = Date.now()
     if (url === lastUrl && now - lastTs < 2000) return
     lastUrl = url
     lastTs = now
 
-    useFilesStore().pendingDownloadAddress = address
-    navigateTo('/files')
+    files.pendingDownloadAddress = link.address
+    files.pendingDownloadName = link.name ?? null
+    router.push('/files')
   }
 
   // Warm/live opens.
-  listen<string[]>('deep-link', (e) => {
-    for (const u of e.payload) handle(u)
-  })
+  listen<string[]>('deep-link', e => e.payload.forEach(handle)).catch(() => {})
 
-  // Cold-start launch URL(s).
+  // Cold-start launch URL(s) captured before this listener was attached.
   invoke<string[]>('take_pending_deep_links')
     .then(urls => urls.forEach(handle))
     .catch(() => {})

--- a/plugins/deep-link.client.ts
+++ b/plugins/deep-link.client.ts
@@ -1,0 +1,50 @@
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
+import { parseAutonomiDeepLink } from '~/utils/validators'
+import { useFilesStore } from '~/stores/files'
+
+/**
+ * Handles `autonomi://<public_address>` deep links (V2-505).
+ *
+ * The Rust side (`src-tauri/src/lib.rs`) delivers URLs two ways:
+ *  - a `deep-link` event for warm/live opens (app already running), and
+ *  - a `take_pending_deep_links` command holding any URL the app was cold-started
+ *    with, before this listener existed.
+ *
+ * Both funnel through `handle()`, which validates the address and asks the Files
+ * page (via the store) to open the Download dialog prefilled with it. The dialog
+ * is the confirmation + filename step — we never download silently, since a web
+ * page is what triggered the action.
+ */
+export default defineNuxtPlugin(() => {
+  // Only in the Tauri desktop runtime — no-op in a plain browser dev session.
+  if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) return
+
+  let lastUrl = ''
+  let lastTs = 0
+
+  const handle = (url: string) => {
+    const address = parseAutonomiDeepLink(url)
+    if (!address) return
+    // Dedupe the brief cold-start overlap (the pending drain and the live event
+    // can both deliver the launch URL), while still allowing a deliberate
+    // re-click of the same link later.
+    const now = Date.now()
+    if (url === lastUrl && now - lastTs < 2000) return
+    lastUrl = url
+    lastTs = now
+
+    useFilesStore().pendingDownloadAddress = address
+    navigateTo('/files')
+  }
+
+  // Warm/live opens.
+  listen<string[]>('deep-link', (e) => {
+    for (const u of e.payload) handle(u)
+  })
+
+  // Cold-start launch URL(s).
+  invoke<string[]>('take_pending_deep_links')
+    .then(urls => urls.forEach(handle))
+    .catch(() => {})
+})

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -788,7 +788,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -799,7 +799,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -862,10 +862,12 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tokio",
  "toml 0.8.2",
@@ -2012,6 +2014,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,7 +2551,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2576,6 +2598,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -2835,7 +2866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3881,7 +3912,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -4801,7 +4832,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4865,7 +4896,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5200,6 +5231,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -5972,7 +6013,7 @@ dependencies = [
  "libc",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6474,6 +6515,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6522,7 +6573,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6590,7 +6641,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6611,7 +6662,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7448,7 +7499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7948,6 +7999,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry 0.5.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8037,6 +8109,22 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]
@@ -8182,7 +8270,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8701,7 +8789,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9272,7 +9360,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9473,6 +9561,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
+tauri-plugin-deep-link = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-os = "2"
 tauri-plugin-process = "2"
@@ -34,3 +35,11 @@ zip = "2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+# Single-instance is only needed on Windows/Linux: it routes a deep link
+# opened while the app is already running into the existing instance (the
+# `deep-link` feature forwards the URL to the deep-link plugin's on_open_url)
+# and focuses the window instead of spawning a duplicate. macOS delivers the
+# URL to the running app directly via on_open_url, so it doesn't need this.
+[target.'cfg(any(target_os = "windows", target_os = "linux"))'.dependencies]
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use autonomi_ops::AutonomiState;
 use config::{AppConfig, FileMetaResult, UploadHistory, UploadHistoryEntry};
 use std::path::PathBuf;
 use std::sync::Arc;
+use tauri::{Emitter, Manager};
 use tokio::sync::{watch, RwLock};
 
 // ── SSE proxy state ──
@@ -743,6 +744,23 @@ fn save_upload_history(entries: Vec<UploadHistoryEntry>) -> Result<(), String> {
     history.save().map_err(|e| e.to_string())
 }
 
+/// Holds `autonomi://` deep-link URLs captured at cold start, before the
+/// frontend is mounted and listening. Drained once via `take_pending_deep_links`.
+/// Live (warm) opens are delivered through the "deep-link" event instead; the
+/// frontend dedupes the brief overlap.
+#[derive(Default)]
+struct DeepLinkState(std::sync::Mutex<Vec<String>>);
+
+/// Drain any deep-link URLs the app was launched with. Returns and clears them.
+#[tauri::command]
+fn take_pending_deep_links(state: tauri::State<DeepLinkState>) -> Vec<String> {
+    state
+        .0
+        .lock()
+        .map(|mut g| std::mem::take(&mut *g))
+        .unwrap_or_default()
+}
+
 #[tauri::command]
 fn export_datamaps(dest_zip: String) -> Result<datamap_backup::ExportSummary, String> {
     datamap_backup::export_datamaps(&dest_zip)
@@ -786,7 +804,26 @@ pub fn run() {
         .with_writer(std::io::stderr)
         .try_init();
 
-    tauri::Builder::default()
+    // `mut` is used only under the Windows/Linux single-instance cfg below.
+    #[allow(unused_mut)]
+    let mut builder = tauri::Builder::default();
+
+    // Single-instance MUST be registered first. On Windows/Linux it forwards a
+    // deep link opened while the app is already running into this instance
+    // (the `deep-link` feature triggers the deep-link plugin's on_open_url) and
+    // focuses the existing window instead of letting the OS spawn a duplicate.
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            if let Some(w) = app.get_webview_window("main") {
+                let _ = w.unminimize();
+                let _ = w.set_focus();
+            }
+        }));
+    }
+
+    builder
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_os::init())
@@ -795,6 +832,43 @@ pub fn run() {
         .manage(AutonomiState::new())
         .manage(Arc::new(SseState::new()))
         .manage(updater_channel::UpdaterChannelState::new())
+        .manage(DeepLinkState::default())
+        .setup(|app| {
+            use tauri_plugin_deep_link::DeepLinkExt;
+
+            // Runtime registration so `autonomi://` resolves to this build on
+            // Windows/Linux without a full install (needed for `tauri dev`).
+            // macOS registers via the bundled Info.plist instead.
+            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            {
+                let _ = app.deep_link().register_all();
+            }
+
+            // Cold start: capture the launch URL(s) so the frontend can drain
+            // them once mounted — the on_open_url event below may fire before
+            // any JS listener exists.
+            if let Ok(Some(urls)) = app.deep_link().get_current() {
+                if let Some(state) = app.try_state::<DeepLinkState>() {
+                    if let Ok(mut g) = state.0.lock() {
+                        g.extend(urls.iter().map(|u| u.to_string()));
+                    }
+                }
+            }
+
+            // Warm/live opens: forward to the frontend (and stash in pending so
+            // a cold-start delivery via this path isn't lost before mount).
+            let handle = app.handle().clone();
+            app.deep_link().on_open_url(move |event| {
+                let urls: Vec<String> = event.urls().iter().map(|u| u.to_string()).collect();
+                if let Some(state) = handle.try_state::<DeepLinkState>() {
+                    if let Ok(mut g) = state.0.lock() {
+                        g.extend(urls.iter().cloned());
+                    }
+                }
+                let _ = handle.emit("deep-link", urls);
+            });
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             load_config,
             save_config,
@@ -814,6 +888,7 @@ pub fn run() {
             save_upload_history,
             export_datamaps,
             import_datamaps,
+            take_pending_deep_links,
             discover_daemon_url,
             ensure_daemon_running,
             restart_daemon,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -814,10 +814,26 @@ pub fn run() {
     // focuses the existing window instead of letting the OS spawn a duplicate.
     #[cfg(any(target_os = "windows", target_os = "linux"))]
     {
-        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             if let Some(w) = app.get_webview_window("main") {
                 let _ = w.unminimize();
                 let _ = w.set_focus();
+            }
+            // Forward any autonomi:// URL the second instance was launched with.
+            // Done explicitly (not only via the deep-link feature) so warm-start
+            // works reliably on Windows/Linux regardless of feature forwarding.
+            let urls: Vec<String> = argv
+                .iter()
+                .filter(|a| a.starts_with("autonomi:"))
+                .cloned()
+                .collect();
+            if !urls.is_empty() {
+                if let Some(state) = app.try_state::<DeepLinkState>() {
+                    if let Ok(mut g) = state.0.lock() {
+                        g.extend(urls.iter().cloned());
+                    }
+                }
+                let _ = app.emit("deep-link", urls);
             }
         }));
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,6 +45,11 @@
         "https://github.com/WithAutonomi/ant-ui/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEIzQkZDNDhGOUU3NkMyRDEKUldUUnduYWVqOFMvc3dXbHFiK2F4SGdHNVlCV2l3Q2RoMG9ENW8zNTRGdTl6WmRrWC9iZno2RloK"
+    },
+    "deep-link": {
+      "desktop": {
+        "schemes": ["autonomi"]
+      }
     }
   }
 }

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -189,6 +189,10 @@ export const useFilesStore = defineStore('files', {
      *  to a numeric parse; the external-signer path uses an opaque `quote-…`
      *  id assigned by `getUploadQuote`, which we register here. */
     _transferIdToRowId: {} as Record<string, number>,
+    /** Set by the deep-link handler when an `autonomi://<address>` URL is
+     *  opened. The Files page watches this, opens the Download dialog prefilled
+     *  with the address, and clears it. Null when there's nothing pending. */
+    pendingDownloadAddress: null as string | null,
   }),
 
   getters: {

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -193,6 +193,9 @@ export const useFilesStore = defineStore('files', {
      *  opened. The Files page watches this, opens the Download dialog prefilled
      *  with the address, and clears it. Null when there's nothing pending. */
     pendingDownloadAddress: null as string | null,
+    /** Optional filename from the deep link's `?name=`, paired with
+     *  `pendingDownloadAddress`. Null/empty when the link carried no name. */
+    pendingDownloadName: null as string | null,
   }),
 
   getters: {

--- a/tests/utils/deep-link.test.ts
+++ b/tests/utils/deep-link.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { isValidPublicAddress, parseAutonomiDeepLink } from '~/utils/validators'
+
+const ADDR = '9703216cb34a6d736ce768cac8859d2bb7efabfb7e92d9cac85f880133a7f471' // 64 hex
+
+describe('isValidPublicAddress', () => {
+  it('accepts a 64-hex address with and without 0x', () => {
+    expect(isValidPublicAddress(ADDR)).toBe(true)
+    expect(isValidPublicAddress(`0x${ADDR}`)).toBe(true)
+    expect(isValidPublicAddress(`  ${ADDR}  `)).toBe(true)
+  })
+
+  it('rejects wrong-length or non-hex values', () => {
+    expect(isValidPublicAddress('')).toBe(false)
+    expect(isValidPublicAddress('deadbeef')).toBe(false) // too short
+    expect(isValidPublicAddress(ADDR + 'ab')).toBe(false) // too long
+    expect(isValidPublicAddress(ADDR.replace('9', 'g'))).toBe(false) // non-hex
+  })
+})
+
+describe('parseAutonomiDeepLink', () => {
+  it('parses a bare autonomi:// address', () => {
+    expect(parseAutonomiDeepLink(`autonomi://${ADDR}`)).toEqual({ address: ADDR, name: undefined })
+  })
+
+  it('tolerates a trailing slash (as the OS often appends)', () => {
+    expect(parseAutonomiDeepLink(`autonomi://${ADDR}/`)).toEqual({ address: ADDR, name: undefined })
+  })
+
+  it('tolerates the scheme without //', () => {
+    expect(parseAutonomiDeepLink(`autonomi:${ADDR}`)?.address).toBe(ADDR)
+  })
+
+  it('extracts the optional ?name= filename', () => {
+    expect(parseAutonomiDeepLink(`autonomi://${ADDR}?name=book.epub`)).toEqual({
+      address: ADDR,
+      name: 'book.epub',
+    })
+    // trailing slash before the query, too
+    expect(parseAutonomiDeepLink(`autonomi://${ADDR}/?name=book.epub`)?.name).toBe('book.epub')
+  })
+
+  it('returns null for non-autonomi or invalid-address URLs', () => {
+    expect(parseAutonomiDeepLink('https://example.com')).toBeNull()
+    expect(parseAutonomiDeepLink('autonomi://not-an-address')).toBeNull()
+    expect(parseAutonomiDeepLink(`autonomi://${ADDR}xy`)).toBeNull() // wrong length
+    expect(parseAutonomiDeepLink('')).toBeNull()
+  })
+})

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -2,6 +2,24 @@ export function isValidEthAddress(addr: string): boolean {
   return /^0x[0-9a-fA-F]{40}$/.test(addr)
 }
 
+/** A public Autonomi data address: a 32-byte (64 hex char) value, optionally
+ *  `0x`-prefixed. Stricter than the download dialog's loose `{8,}` check —
+ *  used to validate untrusted input arriving via the `autonomi://` deep link
+ *  before we act on it. */
+export function isValidPublicAddress(addr: string): boolean {
+  return /^(0x)?[0-9a-fA-F]{64}$/.test(addr.trim())
+}
+
+/** Parse an `autonomi://<address>` deep link into its public address, or null
+ *  if it isn't a well-formed autonomi URL with a valid address. Tolerates an
+ *  optional `//`, a trailing slash, and any query/fragment. */
+export function parseAutonomiDeepLink(url: string): string | null {
+  const m = url.trim().match(/^autonomi:(?:\/\/)?([^/?#]+)/i)
+  if (!m) return null
+  const addr = m[1]
+  return isValidPublicAddress(addr) ? addr : null
+}
+
 // Windows-reserved set is the strict superset across platforms — rejecting it
 // everywhere keeps the same filename portable to any host. Forward/backslash
 // would also be path-traversal; null + control chars are never valid.

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -10,14 +10,31 @@ export function isValidPublicAddress(addr: string): boolean {
   return /^(0x)?[0-9a-fA-F]{64}$/.test(addr.trim())
 }
 
-/** Parse an `autonomi://<address>` deep link into its public address, or null
- *  if it isn't a well-formed autonomi URL with a valid address. Tolerates an
- *  optional `//`, a trailing slash, and any query/fragment. */
-export function parseAutonomiDeepLink(url: string): string | null {
-  const m = url.trim().match(/^autonomi:(?:\/\/)?([^/?#]+)/i)
+export interface AutonomiLink {
+  address: string
+  /** Optional suggested filename from `?name=` — unvalidated; the download
+   *  dialog runs it through `filenameError` and blocks an unsafe name. */
+  name?: string
+}
+
+/** Parse an `autonomi://<address>` deep link into its public address (and an
+ *  optional `?name=` filename), or null if it isn't a well-formed autonomi URL
+ *  with a valid address. Tolerates an optional `//`, a trailing slash, and any
+ *  query/fragment. Example: `autonomi://<64-hex>?name=book.epub`. */
+export function parseAutonomiDeepLink(url: string): AutonomiLink | null {
+  const trimmed = url.trim()
+  const m = trimmed.match(/^autonomi:(?:\/\/)?([^/?#]+)/i)
   if (!m) return null
-  const addr = m[1]
-  return isValidPublicAddress(addr) ? addr : null
+  const address = m[1]
+  if (!isValidPublicAddress(address)) return null
+
+  let name: string | undefined
+  const q = trimmed.indexOf('?')
+  if (q !== -1) {
+    const raw = new URLSearchParams(trimmed.slice(q + 1)).get('name')?.trim()
+    if (raw) name = raw
+  }
+  return { address, name }
 }
 
 // Windows-reserved set is the strict superset across platforms — rejecting it


### PR DESCRIPTION
## Why

Clicking an `autonomi://<public_address>` link in a browser should launch/focus the desktop app and start downloading that file — the public address is already the shareable handle, so a clickable link is the natural next step. Public-only by design (a private upload's datamap isn't URL-shareable).

## What

- Registers the `autonomi://` URL scheme and routes a clicked link into the existing **Download by address** flow: the dialog opens prefilled with the address, which doubles as the confirm + filename step (a web-triggered link never downloads silently).
- Optional filename via `autonomi://<addr>?name=<file>`, prefilled into the dialog (validated by the existing `filenameError` check).

## How

- **Plugins:** `tauri-plugin-deep-link` (scheme declared in `tauri.conf.json`) and, on Windows/Linux, `tauri-plugin-single-instance` with the `deep-link` feature so a link opened while the app is already running routes into the existing window instead of spawning a duplicate. macOS delivers to the running app via `on_open_url`.
- **`src-tauri/src/lib.rs`:** register single-instance first (Win/Linux), init deep-link, `register_all()` at runtime for dev, capture cold-start URLs into `DeepLinkState` (drained via `take_pending_deep_links`), and emit a `deep-link` event for warm opens. On Win/Linux the single-instance callback also parses the `autonomi://` URL out of argv and emits it, so warm-start doesn't depend solely on feature forwarding.
- **Frontend (`plugins/deep-link.client.ts`):** validates the URL (`parseAutonomiDeepLink` / `isValidPublicAddress`), stashes the address (+ optional name) on the files store, and routes to `/files`. The store + router are captured at plugin init because the event callback runs outside the Nuxt instance context. `DownloadDialog` applies the prefill on mount (not just on open-transition) so it works on the very first cold launch, and refreshes if a link arrives while it's open.

## Testing

- Verified end-to-end on **Windows** (warm start, including first attempt after a fresh launch): clicking the link focuses the app, opens the Download dialog prefilled with address + `?name=`, and `download_public` fetches/decrypts/saves.
- `nuxi typecheck` clean, `vitest` 37/37 (adds `parseAutonomiDeepLink` / `isValidPublicAddress` unit tests), `cargo check` clean.
- **Still to validate:** true **cold start** (app fully closed → click link). This can't be exercised under `tauri dev` (the bare dev exe has no Vite server), so it needs an installed/bundled build — pending verification on macOS.

## Out of scope

- Private/datamap downloads (not URL-shareable).
- Per-row single export and other unrelated flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
