### PR TITLE
chore(release): bump version to 0.8.2-rc.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ant-gui",
-  "version": "0.8.2-rc.2",
+  "version": "0.8.2-rc.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "ant-gui"
-version = "0.8.2-rc.2"
+version = "0.8.2-rc.3"
 dependencies = [
  "ant-core",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ant-gui"
-version = "0.8.2-rc.2"
+version = "0.8.2-rc.3"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasgasior/tauri-v2-schema/refs/heads/master/tauri.conf.json",
   "productName": "Autonomi",
-  "version": "0.8.2-rc.2",
+  "version": "0.8.2-rc.3",
   "identifier": "com.autonomi.ant-gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bumps 0.8.2-rc.2 → 0.8.2-rc.3 in the 4 release files.

rc.3 adds everything merged since the rc.2 tag:
- #164 autonomi:// deep-link downloads (+ ?name= filename, + download-dialog placeholder dimming)

Tag `v0.8.2-rc.3` follows once this merges.